### PR TITLE
Add --set flag and fix CLI auth precedence

### DIFF
--- a/packages/cli/src/config/cliEphemeralSettings.test.ts
+++ b/packages/cli/src/config/cliEphemeralSettings.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  applyCliSetArguments,
+  EphemeralSettingTarget,
+} from './cliEphemeralSettings.js';
+
+class TestTarget implements EphemeralSettingTarget {
+  private readonly values = new Map<string, unknown>();
+
+  setEphemeralSetting(key: string, value: unknown): void {
+    this.values.set(key, value);
+  }
+
+  getValue(key: string): unknown {
+    return this.values.get(key);
+  }
+}
+
+describe('applyCliSetArguments', () => {
+  it('applies parsed values for valid key=value pairs', () => {
+    const target = new TestTarget();
+
+    applyCliSetArguments(target, [
+      'context-limit=32000',
+      'tool-output-max-tokens=4096',
+    ]);
+
+    expect(target.getValue('context-limit')).toBe(32000);
+    expect(target.getValue('tool-output-max-tokens')).toBe(4096);
+  });
+
+  it('throws if an entry is missing the "=" separator', () => {
+    const target = new TestTarget();
+
+    expect(() => applyCliSetArguments(target, ['context-limit32000'])).toThrow(
+      /expected key=value/i,
+    );
+  });
+
+  it('throws if the key is not a supported ephemeral setting', () => {
+    const target = new TestTarget();
+
+    expect(() => applyCliSetArguments(target, ['unknown-setting=1'])).toThrow(
+      /unknown-setting/,
+    );
+  });
+});

--- a/packages/cli/src/config/cliEphemeralSettings.ts
+++ b/packages/cli/src/config/cliEphemeralSettings.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { parseEphemeralSettingValue } from '../settings/ephemeralSettings.js';
+
+export interface EphemeralSettingTarget {
+  setEphemeralSetting(key: string, value: unknown): void;
+}
+
+export function applyCliSetArguments(
+  target: EphemeralSettingTarget,
+  setArgs: readonly string[] | undefined,
+): void {
+  if (!setArgs || setArgs.length === 0) {
+    return;
+  }
+
+  for (const entry of setArgs) {
+    const separatorIndex = entry.indexOf('=');
+    if (separatorIndex === -1) {
+      throw new Error(`Invalid --set format: ${entry}. Expected key=value`);
+    }
+
+    const key = entry.slice(0, separatorIndex).trim();
+    const rawValue = entry.slice(separatorIndex + 1);
+
+    if (!key) {
+      throw new Error(`Invalid --set format: ${entry}. Expected key=value`);
+    }
+
+    const parseResult = parseEphemeralSettingValue(key, rawValue);
+
+    if (!parseResult.success) {
+      throw new Error(parseResult.message);
+    }
+
+    target.setEphemeralSetting(key, parseResult.value);
+  }
+}

--- a/packages/cli/src/config/config.integration.test.ts
+++ b/packages/cli/src/config/config.integration.test.ts
@@ -13,6 +13,7 @@ import {
   ConfigParameters,
   ContentGeneratorConfig,
 } from '@vybestack/llxprt-code-core';
+import type { Settings } from './settings.js';
 
 const TEST_CONTENT_GENERATOR_CONFIG: ContentGeneratorConfig = {
   apiKey: 'test-key',
@@ -380,6 +381,40 @@ describe('Configuration Integration Tests', () => {
         expect(argv.approvalMode).toBeUndefined();
         expect(argv.yolo).toBe(false);
         expect(argv.prompt).toBe('test');
+      } finally {
+        process.argv = originalArgv;
+      }
+    });
+  });
+
+  describe('CLI --set argument parsing', () => {
+    let parseArguments: typeof import('./config').parseArguments;
+
+    beforeEach(async () => {
+      const { parseArguments: parseArgs } = await import('./config');
+      parseArguments = parseArgs;
+    });
+
+    it('collects repeated --set key=value pairs', async () => {
+      const originalArgv = process.argv;
+      const settings: Settings = {};
+
+      try {
+        process.argv = [
+          'node',
+          'script.js',
+          '--set',
+          'context-limit=32000',
+          '--set',
+          'tool-output-max-tokens=4096',
+        ];
+
+        const argv = await parseArguments(settings);
+
+        expect(argv.set).toEqual([
+          'context-limit=32000',
+          'tool-output-max-tokens=4096',
+        ]);
       } finally {
         process.argv = originalArgv;
       }

--- a/packages/cli/src/providers/credentialPrecedence.test.ts
+++ b/packages/cli/src/providers/credentialPrecedence.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  resolveCredentialPrecedence,
+  CredentialInputs,
+} from './credentialPrecedence.js';
+
+describe('resolveCredentialPrecedence', () => {
+  it('prefers CLI inline key over profile values', () => {
+    const inputs: CredentialInputs = {
+      cliKey: 'cli-key',
+      profileKey: 'profile-key',
+      profileKeyfile: '/tmp/profile.key',
+    };
+
+    const result = resolveCredentialPrecedence(inputs);
+
+    expect(result.inlineKey).toBe('cli-key');
+    expect(result.inlineSource).toBe('cli');
+    expect(result.keyfilePath).toBeUndefined();
+    expect(result.keyfileSource).toBeUndefined();
+  });
+
+  it('prefers CLI keyfile when no CLI inline key is provided', () => {
+    const inputs: CredentialInputs = {
+      cliKeyfile: '/tmp/cli.key',
+      profileKey: 'profile-key',
+    };
+
+    const result = resolveCredentialPrecedence(inputs);
+
+    expect(result.keyfilePath).toBe('/tmp/cli.key');
+    expect(result.keyfileSource).toBe('cli');
+    expect(result.inlineKey).toBeUndefined();
+  });
+
+  it('falls back to profile credentials when CLI options are absent', () => {
+    const inputs: CredentialInputs = {
+      profileKeyfile: '/tmp/profile.key',
+      profileBaseUrl: 'https://profile.example.com',
+    };
+
+    const result = resolveCredentialPrecedence(inputs);
+
+    expect(result.keyfilePath).toBe('/tmp/profile.key');
+    expect(result.keyfileSource).toBe('profile');
+    expect(result.baseUrl).toBe('https://profile.example.com');
+    expect(result.baseUrlSource).toBe('profile');
+  });
+
+  it('prefers CLI base URL over profile values', () => {
+    const inputs: CredentialInputs = {
+      cliBaseUrl: 'https://cli.example.com',
+      profileBaseUrl: 'https://profile.example.com',
+    };
+
+    const result = resolveCredentialPrecedence(inputs);
+
+    expect(result.baseUrl).toBe('https://cli.example.com');
+    expect(result.baseUrlSource).toBe('cli');
+  });
+});

--- a/packages/cli/src/providers/credentialPrecedence.ts
+++ b/packages/cli/src/providers/credentialPrecedence.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface CredentialInputs {
+  cliKey?: string;
+  cliKeyfile?: string;
+  cliBaseUrl?: string;
+  profileKey?: string;
+  profileKeyfile?: string;
+  profileBaseUrl?: string;
+}
+
+export interface CredentialPrecedenceResult {
+  inlineKey?: string;
+  keyfilePath?: string;
+  baseUrl?: string;
+  inlineSource?: 'cli' | 'profile';
+  keyfileSource?: 'cli' | 'profile';
+  baseUrlSource?: 'cli' | 'profile';
+}
+
+export function resolveCredentialPrecedence(
+  inputs: CredentialInputs,
+): CredentialPrecedenceResult {
+  const cleanedCliKey = cleanString(inputs.cliKey);
+  const cleanedProfileKey = cleanString(inputs.profileKey);
+
+  const result: CredentialPrecedenceResult = {};
+
+  if (cleanedCliKey) {
+    result.inlineKey = cleanedCliKey;
+    result.inlineSource = 'cli';
+  } else if (inputs.cliKeyfile) {
+    result.keyfilePath = inputs.cliKeyfile;
+    result.keyfileSource = 'cli';
+  } else if (cleanedProfileKey) {
+    result.inlineKey = cleanedProfileKey;
+    result.inlineSource = 'profile';
+  } else if (inputs.profileKeyfile) {
+    result.keyfilePath = inputs.profileKeyfile;
+    result.keyfileSource = 'profile';
+  }
+
+  const cleanedCliBaseUrl = cleanString(inputs.cliBaseUrl);
+  if (cleanedCliBaseUrl) {
+    result.baseUrl = inputs.cliBaseUrl;
+    result.baseUrlSource = 'cli';
+  } else if (inputs.profileBaseUrl) {
+    result.baseUrl = inputs.profileBaseUrl;
+    result.baseUrlSource = 'profile';
+  }
+
+  return result;
+}
+
+function cleanString(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed === '' ? undefined : trimmed;
+}

--- a/packages/cli/src/settings/ephemeralSettings.ts
+++ b/packages/cli/src/settings/ephemeralSettings.ts
@@ -1,0 +1,244 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { EmojiFilterMode } from '@vybestack/llxprt-code-core';
+
+export const ephemeralSettingHelp: Record<string, string> = {
+  'context-limit':
+    'Maximum number of tokens for the context window (e.g., 100000)',
+  'compression-threshold':
+    'Fraction of context limit that triggers compression (0.0-1.0, e.g., 0.7 for 70%)',
+  'base-url': 'Base URL for API requests',
+  'tool-format': 'Tool format override for the provider',
+  'api-version': 'API version to use',
+  'custom-headers': 'Custom HTTP headers as JSON object',
+  'stream-options':
+    'Stream options for OpenAI API (default: { include_usage: true })',
+  streaming:
+    'Enable or disable streaming responses (enabled/disabled, default: enabled)',
+  'shell-replacement':
+    'Allow command substitution ($(), <(), backticks) in shell commands (default: false)',
+  'socket-timeout':
+    'Request timeout in milliseconds for local AI servers (default: 60000)',
+  'socket-keepalive':
+    'Enable TCP keepalive for local AI server connections (true/false, default: true)',
+  'socket-nodelay':
+    'Enable TCP_NODELAY concept for local AI servers (true/false, default: true)',
+  'tool-output-max-items':
+    'Maximum number of items/files/matches returned by tools (default: 50)',
+  'tool-output-max-tokens': 'Maximum tokens in tool output (default: 50000)',
+  'tool-output-truncate-mode':
+    'How to handle exceeding limits: warn, truncate, or sample (default: warn)',
+  'tool-output-item-size-limit':
+    'Maximum size per item/file in bytes (default: 524288 = 512KB)',
+  'max-prompt-tokens':
+    'Maximum tokens allowed in any prompt sent to LLM (default: 200000)',
+  emojifilter: 'Emoji filter mode (allowed, auto, warn, error)',
+  retries:
+    'Maximum number of retry attempts for API calls (default: varies by provider)',
+  retrywait:
+    'Initial delay in milliseconds between retry attempts (default: varies by provider)',
+  maxTurnsPerPrompt:
+    'Maximum number of turns allowed per prompt before stopping (default: 100, -1 for unlimited)',
+};
+
+const validEphemeralKeys = Object.keys(ephemeralSettingHelp);
+
+export type EphemeralSettingKey = keyof typeof ephemeralSettingHelp;
+
+export interface EphemeralParseSuccess {
+  success: true;
+  value: unknown;
+}
+
+export interface EphemeralParseFailure {
+  success: false;
+  message: string;
+}
+
+export type EphemeralParseResult =
+  | EphemeralParseSuccess
+  | EphemeralParseFailure;
+
+export function parseEphemeralSettingValue(
+  key: string,
+  rawValue: string,
+): EphemeralParseResult {
+  if (!validEphemeralKeys.includes(key)) {
+    return {
+      success: false,
+      message: `Invalid setting key: ${key}. Valid keys are: ${validEphemeralKeys.join(', ')}`,
+    };
+  }
+
+  let parsedValue = parseValue(rawValue);
+
+  if (key === 'compression-threshold') {
+    const numValue = parsedValue as number;
+    if (typeof numValue !== 'number' || numValue <= 0 || numValue > 1) {
+      return {
+        success: false,
+        message:
+          'compression-threshold must be a decimal between 0 and 1 (e.g., 0.7 for 70%)',
+      };
+    }
+  }
+
+  if (key === 'context-limit') {
+    const numValue = parsedValue as number;
+    if (
+      typeof numValue !== 'number' ||
+      numValue <= 0 ||
+      !Number.isInteger(numValue)
+    ) {
+      return {
+        success: false,
+        message: 'context-limit must be a positive integer (e.g., 100000)',
+      };
+    }
+  }
+
+  if (key === 'socket-timeout') {
+    const numValue = parsedValue as number;
+    if (
+      typeof numValue !== 'number' ||
+      numValue <= 0 ||
+      !Number.isInteger(numValue)
+    ) {
+      return {
+        success: false,
+        message:
+          'socket-timeout must be a positive integer in milliseconds (e.g., 60000)',
+      };
+    }
+  }
+
+  if (key === 'socket-keepalive' || key === 'socket-nodelay') {
+    if (typeof parsedValue !== 'boolean') {
+      return {
+        success: false,
+        message: `${key} must be either 'true' or 'false'`,
+      };
+    }
+  }
+
+  if (
+    key === 'tool-output-max-items' ||
+    key === 'tool-output-max-tokens' ||
+    key === 'tool-output-item-size-limit' ||
+    key === 'max-prompt-tokens'
+  ) {
+    const numValue = parsedValue as number;
+    if (
+      typeof numValue !== 'number' ||
+      numValue <= 0 ||
+      !Number.isInteger(numValue)
+    ) {
+      return {
+        success: false,
+        message: `${key} must be a positive integer`,
+      };
+    }
+  }
+
+  if (key === 'maxTurnsPerPrompt') {
+    const numValue = parsedValue as number;
+    if (
+      typeof numValue !== 'number' ||
+      !Number.isInteger(numValue) ||
+      (numValue !== -1 && numValue <= 0)
+    ) {
+      return {
+        success: false,
+        message: `${key} must be a positive integer or -1 for unlimited`,
+      };
+    }
+  }
+
+  if (key === 'tool-output-truncate-mode') {
+    const validModes = ['warn', 'truncate', 'sample'];
+    if (!validModes.includes(parsedValue as string)) {
+      return {
+        success: false,
+        message: `${key} must be one of: ${validModes.join(', ')}`,
+      };
+    }
+  }
+
+  if (key === 'emojifilter') {
+    const validModes: EmojiFilterMode[] = ['allowed', 'auto', 'warn', 'error'];
+    const value = parsedValue as string;
+    const normalizedValue = value.toLowerCase() as EmojiFilterMode;
+    if (!validModes.includes(normalizedValue)) {
+      return {
+        success: false,
+        message: `Invalid emoji filter mode '${parsedValue}'. Valid modes are: ${validModes.join(', ')}`,
+      };
+    }
+    parsedValue = normalizedValue;
+  }
+
+  if (key === 'shell-replacement') {
+    if (typeof parsedValue !== 'boolean') {
+      return {
+        success: false,
+        message: `shell-replacement must be either 'true' or 'false'`,
+      };
+    }
+  }
+
+  if (key === 'streaming') {
+    const validModes = ['enabled', 'disabled'];
+    if (typeof parsedValue === 'boolean') {
+      parsedValue = parsedValue ? 'enabled' : 'disabled';
+    } else if (
+      typeof parsedValue === 'string' &&
+      validModes.includes(parsedValue.toLowerCase())
+    ) {
+      parsedValue = parsedValue.toLowerCase();
+    } else if (
+      typeof parsedValue === 'string' &&
+      validModes.includes(parsedValue.trim().toLowerCase())
+    ) {
+      parsedValue = parsedValue.trim().toLowerCase();
+    } else if (
+      typeof parsedValue === 'string' &&
+      ['true', 'false'].includes(parsedValue.toLowerCase())
+    ) {
+      parsedValue =
+        parsedValue.toLowerCase() === 'true' ? 'enabled' : 'disabled';
+    } else {
+      return {
+        success: false,
+        message: `Invalid streaming mode '${parsedValue}'. Valid modes are: ${validModes.join(', ')}`,
+      };
+    }
+  }
+
+  return { success: true, value: parsedValue };
+}
+
+function parseValue(value: string): unknown {
+  if (/^-?\d+(\.\d+)?$/.test(value)) {
+    const num = Number(value);
+    if (!Number.isNaN(num)) {
+      return num;
+    }
+  }
+
+  if (value.toLowerCase() === 'true') {
+    return true;
+  }
+  if (value.toLowerCase() === 'false') {
+    return false;
+  }
+
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}


### PR DESCRIPTION
## Summary
- add shared ephemeral-setting parsing and expose a repeatable --set flag so CI/automations can configure session options without /set
- ensure CLI provided credentials/base URLs always win by routing everything through a precedence helper and single apply path in gemini.tsx
- keep behavior parity via new unit/integration tests covering the flag parsing and credential resolution logic

## Testing
- npm run test
- npm run lint
- npm run typecheck
- npm run format
- npm run build

Fixes #332
Fixes #329