### PR TITLE
fix: Update Google OAuth success URL to use vybestack.dev (#368)

### DIFF
--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -47,8 +47,7 @@ const OAUTH_SCOPE = [
 ];
 
 const HTTP_REDIRECT = 301;
-const SIGN_IN_SUCCESS_URL =
-  'https://developers.google.com/gemini-code-assist/auth_success_gemini';
+const SIGN_IN_SUCCESS_URL = 'https://vybestack.dev/google/login.html';
 const SIGN_IN_FAILURE_URL =
   'https://developers.google.com/gemini-code-assist/auth_failure_gemini';
 


### PR DESCRIPTION
This PR addresses issue #368 by updating the Google OAuth success URL from Google's white page to our custom dark mode page at vybestack.dev.

### Changes
- Modified  in  to point to 
- This replaces the harsh white background page with a custom dark mode page that's easier on the eyes

### Testing
- All tests pass
- Linting and type checking completed successfully
- Build completed without errors