### PR TITLE
ci: increase Vitest timeout for integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,6 +326,8 @@ jobs:
           NO_COLOR: true
           # Ensure OAuth tests are skipped in CI (they require browser interaction)
           CI: true
+          # Allow OpenAI integration tests to exceed Vitest's 5s default timeout (issue #338)
+          VITEST_TEST_TIMEOUT: 15000
         run: 'npm run test:ci'
 
       - name: 'Publish Test Report (for non-forks)'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -218,6 +218,8 @@ jobs:
           CI: 'true'
           VERBOSE: 'true'
           KEEP_OUTPUT: 'true'
+          # Allow OpenAI integration tests to exceed Vitest's 5s default timeout (issue #338)
+          VITEST_TEST_TIMEOUT: 15000
         run: |-
           npm run test:e2e
 
@@ -276,5 +278,7 @@ jobs:
           CI: 'true'
           VERBOSE: 'true'
           KEEP_OUTPUT: 'true'
+          # Allow OpenAI integration tests to exceed Vitest's 5s default timeout (issue #338)
+          VITEST_TEST_TIMEOUT: 15000
         run: |-
           npm run test:e2e


### PR DESCRIPTION
## Summary\n- set VITEST_TEST_TIMEOUT=15000 for npm run test:ci so real OpenAI calls do not hit the default 5s limit\n- export the same timeout for macOS and Windows e2e runners\n- document why the override exists inline in both workflows\n\n## Testing\n- actionlint .github/workflows/ci.yml .github/workflows/e2e.yml\n\nFixes #338