### PR TITLE
fix: Resolves Gemini provider unable to read LLXPRT.md configuration file

### DIFF
--- a/packages/core/src/providers/gemini/GeminiProvider.ts
+++ b/packages/core/src/providers/gemini/GeminiProvider.ts
@@ -357,6 +357,8 @@ export class GeminiProvider extends BaseProvider {
    * Sets the config instance for reading OAuth credentials
    */
   override setConfig(config: Config): void {
+    // Call base provider implementation
+    super.setConfig?.(config);
     // Sync with config model if user hasn't explicitly set a model
     // This ensures consistency between config and provider state
     const configModel = config.getModel();


### PR DESCRIPTION

During testing, it was unexpectedly found that the Gemini configuration still could not read 

> LLXPRT.md

. After investigation, found that `GeminiProvider` missed calling `super.setConfig`. 

Other Providers were reviewed and no such issue was found.


## TLDR

- Add missing super.setConfig?.(config) call at the beginning of GeminiProvider.setConfig
- Resolves Gemini provider unable to read LLXPRT.md configuration file
- Ensures BaseProvider configuration is properly initialized before provider-specific logic
- Maintains consistency with other provider implementations

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
Related to #267
<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*


-->
