### PR TITLE
Fix exit showTodoPanelSetting regression

### DIFF
--- a/packages/cli/src/ui/App.quittingMessages.test.ts
+++ b/packages/cli/src/ui/App.quittingMessages.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+describe('App quittingMessages block', () => {
+  it('defines showTodoPanelSetting before it is used', () => {
+    const appSource = readFileSync(
+      path.resolve(__dirname, './App.tsx'),
+      'utf8',
+    );
+    const quittingBlockIndex = appSource.indexOf('if (quittingMessages)');
+    expect(quittingBlockIndex).toBeGreaterThan(0);
+
+    const showTodoDeclarationIndex = appSource.lastIndexOf(
+      'const showTodoPanelSetting',
+      quittingBlockIndex,
+    );
+    expect(showTodoDeclarationIndex).toBeGreaterThanOrEqual(0);
+    expect(showTodoDeclarationIndex).toBeLessThan(quittingBlockIndex);
+  });
+});

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -1252,6 +1252,9 @@ const App = (props: AppInternalProps) => {
     geminiClient,
   ]);
 
+  const showTodoPanelSetting = settings.merged.showTodoPanel ?? true;
+  const hideContextSummary = settings.merged.hideContextSummary ?? false;
+
   if (quittingMessages) {
     return (
       <Box flexDirection="column" marginBottom={1}>
@@ -1289,9 +1292,6 @@ const App = (props: AppInternalProps) => {
     : isPowerShell
       ? '  Type your message, @path/to/file or +path/to/file'
       : '  Type your message or @path/to/file';
-
-  const showTodoPanelSetting = settings.merged.showTodoPanel ?? true;
-  const hideContextSummary = settings.merged.hideContextSummary ?? false;
 
   return (
     <StreamingContext.Provider value={streamingState}>


### PR DESCRIPTION
## Summary
- add regression test to ensure Todo panel setting defined before use
- define showTodoPanelSetting and hideContextSummary prior to quittingMessages early return

## Testing
- npm run test
- npm run lint
- npm run typecheck
- npm run format
- npm run build

Fixes #356