### PR TITLE
docs: align user guides with 0.4.5 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@
 
 LLxprt Code is a powerful fork of [Google's Gemini CLI](https://github.com/google-gemini/gemini-cli), enhanced with multi-provider support and improved theming. We thank Google for their excellent foundation and will continue to track and merge upstream changes as long as practical.
 
+## What's new in 0.4.5
+
+- **Startup configuration:** supply ephemeral settings via `--set key=value` (same keys as `/set`), ideal for CI and automation.
+- **Resilient streaming:** unified retry defaults (6 attempts / 4 s) and better handling of transient SSE disconnects.
+- **Smarter todos:** complex request detection now nudges you to create todo lists and escalates reminders when none exist.
+- **Simplified Gemini UX:** the "Paid Mode" badge and flash fallback were removed; monitor usage with `/stats` or provider dashboards instead.
+- **Token budgeting clarity:** `context-limit` now clearly counts system prompts + `LLXPRT.md`, with improved error messaging and docs.
+
 ## Key Features
 
 - **Multi-Provider Support**: Direct access to OpenAI (o3), Anthropic (Claude), Google Gemini, plus OpenRouter, Fireworks, and local models

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -776,6 +776,9 @@ Arguments passed directly when running the CLI can override other configurations
 - **`--key <api_key>`**:
   - Provides the API key for the current provider directly.
   - Example: `llxprt --key sk-...`
+- **`--set key=value`** (repeatable):
+  - Apply ephemeral settings at startup (same keys as `/set`). Pass each assignment separately (`--set streaming=disabled --set base-url=https://...`). Values are parsed using the same validation as the interactive command.
+  - Precedence: CLI flags take priority over profiles/settings, which in turn override environment variables and finally OAuth tokens.
 - **`--keyfile <path>`**:
   - Path to a file containing the API key for the current provider.
   - Example: `llxprt --keyfile ~/.openai_key`

--- a/docs/cli/retry-settings.md
+++ b/docs/cli/retry-settings.md
@@ -9,13 +9,13 @@ Retry configuration can be set as ephemeral settings, which means they can be ch
 ### Available Retry Settings
 
 - **`retries`** (number):
-  - **Description:** Maximum number of retry attempts for API calls. This setting controls how many times the CLI will retry a failed API request.
-  - **Default:** `5` (Anthropic and Google providers) or `6` (OpenAI provider)
+  - **Description:** Maximum number of retry attempts for API calls. LLxprt now uses a unified default across providers.
+  - **Default:** `6`
   - **Example:** `/set retries 3`
 
 - **`retrywait`** (number):
   - **Description:** Initial delay in milliseconds between retry attempts. The delay increases exponentially for subsequent retries.
-  - **Default:** `5000` ms (Anthropic and Google providers) or `4000` ms (OpenAI provider)
+  - **Default:** `4000` ms
   - **Example:** `/set retrywait 10000`
 
 ### How to Configure Retry Settings
@@ -34,13 +34,11 @@ These settings will apply to all subsequent API calls during your session and ca
 
 ### Provider-Specific Retry Behavior
 
-Different providers have different default retry configurations:
+The retry logic now uses the same baseline everywhere (6 attempts, 4-second initial delay) and includes:
 
-- **Google/Gemini:** 5 retries with 5000ms initial delay
-- **Anthropic:** 5 retries with 5000ms initial delay
-- **OpenAI:** 6 retries with 4000ms initial delay
-
-The retry logic includes special handling for 429 (rate limit) errors and will automatically adjust behavior based on `Retry-After` headers when present.
+- Special handling for 429 (rate limit) errors (respecting `Retry-After` headers)
+- Automatic detection of transient network issues (socket resets, stream interruptions)
+- Integration with streaming pipelines so SSE disconnects are retried without user intervention
 
 ### Technical Implementation
 

--- a/docs/cli/themes.md
+++ b/docs/cli/themes.md
@@ -29,7 +29,7 @@ LLxprt Code comes with a selection of pre-defined themes, which you can list usi
 3.  Using the arrow keys, select a theme. Some interfaces might offer a live preview or highlight as you select.
 4.  Confirm your selection to apply the theme.
 
-**Note:** If a theme is defined in your `settings.json` file (either by name or by a file path), you must remove the `"theme"` setting from the file before you can change the theme using the `/theme` command.
+**Note:** Theme selection follows the same precedence as other settings (workspace `.llxprt/settings.json` > user `~/.llxprt/settings.json` > system overrides). `/theme` will update the highest-precedence writable file; you no longer need to delete the `"theme"` key manually before switching themes.
 
 ### Theme Persistence
 

--- a/docs/npm.md
+++ b/docs/npm.md
@@ -60,6 +60,15 @@ npm install -g @vybestack/llxprt-code@nightly
 
 We also run a Google cloud build called [release-docker.yml](../.gcp/release-docker.yaml). Which publishes the sandbox docker to match your release. This will also be moved to GH and combined with the main release file once service account permissions are sorted out.
 
+### VS Code Companion toggle inputs
+
+The release workflow now exposes two additional booleans:
+
+- `publish_vscode_only`: build/publish just the VS Code companion (`llxprt-code-vscode-ide-companion`) without touching npm packages. Use this for hotfixes to the marketplace / Open VSX extension.
+- `skip_vscode_publish`: skip companion publishing entirely (nightly runs set this to `true` so the extension isn’t rebuilt every day).
+
+Make sure these inputs are set appropriately before triggering manual releases; nightly automation defaults to "skip" so the IDE extension matches tagged releases only.
+
 ### After the Release
 
 After the workflow has successfully completed, you can monitor its progress in the [GitHub Actions tab](https://github.com/acoliver/llxprt-code/actions/workflows/release.yml). Once complete, you should:

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -18,9 +18,10 @@ OAuth provides secure authentication without requiring API keys, offering better
 
 The system uses the following authentication precedence (highest to lowest):
 
-1. **Command line API key** (`--key` flag)
-2. **Environment variables** (`OPENAI_API_KEY`, `GEMINI_API_KEY`, etc.)
-3. **OAuth tokens** (stored securely in `~/.llxprt/oauth/`)
+1. **Command line API key** (`--key`/`--keyfile` flags or `--set auth-key=...`)
+2. **Profiles / settings files** (values saved via `/profile save` or `settings.json`)
+3. **Environment variables** (`OPENAI_API_KEY`, `GEMINI_API_KEY`, etc.)
+4. **OAuth tokens** (stored securely in `~/.llxprt/oauth/`)
 
 ## Setting Up OAuth
 

--- a/docs/prompt-configuration.md
+++ b/docs/prompt-configuration.md
@@ -70,9 +70,27 @@ Prompts are resolved in the following order (later overrides earlier):
 Prompts support template variables that are automatically replaced:
 
 - `{{enabledTools}}`: List of available tools
-- `{{environment}}`: Current environment details
+- `{{environment}}`: Current environment details (see below)
 - `{{provider}}`: Active provider name
 - `{{model}}`: Current model name
+
+### `{{environment}}` fields
+
+The environment object exposes the same properties as `PromptEnvironment` in code. Common fields include:
+
+| Field                  | Description                                              |
+| ---------------------- | -------------------------------------------------------- |
+| `workspaceName`        | Basename of the current workspace directory              |
+| `workspaceRoot`        | Absolute path to the workspace root                      |
+| `workspaceDirectories` | Array of directories included in the session             |
+| `workingDirectory`     | The cwd the CLI started in                               |
+| `isGitRepository`      | `true` if git metadata was detected                      |
+| `isSandboxed`          | `true` when running inside Docker/Seatbelt/etc.          |
+| `sandboxType`          | `macos-seatbelt`, `generic`, or omitted                  |
+| `hasIdeCompanion`      | Indicates VS Code integration status                     |
+| `folderStructure`      | A summarized folder tree (may be omitted if unavailable) |
+
+Use these fields in custom prompts, e.g., `{{environment.workspaceName}}`.
 
 ### Example Template Usage
 

--- a/docs/quota-and-pricing.md
+++ b/docs/quota-and-pricing.md
@@ -2,7 +2,7 @@
 
 LLxprt Code supports multiple AI providers, each with their own pricing and quota structures. A summary of model usage is available through the `/stats` command and presented on exit at the end of a session.
 
-**Important:** The "Paid Mode" indicator in the lower right corner is specifically for the Gemini provider. It shows whether you're using OAuth authentication (free tier) or your Gemini API key (paid tier). This indicator does not apply to other providers - all non-Gemini providers are always considered paid when using their API keys.
+**Important:** Earlier builds surfaced a "Paid Mode" badge in the footer for Gemini sessions. That UI has been removed—LLxprt now stays on the exact model you selected and no longer tries to fall back to flash tiers. To understand whether you're incurring paid traffic, rely on `/stats` or your provider's billing dashboards.
 
 ## Provider-Specific Pricing
 

--- a/docs/settings-and-profiles.md
+++ b/docs/settings-and-profiles.md
@@ -26,29 +26,32 @@ Ephemeral settings are runtime configurations that last only for your current se
 
 ### Available Ephemeral Settings
 
-| Setting                       | Description                                             | Default                   | Example                            |
-| ----------------------------- | ------------------------------------------------------- | ------------------------- | ---------------------------------- |
-| `context-limit`               | Maximum tokens for context window                       | -                         | `100000`                           |
-| `compression-threshold`       | When to compress history (0.0-1.0)                      | -                         | `0.7` (70% of context)             |
-| `base-url`                    | Custom API endpoint                                     | -                         | `https://api.anthropic.com`        |
-| `tool-format`                 | Tool format override                                    | -                         | `openai`, `anthropic`, `hermes`    |
-| `api-version`                 | API version (Azure)                                     | -                         | `2024-02-01`                       |
-| `custom-headers`              | HTTP headers as JSON                                    | -                         | `{"X-Custom": "value"}`            |
-| `stream-options`              | Stream options for OpenAI API                           | `{"include_usage": true}` | `{"include_usage": false}`         |
-| `streaming`                   | Enable or disable streaming responses                   | `enabled`                 | `disabled`                         |
-| `tool-output-max-items`       | Maximum number of items/files/matches returned by tools | `50`                      | `100`                              |
-| `tool-output-max-tokens`      | Maximum tokens in tool output                           | `50000`                   | `100000`                           |
-| `tool-output-truncate-mode`   | How to handle exceeding limits                          | `warn`                    | `warn`, `truncate`, or `sample`    |
-| `tool-output-item-size-limit` | Maximum size per item/file in bytes                     | `524288`                  | `1048576` (1MB)                    |
-| `max-prompt-tokens`           | Maximum tokens allowed in any prompt sent to LLM        | `200000`                  | `300000`                           |
-| `shell-replacement`           | Allow command substitution ($(), <(), backticks)        | `false`                   | `true`                             |
-| `emojifilter`                 | Emoji filter mode for LLM responses                     | `auto`                    | `allowed`, `auto`, `warn`, `error` |
+| Setting                       | Description                                                                                          | Default                   | Example                            |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------- | ---------------------------------- |
+| `context-limit`               | Maximum tokens for context window (counts system prompt + LLXPRT.md)                                 | -                         | `100000`                           |
+| `compression-threshold`       | When to compress history (0.0-1.0)                                                                   | -                         | `0.7` (70% of context)             |
+| `base-url`                    | Custom API endpoint                                                                                  | -                         | `https://api.anthropic.com`        |
+| `tool-format`                 | Tool format override                                                                                 | -                         | `openai`, `anthropic`, `hermes`    |
+| `api-version`                 | API version (Azure)                                                                                  | -                         | `2024-02-01`                       |
+| `custom-headers`              | HTTP headers as JSON                                                                                 | -                         | `{"X-Custom": "value"}`            |
+| `stream-options`              | Stream options for OpenAI API                                                                        | `{"include_usage": true}` | `{"include_usage": false}`         |
+| `streaming`                   | Enable or disable streaming responses (stored as `enabled`/`disabled` even if booleans are provided) | `enabled`                 | `disabled`                         |
+| `socket-timeout`              | Request timeout in milliseconds for local / OpenAI-compatible servers                                | `60000`                   | `120000`                           |
+| `socket-keepalive`            | Enable TCP keepalive for local AI server connections                                                 | `true`                    | `false`                            |
+| `socket-nodelay`              | Enable TCP_NODELAY for local AI server connections                                                   | `true`                    | `false`                            |
+| `tool-output-max-items`       | Maximum number of items/files/matches returned by tools                                              | `50`                      | `100`                              |
+| `tool-output-max-tokens`      | Maximum tokens in tool output                                                                        | `50000`                   | `100000`                           |
+| `tool-output-truncate-mode`   | How to handle exceeding limits                                                                       | `warn`                    | `warn`, `truncate`, or `sample`    |
+| `tool-output-item-size-limit` | Maximum size per item/file in bytes                                                                  | `524288`                  | `1048576` (1MB)                    |
+| `max-prompt-tokens`           | Maximum tokens allowed in any prompt sent to LLM                                                     | `200000`                  | `300000`                           |
+| `shell-replacement`           | Allow command substitution ($(), <(), backticks)                                                     | `false`                   | `true`                             |
+| `emojifilter`                 | Emoji filter mode for LLM responses                                                                  | `auto`                    | `allowed`, `auto`, `warn`, `error` |
 
 **Note:** `auth-key` and `auth-keyfile` are no longer supported as ephemeral settings. Use `/key` and `/keyfile` commands instead.
 
 ### Setting Ephemeral Values
 
-```bash
+````bash
 # Set context limit
 /set context-limit 100000
 
@@ -58,26 +61,47 @@ Ephemeral settings are runtime configurations that last only for your current se
 # Set custom headers
 /set custom-headers {"X-Organization": "my-org", "X-Project": "my-project"}
 
+### Boot-time overrides
+
+You can apply the same settings at startup via CLI flags:
+
+```bash
+llxprt --set streaming=disabled --set base-url=https://api.anthropic.com --provider anthropic
+````
+
+The CLI parses each `--set key=value` just like `/set`, so CI jobs and scripts can configure ephemeral behavior without interactive prompts. Command-line values take precedence over profile/settings files.
+
 # Configure streaming
-/set streaming disabled                 # Disable streaming responses
-/set stream-options {"include_usage": false}  # OpenAI stream options
+
+/set streaming disabled # Disable streaming responses
+/set stream-options {"include_usage": false} # OpenAI stream options
+
+# Configure socket behavior for local/OpenAI-compatible servers
+
+/set socket-timeout 120000
+/set socket-keepalive true
+/set socket-nodelay true
 
 # Enable shell command substitution (use with caution)
+
 /set shell-replacement true
 
 # Tool output control settings
-/set tool-output-max-items 100          # Allow up to 100 files/matches
-/set tool-output-max-tokens 100000      # Allow up to 100k tokens in tool output
+
+/set tool-output-max-items 100 # Allow up to 100 files/matches
+/set tool-output-max-tokens 100000 # Allow up to 100k tokens in tool output
 /set tool-output-truncate-mode truncate # Truncate instead of warning
 /set tool-output-item-size-limit 1048576 # 1MB per file
-/set max-prompt-tokens 300000           # Increase max prompt size
+/set max-prompt-tokens 300000 # Increase max prompt size
 
 # Emoji filter settings
-/set emojifilter auto                   # Silent filtering (default)
-/set emojifilter warn                   # Filter with feedback
-/set emojifilter error                  # Block content with emojis
-/set emojifilter allowed                # Allow emojis through
-```
+
+/set emojifilter auto # Silent filtering (default)
+/set emojifilter warn # Filter with feedback
+/set emojifilter error # Block content with emojis
+/set emojifilter allowed # Allow emojis through
+
+````
 
 ### Unsetting Values
 
@@ -87,7 +111,7 @@ Ephemeral settings are runtime configurations that last only for your current se
 
 # Remove a specific header
 /set unset custom-headers X-Organization
-```
+````
 
 ## Model Parameters
 

--- a/docs/todo-system.md
+++ b/docs/todo-system.md
@@ -43,8 +43,14 @@ This built-in tool allows the AI model to pause its automatic workflow continuat
 
 The `todo-continuation` ephemeral setting controls a powerful feature of LLxprt Code: its ability to automatically prompt the AI to continue working.
 
-**Mechanism**: If the `todo-continuation` setting is enabled (it is `true` by default) and the AI completes a response turn without making any tool calls, but the system detects there are still `pending` or `in_progress` todos, LLxprt Code will automatically generate a new prompt like "Continue working on this task: <todo content>" and send it to the model.
+**Mechanism**: When `todo-continuation` is enabled (default `true`), LLxprt monitors each turn for signals of complex, multi-step work:
 
-**Goal**: This creates a seamless, self-directed workflow where the AI can work through a list of tasks without requiring the user to manually prompt it after each step.
+- Consecutive user prompts that contain ordered/sequential keywords ("first", "then", "next", etc.)
+- Detected task lists, file references, or multiple questions extracted by the complexity analyzer
+- Active todos that remain in `pending`/`in_progress`
+
+If the AI finishes a response without making tool calls and the analyzer detects a backlog of tasks, LLxprt automatically emits a follow-up prompt such as "Continue working on this task: <todo content>". If the user never created a todo list, the system now escalates reminders (“Use TodoWrite now…”) once a threshold of complex turns is exceeded.
+
+**Goal**: This creates a seamless, self-directed workflow where the AI can work through a list of tasks without requiring the user to manually prompt it after each step, while nudging the model to formalize todo lists for complex work.
 
 **Control**: You can disable this feature for the current session using `/ephemeral todo-continuation false`.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -93,6 +93,16 @@ This means if you're using OpenAI as your main provider but want web search, you
 - **Q: Why don't I see cached token counts in my stats output?**
   - A: Cached token information is only displayed when cached tokens are being used. This feature is available for API key users (Gemini API key or Vertex AI) but not for OAuth users (Google Personal/Enterprise accounts) at this time, as the Code Assist API does not support cached content creation. You can still view your total token usage with the `/stats` command.
 
+## Streaming / Retry issues
+
+- **Message:** `stream interrupted, retrying` (sometimes followed by `attempt 2/6`)
+  - **Cause:** LLxprt detected a transient network problem (SSE disconnect, socket hang-up, etc.) and automatically queued a retry using the global `retries`/`retrywait` settings.
+  - **Resolution:** Normally no action is required; the CLI will retry up to six times with exponential backoff. If you consistently hit this message, consider increasing `/set retrywait <ms>` or `/set retries <n>`, or inspect local proxies/firewalls.
+
+- **Error:** `Request would exceed the <limit> token context window even after compression (… including system prompt and a <completion> token completion budget).`
+  - **Cause:** After PR #315, system prompts and the contents of your loaded `LLXPRT.md` files are counted in `context-limit`. Even after compression there isn’t enough room for the pending turn plus the reserved completion budget.
+  - **Resolution:** Shorten or remove entries from your `LLXPRT.md`, run `/compress`, lower `/set maxOutputTokens <n>` (or provider-specific `max_tokens`), or temporarily disable large memories before trying again.
+
 ## PowerShell @ Symbol Issues
 
 ### Problem


### PR DESCRIPTION
## Summary\n- document the new --set flag, credential precedence, and socket settings; note that streaming values normalize to enabled/disabled\n- capture user-facing behavior changes (Gemini "Paid Mode" removal, retry defaults, todo escalation, prompt environment fields)\n- update README + release docs so 0.4.5 highlights are visible\n\n## Testing\n- npm run format