### PR TITLE
Fix integration runtime bootstrap

### DIFF
--- a/packages/core/src/test-utils/runtime.ts
+++ b/packages/core/src/test-utils/runtime.ts
@@ -161,6 +161,43 @@ export function createRuntimeConfigStub(
   return Object.assign(base, overrides) as unknown as Config;
 }
 
+interface TestRuntimeInitOptions {
+  runtimeId?: string;
+  metadata?: Record<string, unknown>;
+  configOverrides?: Partial<Record<string, unknown>>;
+}
+
+/**
+ * Initializes a lightweight provider runtime context for test environments.
+ * Returns the created settings service, config stub, and runtime context.
+ */
+export function initializeTestProviderRuntime(
+  options: TestRuntimeInitOptions = {},
+): {
+  settingsService: SettingsService;
+  config: Config;
+  runtime: ProviderRuntimeContext;
+} {
+  const settingsService = new SettingsService();
+  const config = createRuntimeConfigStub(settingsService, {
+    ...(options.configOverrides ?? {}),
+  });
+  const runtime = createProviderRuntimeContext({
+    settingsService,
+    config,
+    runtimeId:
+      options.runtimeId ??
+      `test.provider.runtime.${Math.random().toString(36).slice(2, 10)}`,
+    metadata: {
+      source: 'test-utils#initializeTestProviderRuntime',
+      ...(options.metadata ?? {}),
+    },
+  });
+
+  setActiveProviderRuntimeContext(runtime);
+  return { settingsService, config, runtime };
+}
+
 function requireVi() {
   const viGlobal = (globalThis as { vi?: (typeof import('vitest'))['vi'] }).vi;
   if (viGlobal) {

--- a/packages/core/test-setup.ts
+++ b/packages/core/test-setup.ts
@@ -10,26 +10,27 @@ if (process.env.NO_COLOR !== undefined) {
 }
 
 import { setSimulate429 } from './src/utils/testUtils.js';
-import { beforeEach, afterEach } from 'vitest';
-import {
-  createProviderRuntimeContext,
-  setActiveProviderRuntimeContext,
-  clearActiveProviderRuntimeContext,
-} from './src/runtime/providerRuntimeContext.js';
-import { SettingsService } from './src/settings/SettingsService.js';
+import { beforeAll, beforeEach, afterEach } from 'vitest';
+import { clearActiveProviderRuntimeContext } from './src/runtime/providerRuntimeContext.js';
+import { initializeTestProviderRuntime } from './src/test-utils/runtime.js';
 
 // Disable 429 simulation globally for all tests
 setSimulate429(false);
 
+function bootstrapRuntime(scope: string): void {
+  initializeTestProviderRuntime({
+    runtimeId: `test-global-runtime.${scope}`,
+    metadata: { source: `test-setup.ts:${scope}` },
+  });
+}
+
+beforeAll(() => {
+  bootstrapRuntime('beforeAll');
+});
+
 // Set up a runtime context for all tests to prevent MissingProviderRuntimeError
 beforeEach(() => {
-  const settingsService = new SettingsService();
-  const runtime = createProviderRuntimeContext({
-    settingsService,
-    runtimeId: 'test-global-runtime',
-    metadata: { source: 'test-setup.ts' },
-  });
-  setActiveProviderRuntimeContext(runtime);
+  bootstrapRuntime('beforeEach');
 });
 
 afterEach(() => {


### PR DESCRIPTION
Ensure integration suites initialize provider runtimes before accessing settings to keep merged main green.