### PR TITLE
Fix CodeQL regex warnings

### DIFF
--- a/packages/core/src/services/complexity-analyzer.test.ts
+++ b/packages/core/src/services/complexity-analyzer.test.ts
@@ -91,4 +91,34 @@ describe('ComplexityAnalyzer', () => {
     // With new threshold of 0.6, 0.5 is below threshold so not complex
     expect(result.isComplex).toBe(false);
   });
+
+  it('normalizes excessive whitespace in bullet list tasks', () => {
+    const analyzer = new ComplexityAnalyzer();
+
+    const message = `
+-   deploy    the    pipeline
+*   verify     the     QA     checklist
+`;
+
+    const result = analyzer.analyzeComplexity(message);
+
+    expect(result.detectedTasks).toEqual([
+      'deploy the pipeline',
+      'verify the QA checklist',
+    ]);
+  });
+
+  it('normalizes excessive whitespace in natural language tasks', () => {
+    const analyzer = new ComplexityAnalyzer();
+
+    const message =
+      'I must   coordinate     the   release, and   document    the   decisions.';
+
+    const result = analyzer.analyzeComplexity(message);
+
+    expect(result.detectedTasks).toEqual([
+      'coordinate the release',
+      'document the decisions',
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- dismissed alerts #60 and #61 as false positives because dangerous keys are already rejected before nested assignments
- tighten complexity analyzer regexes to avoid polynomial-time backtracking on user-controlled input
- normalize extracted task strings to collapse repeated whitespace and cover behavior with new tests

## Testing
- npm run format:check
- npm run lint
- npm run typecheck
- npm run test
- npm run build
- node scripts/start.js --profile-load synthetic --prompt "just say hi"