### PR TITLE
Add CLI --set support for model params

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -777,7 +777,7 @@ Arguments passed directly when running the CLI can override other configurations
   - Provides the API key for the current provider directly.
   - Example: `llxprt --key sk-...`
 - **`--set key=value`** (repeatable):
-  - Apply ephemeral settings at startup (same keys as `/set`). Pass each assignment separately (`--set streaming=disabled --set base-url=https://...`). Values are parsed using the same validation as the interactive command.
+  - Apply ephemeral settings at startup (same keys as `/set`). Pass each assignment separately (`--set streaming=disabled --set base-url=https://...`). For model parameters, use the dotted syntax (`--set modelparam.temperature=0.7 --set modelparam.max_tokens=4096`). Values are parsed using the same validation as the interactive command.
   - Precedence: CLI flags take priority over profiles/settings, which in turn override environment variables and finally OAuth tokens.
 - **`--keyfile <path>`**:
   - Path to a file containing the API key for the current provider.

--- a/docs/settings-and-profiles.md
+++ b/docs/settings-and-profiles.md
@@ -67,9 +67,12 @@ You can apply the same settings at startup via CLI flags:
 
 ```bash
 llxprt --set streaming=disabled --set base-url=https://api.anthropic.com --provider anthropic
+
+# Apply model parameters non-interactively
+llxprt --set modelparam.temperature=0.7 --set modelparam.max_tokens=4096
 ````
 
-The CLI parses each `--set key=value` just like `/set`, so CI jobs and scripts can configure ephemeral behavior without interactive prompts. Command-line values take precedence over profile/settings files.
+The CLI parses each `--set key=value` just like `/set`, so CI jobs and scripts can configure ephemeral behavior without interactive prompts. Command-line values take precedence over profile/settings files. For model parameters, use the dotted syntax `--set modelparam.<name>=<value>` which mirrors `/set modelparam <name> <value>`.
 
 # Configure streaming
 

--- a/packages/cli/src/config/cliEphemeralSettings.test.ts
+++ b/packages/cli/src/config/cliEphemeralSettings.test.ts
@@ -60,4 +60,27 @@ describe('applyCliSetArguments', () => {
     applyCliSetArguments(target, ['authOnly=false']);
     expect(target.getValue('authOnly')).toBe(false);
   });
+
+  it('collects model parameter entries and returns them separately', () => {
+    const target = new TestTarget();
+
+    const result = applyCliSetArguments(target, [
+      'modelparam.temperature=0.7',
+      'modelparam.stop_sequences=["END"]',
+    ]);
+
+    expect(result.modelParams).toEqual({
+      temperature: 0.7,
+      stop_sequences: ['END'],
+    });
+    expect(target.getValue('modelparam.temperature')).toBeUndefined();
+  });
+
+  it('requires a name when using the modelparam prefix', () => {
+    const target = new TestTarget();
+
+    expect(() => applyCliSetArguments(target, ['modelparam.=0.7'])).toThrow(
+      /model parameter key/i,
+    );
+  });
 });

--- a/packages/cli/src/config/cliEphemeralSettings.ts
+++ b/packages/cli/src/config/cliEphemeralSettings.ts
@@ -5,17 +5,26 @@
  */
 
 import { parseEphemeralSettingValue } from '../settings/ephemeralSettings.js';
+import { parseModelParamValue } from '../settings/modelParamParser.js';
 
 export interface EphemeralSettingTarget {
   setEphemeralSetting(key: string, value: unknown): void;
 }
 
+export interface CliSetResult {
+  modelParams: Record<string, unknown>;
+}
+
+const MODEL_PARAM_PREFIX = 'modelparam.';
+
 export function applyCliSetArguments(
   target: EphemeralSettingTarget,
   setArgs: readonly string[] | undefined,
-): void {
+): CliSetResult {
+  const cliModelParams: Record<string, unknown> = {};
+
   if (!setArgs || setArgs.length === 0) {
-    return;
+    return { modelParams: cliModelParams };
   }
 
   for (const entry of setArgs) {
@@ -31,6 +40,23 @@ export function applyCliSetArguments(
       throw new Error(`Invalid --set format: ${entry}. Expected key=value`);
     }
 
+    if (key === 'modelparam') {
+      throw new Error(
+        `Invalid --set key: ${entry}. Use --set modelparam.<name>=<value> (e.g., --set modelparam.temperature=0.7)`,
+      );
+    }
+
+    if (key.startsWith(MODEL_PARAM_PREFIX)) {
+      const paramName = key.slice(MODEL_PARAM_PREFIX.length).trim();
+      if (!paramName) {
+        throw new Error(
+          `Invalid model parameter key in ${entry}. Expected --set modelparam.<name>=<value>`,
+        );
+      }
+      cliModelParams[paramName] = parseModelParamValue(rawValue);
+      continue;
+    }
+
     const parseResult = parseEphemeralSettingValue(key, rawValue);
 
     if (!parseResult.success) {
@@ -39,4 +65,6 @@ export function applyCliSetArguments(
 
     target.setEphemeralSetting(key, parseResult.value);
   }
+
+  return { modelParams: cliModelParams };
 }

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -960,7 +960,14 @@ export async function loadCliConfig(
     }
   }
 
-  applyCliSetArguments(enhancedConfig, argv.set);
+  const cliSetResult = applyCliSetArguments(enhancedConfig, argv.set);
+
+  if (Object.keys(cliSetResult.modelParams).length > 0) {
+    const configWithCliParams = enhancedConfig as Config & {
+      _cliModelParams?: Record<string, unknown>;
+    };
+    configWithCliParams._cliModelParams = cliSetResult.modelParams;
+  }
 
   // Store profile model params on the config for later application
   if (profileModelParams) {

--- a/packages/cli/src/settings/modelParamParser.ts
+++ b/packages/cli/src/settings/modelParamParser.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Parse a model parameter value provided via CLI or slash commands.
+ * Attempts numeric, boolean, and JSON decoding before falling back to raw string.
+ */
+export function parseModelParamValue(value: string): unknown {
+  if (/^-?\d+(\.\d+)?$/.test(value)) {
+    const num = Number(value);
+    if (!Number.isNaN(num)) {
+      return num;
+    }
+  }
+
+  const lower = value.toLowerCase();
+  if (lower === 'true') {
+    return true;
+  }
+  if (lower === 'false') {
+    return false;
+  }
+
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}

--- a/packages/cli/src/ui/commands/setCommand.ts
+++ b/packages/cli/src/ui/commands/setCommand.ts
@@ -15,6 +15,7 @@ import {
   ephemeralSettingHelp,
   parseEphemeralSettingValue,
 } from '../../settings/ephemeralSettings.js';
+import { parseModelParamValue } from '../../settings/modelParamParser.js';
 
 // Subcommand for /set unset - removes ephemeral settings or model parameters
 const unsetCommand: SlashCommand = {
@@ -524,26 +525,3 @@ export const setCommand: SlashCommand = {
     return ephemeralKeys;
   },
 };
-
-function parseModelParamValue(value: string): unknown {
-  if (/^-?\d+(\.\d+)?$/.test(value)) {
-    const num = Number(value);
-    if (!Number.isNaN(num)) {
-      return num;
-    }
-  }
-
-  const lower = value.toLowerCase();
-  if (lower === 'true') {
-    return true;
-  }
-  if (lower === 'false') {
-    return false;
-  }
-
-  try {
-    return JSON.parse(value);
-  } catch {
-    return value;
-  }
-}

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -251,19 +251,24 @@ class GeminiAgent {
                 activeProvider.setBaseUrl(baseUrl);
               }
 
-              // Apply profile model params if loaded
+              // Apply model params from profile and CLI overrides if available
               const configWithProfile = sessionConfig as Config & {
                 _profileModelParams?: Record<string, unknown>;
+                _cliModelParams?: Record<string, unknown>;
+              };
+              const mergedModelParams = {
+                ...(configWithProfile._profileModelParams || {}),
+                ...(configWithProfile._cliModelParams || {}),
               };
               if (
-                configWithProfile._profileModelParams &&
+                Object.keys(mergedModelParams).length > 0 &&
                 'setModelParams' in activeProvider &&
                 activeProvider.setModelParams
               ) {
-                this.logger.debug(() => 'Setting model params from profile');
-                activeProvider.setModelParams(
-                  configWithProfile._profileModelParams,
+                this.logger.debug(
+                  () => 'Setting model params from profile/CLI overrides',
                 );
+                activeProvider.setModelParams(mergedModelParams);
               }
             }
           }


### PR DESCRIPTION
## Summary\n- parse dotted `--set modelparam.*` entries and forward them to providers alongside profile values\n- share a model param parser with /set and document the CLI usage\n- cover the new behavior with tests and ensure startup plumbing applies the overrides\n\nResolves #346