### PR TITLE
fix: improve markdown table wrapping

### DIFF
--- a/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
@@ -169,6 +169,27 @@ Test
     expect(lastFrame()).toMatchSnapshot();
   });
 
+  it('wraps long table cells while preserving markdown styling', () => {
+    const text = `
+| Header 1 | Header 2 |
+|----------|----------|
+| **Important bold content that should exceed column width** | Regular text that also runs very long and should trigger wrapping behavior |
+`.replace(/\n/g, EOL);
+    const { lastFrame } = render(
+      <SettingsContext.Provider value={mockSettings}>
+        <MarkdownDisplay {...baseProps} text={text} terminalWidth={32} />
+      </SettingsContext.Provider>,
+    );
+    const frame = lastFrame();
+    expect(frame).toContain('┌────────────┬───────────────┐');
+    expect(frame).toContain('│ Header 1   │ Header 2      │');
+    expect(frame).toContain('│ Important  │ Regular text  │');
+    expect(frame).toContain('│ bold       │ that also     │');
+    expect(frame).toContain('│ width      │ behavior      │');
+    expect(frame).not.toContain('...');
+    expect(frame).toContain('└────────────┴───────────────┘');
+  });
+
   it('handles a table at the end of the input', () => {
     const text = `
 Some text before.

--- a/packages/cli/src/ui/utils/TableRenderer.tsx
+++ b/packages/cli/src/ui/utils/TableRenderer.tsx
@@ -9,6 +9,243 @@ import { Text, Box } from 'ink';
 import { theme } from '../colors.js';
 import { RenderInline, getPlainTextLength } from './InlineMarkdownRenderer.js';
 
+const TERMINAL_MARGIN = 2;
+const MIN_COLUMN_WIDTH = 4;
+const WRAP_CACHE_LIMIT = 200;
+
+const wrapCache = new Map<string, string[]>();
+const wrapCacheOrder: string[] = [];
+
+interface MarkerDef {
+  open: string;
+  close: string;
+  symmetric: boolean;
+}
+
+interface MarkerState {
+  def: MarkerDef;
+}
+
+const MARKER_DEFS: MarkerDef[] = [
+  { open: '**', close: '**', symmetric: true },
+  { open: '__', close: '__', symmetric: true },
+  { open: '~~', close: '~~', symmetric: true },
+  { open: '*', close: '*', symmetric: true },
+  { open: '_', close: '_', symmetric: true },
+  { open: '<u>', close: '</u>', symmetric: false },
+];
+
+const SORTED_MARKERS = [...MARKER_DEFS].sort(
+  (a, b) =>
+    Math.max(b.open.length, b.close.length) -
+    Math.max(a.open.length, a.close.length),
+);
+
+const MARKER_BOUNDARY_CHARS = new Set(['*', '_', '~', '<', '/', '`']);
+
+const getOpeningSequence = (stack: MarkerState[]): string =>
+  stack.map(({ def }) => def.open).join('');
+
+const getClosingSequence = (stack: MarkerState[]): string => {
+  let closing = '';
+  for (let index = stack.length - 1; index >= 0; index -= 1) {
+    closing += stack[index]?.def.close ?? '';
+  }
+  return closing;
+};
+
+const updateMarkerStack = (
+  segment: string,
+  stack: MarkerState[],
+): MarkerState[] => {
+  if (!segment) return [...stack];
+
+  const updated = [...stack];
+  let pointer = 0;
+
+  while (pointer < segment.length) {
+    let matched = false;
+
+    for (const marker of SORTED_MARKERS) {
+      if (!marker.symmetric && segment.startsWith(marker.close, pointer)) {
+        const matchIndex = [...updated]
+          .reverse()
+          .findIndex((entry) => entry.def === marker);
+        if (matchIndex !== -1) {
+          updated.splice(updated.length - matchIndex - 1);
+        }
+        pointer += marker.close.length;
+        matched = true;
+        break;
+      }
+
+      if (segment.startsWith(marker.open, pointer)) {
+        if (marker.symmetric) {
+          if (
+            updated.length > 0 &&
+            updated[updated.length - 1]?.def === marker
+          ) {
+            updated.pop();
+          } else {
+            updated.push({ def: marker });
+          }
+        } else {
+          updated.push({ def: marker });
+        }
+        pointer += marker.open.length;
+        matched = true;
+        break;
+      }
+    }
+
+    if (!matched) {
+      pointer += 1;
+    }
+  }
+
+  return updated;
+};
+
+const findBreakIndex = (
+  content: string,
+  prefix: string,
+  maxWidth: number,
+): number => {
+  let left = 0;
+  let right = content.length;
+  let best = 0;
+
+  while (left <= right) {
+    const mid = Math.floor((left + right) / 2);
+    const candidate = prefix + content.slice(0, mid);
+    if (getPlainTextLength(candidate) <= maxWidth) {
+      best = mid;
+      left = mid + 1;
+    } else {
+      right = mid - 1;
+    }
+  }
+
+  return best;
+};
+
+const adjustBreakIndex = (content: string, index: number): number => {
+  if (index <= 0 || index > content.length) {
+    return index;
+  }
+
+  const slice = content.slice(0, index);
+  let whitespaceIndex = -1;
+  for (let pointer = slice.length - 1; pointer >= 0; pointer -= 1) {
+    if (/\s/u.test(slice[pointer] ?? '')) {
+      whitespaceIndex = pointer;
+      break;
+    }
+  }
+
+  let adjusted = index;
+  if (whitespaceIndex !== -1) {
+    adjusted = whitespaceIndex + 1;
+  }
+
+  if (adjusted === 0) {
+    adjusted = index;
+  }
+
+  while (
+    adjusted > 0 &&
+    MARKER_BOUNDARY_CHARS.has(content[adjusted - 1] ?? '')
+  ) {
+    adjusted -= 1;
+  }
+
+  return adjusted > 0 ? adjusted : index;
+};
+
+const wrapCellContent = (content: string, maxWidth: number): string[] => {
+  const cacheKey = `${maxWidth}::${content}`;
+  const cached = wrapCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  if (maxWidth <= 0) {
+    rememberWrapResult(cacheKey, ['']);
+    return [''];
+  }
+  if (!content) {
+    rememberWrapResult(cacheKey, ['']);
+    return [''];
+  }
+  if (getPlainTextLength(content) <= maxWidth) {
+    rememberWrapResult(cacheKey, [content]);
+    return [content];
+  }
+
+  const lines: string[] = [];
+  let remaining = content;
+  let activeStack: MarkerState[] = [];
+  let guard = 0;
+
+  while (remaining.length > 0 && guard < 1000) {
+    guard += 1;
+
+    const prefix = getOpeningSequence(activeStack);
+    let breakIndex = findBreakIndex(remaining, prefix, maxWidth);
+
+    if (breakIndex <= 0) {
+      const [firstChar] = [...remaining];
+      const charLength = firstChar ? firstChar.length : 1;
+      const segment = remaining.slice(0, charLength);
+      lines.push(prefix + segment + getClosingSequence(activeStack));
+      remaining = remaining.slice(charLength);
+      continue;
+    }
+
+    if (breakIndex < remaining.length) {
+      const adjusted = adjustBreakIndex(remaining, breakIndex);
+      if (adjusted > 0) {
+        breakIndex = adjusted;
+      }
+    }
+
+    const segmentRaw = remaining.slice(0, breakIndex);
+    remaining = remaining.slice(breakIndex).replace(/^\s+/u, '');
+
+    const segment = segmentRaw.replace(/\s+$/u, '');
+    const updatedStack = updateMarkerStack(segment, activeStack);
+    const closingSequence = getClosingSequence(updatedStack);
+
+    if (segment.length > 0 || closingSequence.length > 0) {
+      lines.push(prefix + segment + closingSequence);
+    }
+
+    activeStack = updatedStack;
+  }
+
+  const result = lines.length > 0 ? lines : [''];
+  rememberWrapResult(cacheKey, result);
+  return result;
+};
+
+const rememberWrapResult = (key: string, lines: string[]): void => {
+  if (wrapCache.has(key)) {
+    const existingIndex = wrapCacheOrder.indexOf(key);
+    if (existingIndex !== -1) {
+      wrapCacheOrder.splice(existingIndex, 1);
+    }
+  }
+  wrapCache.set(key, lines);
+  wrapCacheOrder.push(key);
+
+  while (wrapCacheOrder.length > WRAP_CACHE_LIMIT) {
+    const oldestKey = wrapCacheOrder.shift();
+    if (oldestKey) {
+      wrapCache.delete(oldestKey);
+    }
+  }
+};
+
 interface TableRendererProps {
   headers: string[];
   rows: string[][];
@@ -35,70 +272,39 @@ export const TableRenderer: React.FC<TableRendererProps> = ({
 
   // Ensure table fits within terminal width
   const totalWidth = columnWidths.reduce((sum, width) => sum + width + 1, 1);
+  const minTotalWidth = headers.length * MIN_COLUMN_WIDTH + headers.length + 1;
+  const availableWidth = Math.max(
+    Math.min(totalWidth, Math.max(terminalWidth - TERMINAL_MARGIN, 0)),
+    minTotalWidth,
+  );
   const scaleFactor =
-    totalWidth > terminalWidth ? terminalWidth / totalWidth : 1;
+    totalWidth > availableWidth ? availableWidth / totalWidth : 1;
   const adjustedWidths = columnWidths.map((width) =>
-    Math.floor(width * scaleFactor),
+    Math.max(MIN_COLUMN_WIDTH, Math.floor(width * scaleFactor)),
   );
 
-  // Helper function to render a cell with proper width
-  const renderCell = (
-    content: string,
-    width: number,
-    isHeader = false,
-  ): React.ReactNode => {
-    const contentWidth = Math.max(0, width - 2);
-    const displayWidth = getPlainTextLength(content);
+  let adjustedTotal = adjustedWidths.reduce((sum, width) => sum + width + 1, 1);
 
-    let cellContent = content;
-    if (displayWidth > contentWidth) {
-      if (contentWidth <= 3) {
-        // Just truncate by character count
-        cellContent = content.substring(
-          0,
-          Math.min(content.length, contentWidth),
-        );
-      } else {
-        // Truncate preserving markdown formatting using binary search
-        let left = 0;
-        let right = content.length;
-        let bestTruncated = content;
-
-        // Binary search to find the optimal truncation point
-        while (left <= right) {
-          const mid = Math.floor((left + right) / 2);
-          const candidate = content.substring(0, mid);
-          const candidateWidth = getPlainTextLength(candidate);
-
-          if (candidateWidth <= contentWidth - 3) {
-            bestTruncated = candidate;
-            left = mid + 1;
-          } else {
-            right = mid - 1;
-          }
-        }
-
-        cellContent = bestTruncated + '...';
+  while (
+    adjustedTotal > availableWidth &&
+    adjustedWidths.some((width) => width > MIN_COLUMN_WIDTH)
+  ) {
+    let indexToTrim = -1;
+    let largestWidth = MIN_COLUMN_WIDTH;
+    adjustedWidths.forEach((width, index) => {
+      if (width > largestWidth) {
+        largestWidth = width;
+        indexToTrim = index;
       }
+    });
+
+    if (indexToTrim === -1) {
+      break;
     }
 
-    // Calculate exact padding needed
-    const actualDisplayWidth = getPlainTextLength(cellContent);
-    const paddingNeeded = Math.max(0, contentWidth - actualDisplayWidth);
-
-    return (
-      <Text>
-        {isHeader ? (
-          <Text bold color={theme.text.accent}>
-            <RenderInline text={cellContent} />
-          </Text>
-        ) : (
-          <RenderInline text={cellContent} />
-        )}
-        {' '.repeat(paddingNeeded)}
-      </Text>
-    );
-  };
+    adjustedWidths[indexToTrim] -= 1;
+    adjustedTotal -= 1;
+  }
 
   // Helper function to render border
   const renderBorder = (type: 'top' | 'middle' | 'bottom'): React.ReactNode => {
@@ -117,28 +323,51 @@ export const TableRenderer: React.FC<TableRendererProps> = ({
 
   // Helper function to render a table row
   const renderRow = (cells: string[], isHeader = false): React.ReactNode => {
-    const renderedCells = cells.map((cell, index) => {
+    const cellData = cells.map((cell, index) => {
       const width = adjustedWidths[index] || 0;
-      return renderCell(cell || '', width, isHeader);
+      const contentWidth = Math.max(0, width - 2);
+      const cacheKey = `${contentWidth}::${cell || ''}`;
+      const cachedLines = wrapCache.get(cacheKey);
+      const lines = cachedLines ?? wrapCellContent(cell || '', contentWidth);
+      return { lines, contentWidth };
     });
+
+    const maxLines = Math.max(1, ...cellData.map((data) => data.lines.length));
 
     return (
       <Text>
-        <Text color={theme.border.default}>│</Text>{' '}
-        {renderedCells.map((cell, index) => (
-          <React.Fragment key={index}>
-            {cell}
-            {index < renderedCells.length - 1 ? (
-              <>
-                {' '}
-                <Text color={theme.border.default}>│</Text>{' '}
-              </>
-            ) : (
-              ''
-            )}
+        {Array.from({ length: maxLines }).map((_, lineIndex) => (
+          <React.Fragment key={lineIndex}>
+            {lineIndex > 0 ? '\n' : null}
+            <Text color={theme.border.default}>│</Text>{' '}
+            {cellData.map((data, index) => {
+              const lineContent = data.lines[lineIndex] ?? '';
+              const displayWidth = getPlainTextLength(lineContent);
+              const padding = Math.max(0, data.contentWidth - displayWidth);
+              const contentNode = isHeader ? (
+                <Text bold color={theme.text.accent}>
+                  <RenderInline text={lineContent} />
+                </Text>
+              ) : (
+                <RenderInline text={lineContent} />
+              );
+
+              return (
+                <React.Fragment key={index}>
+                  {contentNode}
+                  {padding > 0 ? ' '.repeat(padding) : ''}
+                  {index < cellData.length - 1 ? (
+                    <>
+                      {' '}
+                      <Text color={theme.border.default}>│</Text>{' '}
+                    </>
+                  ) : null}
+                </React.Fragment>
+              );
+            })}{' '}
+            <Text color={theme.border.default}>│</Text>
           </React.Fragment>
-        ))}{' '}
-        <Text color={theme.border.default}>│</Text>
+        ))}
       </Text>
     );
   };


### PR DESCRIPTION
## Summary
- add markdown-aware table cell wrapping that preserves inline styling
- balance column widths and support multi-line rows without truncation
- cover the new wrapping behavior in MarkdownDisplay snapshots

## Testing
- npm run test:ci
- npm run test
- npm run lint
- npm run typecheck
- npm run format
- npm run build

Fixes #352
