### PR TITLE
Feature: Add Provider Alias Support (issue #123)

### DIFF
--- a/packages/core/src/providers/openai/OpenAIProvider.ts
+++ b/packages/core/src/providers/openai/OpenAIProvider.ts
@@ -526,6 +526,9 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
 
   override getDefaultModel(): string {
     // Return hardcoded default - do NOT call getModel() to avoid circular dependency
+    if (this.providerConfig?.defaultModel) {
+      return this.providerConfig.defaultModel;
+    }
     // Check if this is a Qwen provider instance based on baseURL
     const baseURL = this.getBaseURL();
     if (


### PR DESCRIPTION


## TLDR

- Refactor AI provider initialization logic to support dynamic registration of various OpenAI-compatible services.
- Add `defaultModel` configuration option to `OpenAIProvider`, improving model selection flexibility across different services.

## Dive Deeper

```ts
// packages/cli/src/providers/providerManagerInstance.ts (Lines 363–392)
  const providerSettings = {
    Fireworks: {
      baseURL: 'https://api.fireworks.ai/inference/v1/',
      model: 'accounts/fireworks/models/llama-v3p3-70b-instruct',
    },
    OpenRouter: {
      baseURL: 'https://openrouter.ai/api/v1/',
      model: 'nvidia/nemotron-nano-9b-v2:free',
    },
    'Chutes.ai': {
      baseURL: 'https://llm.chutes.ai/v1/',
      model: 'zai-org/GLM-4.5-Air',
    },
    'Cerebras Code': {
      baseURL: 'https://api.cerebras.ai/v1/',
      model: 'qwen-3-coder-480b',
    },
    xAI: {
      baseURL: 'https://api.x.ai/v1/',
      model: 'grok-3',
    },
    'LM Studio': {
      baseURL: 'http://127.0.0.1:1234/v1/',
      model: 'gemma-3b-it',
    },
    'llama.cpp': {
      baseURL: 'http://localhost:8080/v1/',
      model: 'local-model',
    },
  };

```

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
This PR makes progress on #123 
<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
