### PR TITLE
feat: improve auth status reporting (#395)

### DIFF
--- a/packages/cli/src/auth/oauth-manager.ts
+++ b/packages/cli/src/auth/oauth-manager.ts
@@ -378,6 +378,27 @@ export class OAuthManager {
   }
 
   /**
+   * Retrieve the stored OAuth token without refreshing it.
+   * Returns null if the provider is unknown or no token exists.
+   */
+  async peekStoredToken(providerName: string): Promise<OAuthToken | null> {
+    if (!providerName || typeof providerName !== 'string') {
+      throw new Error('Provider name must be a non-empty string');
+    }
+
+    if (!this.providers.has(providerName)) {
+      throw new Error(`Unknown provider: ${providerName}`);
+    }
+
+    try {
+      return await this.tokenStore.getToken(providerName);
+    } catch (error) {
+      console.debug(`Failed to load stored token for ${providerName}:`, error);
+      return null;
+    }
+  }
+
+  /**
    * Get OAuth token object for a specific provider
    * @param providerName - Name of the provider
    * @returns OAuth token if available, null otherwise

--- a/packages/cli/src/ui/commands/authCommand.ts
+++ b/packages/cli/src/ui/commands/authCommand.ts
@@ -94,9 +94,17 @@ export class AuthCommandExecutor {
 
       let status = `OAuth for ${provider}: ${isEnabled ? 'ENABLED' : 'DISABLED'}`;
       if (isEnabled && isAuthenticated) {
-        // Lines 70-85: Show token expiry information @pseudocode lines 70-85
-        const token = await this.oauthManager.getOAuthToken(provider);
-        if (token && token.expiry) {
+        let token = null;
+        try {
+          token = await this.oauthManager.peekStoredToken(provider);
+        } catch (error) {
+          console.debug(
+            `Failed to read stored OAuth token for ${provider}:`,
+            error,
+          );
+        }
+
+        if (token && typeof token.expiry === 'number') {
           // Lines 72-76: Calculate time until expiry
           const expiryDate = new Date(token.expiry * 1000);
           const timeUntilExpiry = Math.max(0, token.expiry - Date.now() / 1000);


### PR DESCRIPTION
## Summary
- avoid triggering provider refresh when rendering /auth status
- surface provider authentication status in the auth dialog list

## Testing
- npm run test:ci
- npm run test
- npm run typecheck
- npm run lint
- npm run format
- npm run build

Fixes #395