### PR TITLE
fix: respect context-limit when enforcing context window (#384)

### DIFF
--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -1290,7 +1290,13 @@ export class GeminiClient {
     if (!force) {
       const threshold =
         contextPercentageThreshold ?? COMPRESSION_TOKEN_THRESHOLD;
-      if (originalTokenCount < threshold * tokenLimit(model)) {
+      const userContextLimit = this.config.getEphemeralSetting(
+        'context-limit',
+      ) as number | undefined;
+      if (
+        originalTokenCount <
+        threshold * tokenLimit(model, userContextLimit)
+      ) {
         return {
           originalTokenCount,
           newTokenCount: originalTokenCount,
@@ -1385,10 +1391,13 @@ export class GeminiClient {
       if (typeof compressedChat.getHistoryService === 'function') {
         const historyService = compressedChat.getHistoryService();
         if (historyService) {
+          const userContextLimit = this.config.getEphemeralSetting(
+            'context-limit',
+          ) as number | undefined;
           historyService.emit('tokensUpdated', {
             totalTokens: newTokenCount,
             addedTokens: newTokenCount - originalTokenCount,
-            tokenLimit: tokenLimit(this.config.getModel()),
+            tokenLimit: tokenLimit(this.config.getModel(), userContextLimit),
           });
         }
       }

--- a/packages/core/src/core/geminiChat.contextlimit.test.ts
+++ b/packages/core/src/core/geminiChat.contextlimit.test.ts
@@ -1,0 +1,124 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GeminiChat } from './geminiChat.js';
+import { Config } from '../config/config.js';
+import { DEFAULT_TOKEN_LIMIT } from './tokenLimits.js';
+import * as tokenLimitsModule from './tokenLimits.js';
+
+describe('GeminiChat Context Limit Enforcement', () => {
+  let chat: GeminiChat;
+  let mockConfig: Config;
+  let mockHistoryService: {
+    getTotalTokens: ReturnType<typeof vi.fn>;
+    waitForTokenUpdates: ReturnType<typeof vi.fn>;
+    emit: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    // Mock Config object similar to existing tests
+    mockConfig = {
+      getSessionId: () => 'test-session-id',
+      getTelemetryLogPromptsEnabled: () => true,
+      getUsageStatisticsEnabled: () => true,
+      getDebugMode: () => false,
+      getContentGeneratorConfig: () => ({
+        authType: 'oauth-personal',
+        model: 'test-model',
+      }),
+      getModel: vi.fn().mockReturnValue('hf:zai-org/GLM-4.6'),
+      setModel: vi.fn(),
+      getEphemeralSettings: vi.fn().mockReturnValue({}),
+      getEphemeralSetting: vi.fn().mockImplementation((key) => {
+        if (key === 'context-limit') return 190000;
+        return undefined;
+      }),
+      setEphemeralSetting: vi.fn(),
+      getProviderManager: vi.fn().mockReturnValue({
+        getActiveProvider: vi.fn().mockReturnValue({
+          name: 'test-provider',
+          generateChatCompletion: vi.fn(),
+        }),
+      }),
+    } as unknown as Config;
+
+    // Mock the history service
+    mockHistoryService = {
+      getTotalTokens: vi.fn().mockReturnValue(180000),
+      waitForTokenUpdates: vi.fn().mockResolvedValue(undefined),
+      emit: vi.fn(),
+    };
+
+    // Mock the tokenLimit function to track calls
+    vi.spyOn(tokenLimitsModule, 'tokenLimit').mockImplementation(
+      (model, userContextLimit) => {
+        if (userContextLimit) {
+          return userContextLimit;
+        }
+        return DEFAULT_TOKEN_LIMIT;
+      },
+    );
+  });
+
+  it('should enforce context window using user-configured context-limit', async () => {
+    // Arrange: Set up chat with context-limit and mock large pending tokens
+    chat = new GeminiChat(mockConfig, mockHistoryService);
+
+    // Mock large pending tokens that would exceed the context-limit but not the default
+    const pendingTokens = 15000; // This would exceed 190000 but not the default 1M
+
+    // Act & Assert: enforceContextWindow should trigger compression
+    // because total (180000) + pending (15000) = 195000 > context-limit (190000)
+    await expect(
+      chat['enforceContextWindow'](pendingTokens, 'test-prompt-id'),
+    ).resolves.not.toThrow();
+
+    // Verify tokenLimit was called with the user context limit
+    expect(tokenLimitsModule.tokenLimit).toHaveBeenCalledWith(
+      mockConfig.getModel(),
+      190000, // This should be passed as userContextLimit
+    );
+  });
+
+  it('should not trigger compression when within context-limit', async () => {
+    // Arrange: Set up chat with context-limit and small pending tokens
+    chat = new GeminiChat(mockConfig, mockHistoryService);
+    const pendingTokens = 5000; // This should be within the limit
+
+    // Act: Should not trigger compression
+    await expect(
+      chat['enforceContextWindow'](pendingTokens, 'test-prompt-id'),
+    ).resolves.not.toThrow();
+
+    // Verify tokenLimit was called with the user context limit
+    expect(tokenLimitsModule.tokenLimit).toHaveBeenCalledWith(
+      mockConfig.getModel(),
+      190000,
+    );
+  });
+
+  it('should use context-limit when available, falling back to default when not set', async () => {
+    // Arrange: Create config without context-limit
+    const configWithoutLimit = {
+      ...mockConfig,
+      getEphemeralSetting: vi.fn().mockReturnValue(undefined),
+    };
+    chat = new GeminiChat(configWithoutLimit, mockHistoryService);
+    const pendingTokens = 15000;
+
+    // Act
+    await expect(
+      chat['enforceContextWindow'](pendingTokens, 'test-prompt-id'),
+    ).resolves.not.toThrow();
+
+    // Verify tokenLimit was called without user context limit
+    expect(tokenLimitsModule.tokenLimit).toHaveBeenCalledWith(
+      configWithoutLimit.getModel(),
+      undefined,
+    );
+  });
+});

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -1264,7 +1264,10 @@ export class GeminiChat {
     await this.historyService.waitForTokenUpdates();
 
     const completionBudget = Math.max(0, this.getCompletionBudget(provider));
-    const limit = tokenLimit(this.config.getModel());
+    const userContextLimit = this.config.getEphemeralSetting(
+      'context-limit',
+    ) as number | undefined;
+    const limit = tokenLimit(this.config.getModel(), userContextLimit);
     const marginAdjustedLimit = Math.max(
       0,
       limit - GeminiChat.TOKEN_SAFETY_MARGIN,


### PR DESCRIPTION
## Summary

Fixes #384 - Context limit enforcement was ignoring user-configured context-limit setting and using default token limits, causing requests to exceed provider context windows.

## Problem

- GeminiChat.enforceContextWindow was calling tokenLimit(this.config.getModel()) without passing the user context limit
- CoreClient.tryCompressChat had the same issue in two places:
  - Threshold comparison for compression decisions
  - Token limit reporting in compression events
- This resulted in requests potentially exceeding the actual provider context window (e.g., 200k) and receiving HTTP 400 errors

## Solution

Modified all three locations to pass the user-configured context limit to tokenLimit():

1. GeminiChat.enforceContextWindow - Added retrieval of context-limit from ephemeral settings
2. CoreClient.tryCompressChat threshold comparison - Now respects user context limit when deciding whether to compress
3. CoreClient.tryCompressChat token emissions - Reports accurate token limits reflecting user configuration

## Changes

- packages/core/src/core/geminiChat.ts: Pass userContextLimit to tokenLimit() in enforceContextWindow
- packages/core/src/core/client.ts: Pass userContextLimit to tokenLimit() in two locations within tryCompressChat
- packages/core/src/core/geminiChat.contextlimit.test.ts: New comprehensive unit tests

## Testing

- Added unit tests verifying context-limit is properly passed to tokenLimit()
- Tests cover scenarios with and without context-limit configured
- All existing tests continue to pass
- Full CI pipeline passes (lint, typecheck, build, tests)

## Impact

- User-configured context limits are now properly respected throughout the context window enforcement pipeline
- Prevents HTTP 400 errors for context overflow
- Maintains backward compatibility when context-limit is not configured