### PR TITLE
Detect GLM models as Qwen tool format

### DIFF
--- a/packages/core/src/providers/anthropic/AnthropicProvider.toolFormatDetection.test.ts
+++ b/packages/core/src/providers/anthropic/AnthropicProvider.toolFormatDetection.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AnthropicProvider } from './AnthropicProvider.js';
+
+const mockSettingsService = vi.hoisted(() => ({
+  set: vi.fn(),
+  get: vi.fn(),
+  setProviderSetting: vi.fn(),
+  getProviderSetting: vi.fn(),
+  getProviderSettings: vi.fn(),
+  updateSettings: vi.fn(),
+  settings: { providers: { anthropic: {} } },
+}));
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: vi.fn(),
+}));
+
+vi.mock('../../tools/ToolFormatter.js', () => ({
+  ToolFormatter: vi.fn().mockImplementation(() => ({
+    convertGeminiToFormat: vi.fn(),
+  })),
+}));
+
+vi.mock('../../core/prompts.js', () => ({
+  getCoreSystemPromptAsync: vi.fn().mockResolvedValue('system prompt'),
+}));
+
+vi.mock('../../utils/retry.js', () => ({
+  retryWithBackoff: vi.fn(async (fn) => fn()),
+  getErrorStatus: vi.fn(),
+  isNetworkTransientError: vi.fn(),
+}));
+
+vi.mock('../../settings/settingsServiceInstance.js', () => ({
+  getSettingsService: () => mockSettingsService,
+}));
+
+describe('AnthropicProvider tool format detection', () => {
+  let provider: AnthropicProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSettingsService.settings = { providers: { anthropic: {} } };
+    provider = new AnthropicProvider('test-key');
+  });
+
+  it('detects qwen format for GLM models', () => {
+    vi.spyOn(provider, 'getCurrentModel').mockReturnValue('glm-4.6');
+
+    expect(provider.getToolFormat()).toBe('qwen');
+  });
+
+  it('keeps anthropic format for non-GLM models', () => {
+    vi.spyOn(provider, 'getCurrentModel').mockReturnValue('claude-3-7b');
+
+    expect(provider.getToolFormat()).toBe('anthropic');
+  });
+});

--- a/packages/core/src/providers/anthropic/AnthropicProvider.ts
+++ b/packages/core/src/providers/anthropic/AnthropicProvider.ts
@@ -528,8 +528,8 @@ export class AnthropicProvider extends BaseProvider {
       // Auto-detect based on model name if set to 'auto' or not set
       const modelName = this.getCurrentModel().toLowerCase();
 
-      // Check for GLM-4.5 models (glm-4.5, glm-4-5)
-      if (modelName.includes('glm-4.5') || modelName.includes('glm-4-5')) {
+      // Check for GLM models which require Qwen handling
+      if (modelName.includes('glm-')) {
         return 'qwen';
       }
 
@@ -548,7 +548,7 @@ export class AnthropicProvider extends BaseProvider {
       // Fallback detection without SettingsService
       const modelName = this.getCurrentModel().toLowerCase();
 
-      if (modelName.includes('glm-4.5') || modelName.includes('glm-4-5')) {
+      if (modelName.includes('glm-')) {
         return 'qwen';
       }
 

--- a/packages/core/src/providers/openai/OpenAIProvider.toolFormatDetection.test.ts
+++ b/packages/core/src/providers/openai/OpenAIProvider.toolFormatDetection.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { OpenAIProvider } from './OpenAIProvider.js';
+
+const mockSettingsService = vi.hoisted(() => ({
+  set: vi.fn(),
+  get: vi.fn(),
+  setProviderSetting: vi.fn(),
+  getProviderSetting: vi.fn(),
+  getProviderSettings: vi.fn(),
+  updateSettings: vi.fn(),
+  settings: { providers: { openai: {} } },
+}));
+
+vi.mock('openai', () => ({
+  default: vi.fn(),
+}));
+
+vi.mock('../../settings/settingsServiceInstance.js', () => ({
+  getSettingsService: () => mockSettingsService,
+}));
+
+describe('OpenAIProvider tool format detection', () => {
+  let provider: OpenAIProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSettingsService.settings = { providers: { openai: {} } };
+    provider = new OpenAIProvider('test-key');
+  });
+
+  it('detects qwen format for GLM models', () => {
+    vi.spyOn(provider, 'getModel').mockReturnValue('openai:hf:zai-org/GLM-4.6');
+
+    expect(provider.getToolFormat()).toBe('qwen');
+  });
+
+  it('keeps openai format for non-GLM models', () => {
+    vi.spyOn(provider, 'getModel').mockReturnValue('gpt-4.1-mini');
+
+    expect(provider.getToolFormat()).toBe('openai');
+  });
+});

--- a/packages/core/src/providers/openai/OpenAIProvider.ts
+++ b/packages/core/src/providers/openai/OpenAIProvider.ts
@@ -1585,10 +1585,10 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
     // Auto-detect based on model name if set to 'auto' or not set
     const modelName = (this.getModel() || this.getDefaultModel()).toLowerCase();
 
-    // Check for GLM-4.5 models (glm-4.5, glm-4-5)
-    if (modelName.includes('glm-4.5') || modelName.includes('glm-4-5')) {
+    // Check for GLM models (glm-4.5, glm-4-6, etc.) which require Qwen handling
+    if (modelName.includes('glm-')) {
       this.logger.debug(
-        () => `Auto-detected 'qwen' format for GLM-4.5 model: ${modelName}`,
+        () => `Auto-detected 'qwen' format for GLM model: ${modelName}`,
       );
       return 'qwen';
     }


### PR DESCRIPTION
## Summary
- auto-detect Qwen tooling for any glm-* model (covers GLM-4.6 streaming fix)
- mirror the detection in the Anthropic provider for consistency
- lock the behaviour with provider-specific tool-format detection tests

## Testing
- npm run test
- npm run lint
- npm run typecheck
- npm run format
- npm run build

Fixes #362],