### PR TITLE
feat: add provider and base URL to /about command output

### DIFF
--- a/packages/cli/src/ui/commands/aboutCommand.test.ts
+++ b/packages/cli/src/ui/commands/aboutCommand.test.ts
@@ -120,6 +120,8 @@ describe('aboutCommand', () => {
         keyfile: '',
         key: '',
         ideClient: 'test-ide',
+        provider: 'Unknown',
+        baseURL: '',
       },
       expect.any(Number),
     );
@@ -180,6 +182,8 @@ describe('aboutCommand', () => {
         selectedAuthType: 'test-auth',
         gcpProject: 'test-gcp-project',
         ideClient: '',
+        provider: 'Unknown',
+        baseURL: '',
       }),
       expect.any(Number),
     );

--- a/packages/cli/src/ui/components/AboutBox.tsx
+++ b/packages/cli/src/ui/components/AboutBox.tsx
@@ -16,7 +16,11 @@ interface AboutBoxProps {
   modelVersion: string;
   selectedAuthType: string;
   gcpProject: string;
+  keyfile: string;
+  key: string;
   ideClient: string;
+  provider: string;
+  baseURL: string;
 }
 
 export const AboutBox: React.FC<AboutBoxProps> = ({
@@ -27,6 +31,8 @@ export const AboutBox: React.FC<AboutBoxProps> = ({
   selectedAuthType,
   gcpProject,
   ideClient,
+  provider,
+  baseURL,
 }) => (
   <Box
     borderStyle="round"
@@ -73,6 +79,28 @@ export const AboutBox: React.FC<AboutBoxProps> = ({
         <Text color={Colors.Foreground}>{modelVersion}</Text>
       </Box>
     </Box>
+    <Box flexDirection="row">
+      <Box width="35%">
+        <Text bold color={Colors.LightBlue}>
+          Provider
+        </Text>
+      </Box>
+      <Box>
+        <Text color={Colors.Foreground}>{provider}</Text>
+      </Box>
+    </Box>
+    {baseURL && (
+      <Box flexDirection="row">
+        <Box width="35%">
+          <Text bold color={Colors.LightBlue}>
+            Base URL
+          </Text>
+        </Box>
+        <Box>
+          <Text color={Colors.Foreground}>{baseURL}</Text>
+        </Box>
+      </Box>
+    )}
     <Box flexDirection="row">
       <Box width="35%">
         <Text bold color={Colors.LightBlue}>

--- a/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
@@ -77,6 +77,8 @@ describe('<HistoryItemDisplay />', () => {
       keyfile: 'test-keyfile',
       key: 'test-key',
       ideClient: 'test-ide',
+      provider: 'test-provider',
+      baseURL: 'test-url',
     };
     const { lastFrame } = render(
       <HistoryItemDisplay {...baseItem} item={item} />,

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -77,6 +77,10 @@ export const HistoryItemDisplay: React.FC<HistoryItemDisplayProps> = ({
         selectedAuthType={item.selectedAuthType}
         gcpProject={item.gcpProject}
         ideClient={item.ideClient}
+        provider={item.provider}
+        baseURL={item.baseURL}
+        keyfile={item.keyfile}
+        key={item.key}
       />
     )}
     {item.type === 'help' && <Help commands={slashCommands} />}

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -127,6 +127,8 @@ export const useSlashCommandProcessor = (
           keyfile: message.keyfile,
           key: message.key,
           ideClient: message.ideClient,
+          provider: message.provider,
+          baseURL: message.baseURL,
         };
       } else if (message.type === MessageType.HELP) {
         historyItemContent = {

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -114,6 +114,8 @@ export type HistoryItemAbout = HistoryItemBase & {
    */
   key: string;
   ideClient: string;
+  provider: string;
+  baseURL: string;
 };
 
 export type HistoryItemHelp = HistoryItemBase & {
@@ -211,6 +213,8 @@ export type Message =
       keyfile: string;
       key: string;
       ideClient: string;
+      provider: string;
+      baseURL: string;
       content?: string; // Optional content, not really used for ABOUT
     }
   | {


### PR DESCRIPTION
This PR adds the provider name and base URL to the /about command output, addressing #396.

The changes include:
- Added provider and baseURL fields to AboutBox component
- Updated aboutCommand to fetch provider info from the active provider
- Fixed theme compliance for the base URL display
- Updated all related types and test files

Closes #396