### PR TITLE
refactor(tools): Implement namespacing for MCP tool identification

### DIFF
--- a/packages/cli/src/ui/commands/mcpCommand.ts
+++ b/packages/cli/src/ui/commands/mcpCommand.ts
@@ -210,9 +210,11 @@ const getMcpStatus = async (
     if (serverTools.length > 0) {
       message += `  ${COLOR_CYAN}Tools:${RESET_COLOR}\n`;
       serverTools.forEach((tool) => {
+        const toolName = (tool as DiscoveredMCPTool).serverToolName;
+
         if (showDescriptions && tool.description) {
           // Format tool name in cyan using simple ANSI cyan color
-          message += `  - ${COLOR_CYAN}${tool.name}${RESET_COLOR}`;
+          message += `  - ${COLOR_CYAN}${toolName}${RESET_COLOR}`;
 
           // Handle multi-line descriptions by properly indenting and preserving formatting
           const descLines = tool.description.trim().split('\n');
@@ -227,7 +229,7 @@ const getMcpStatus = async (
           // Reset is handled inline with each line now
         } else {
           // Use cyan color for the tool name even when not showing descriptions
-          message += `  - ${COLOR_CYAN}${tool.name}${RESET_COLOR}\n`;
+          message += `  - ${COLOR_CYAN}${toolName}${RESET_COLOR}\n`;
         }
         const parameters =
           tool.schema.parametersJsonSchema ?? tool.schema.parameters;

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -694,7 +694,7 @@ export async function discoverTools(
             funcDecl.description ?? '',
             funcDecl.parametersJsonSchema ?? { type: 'object', properties: {} },
             mcpServerConfig.trust,
-            undefined,
+            `mcp__${mcpServerName}__${funcDecl.name!}`,
             cliConfig,
           ),
         );

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -194,6 +194,10 @@ export class DiscoveredMCPTool extends BaseDeclarativeTool<
     );
   }
 
+  /**
+   * @deprecated This method is no longer used as MCP tools now receive unique names during creation.
+   * The unique name is formed as `mcp__${serverName}__${serverToolName}` in the discovery process.
+   */
   asFullyQualifiedTool(): DiscoveredMCPTool {
     return new DiscoveredMCPTool(
       this.mcpTool,

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -586,20 +586,18 @@ export class ToolRegistry {
     tool: AnyDeclarativeTool,
     targetMap: Map<string, AnyDeclarativeTool>,
   ): void {
-    let toolToRegister = tool;
-
-    if (targetMap.has(toolToRegister.name)) {
-      if (toolToRegister instanceof DiscoveredMCPTool) {
-        toolToRegister = toolToRegister.asFullyQualifiedTool();
-      } else {
+    if (targetMap.has(tool.name)) {
+      // For non-MCP tools, log warning and overwrite
+      if (!(tool instanceof DiscoveredMCPTool)) {
         this.logger.warn(
           () =>
-            `Tool with name "${toolToRegister.name}" is already registered. Overwriting.`,
+            `Tool with name "${tool.name}" is already registered. Overwriting.`,
         );
       }
+      // For MCP tools, we assume they already have unique names from serverName__toolName
+      // so we simply overwrite (this should not happen in normal operation)
     }
-
-    targetMap.set(toolToRegister.name, toolToRegister);
+    targetMap.set(tool.name, tool);
   }
 
   private async withDiscoveryLock<T>(task: () => Promise<T>): Promise<T> {


### PR DESCRIPTION
This commit introduces a structured naming convention for MCP (Multi-Capability Peripheral) tools to enhance system-level identification and prevent name collisions.

Previously, the system treated all tools as a flat collection, making it unable to distinguish MCP-provided tools from others. This prevented the system from accurately reporting on its own MCP capabilities when queried.

The new implementation adopts a `mcp__<serverName>__<toolName>` naming scheme. The `mcp__` prefix acts as a namespace, allowing the system to programmatically identify and categorize all MCP-related tools. This change aligns the system's internal tool awareness with the user's expectation that the agent can report on the nature and origin of its capabilities.

Key changes include:
- Preemptively creating namespaced tool names in `mcp-client`.
- Adjusting CLI display logic in `mcpCommand` to parse and show the original short tool name, ensuring the new internal naming is not exposed to the end-user.
- Removing now-redundant name qualification logic from `mcp-tool` and `tool-registry`.

This refactoring makes the tool framework more robust and improves the system's ability to reason about its own toolset.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
