### PR TITLE
Fix CodeQL regex warning in complexity analyzer

### DIFF
--- a/packages/core/src/services/complexity-analyzer.test.ts
+++ b/packages/core/src/services/complexity-analyzer.test.ts
@@ -91,4 +91,34 @@ describe('ComplexityAnalyzer', () => {
     // With new threshold of 0.6, 0.5 is below threshold so not complex
     expect(result.isComplex).toBe(false);
   });
+
+  it('normalizes excessive whitespace in bullet list tasks', () => {
+    const analyzer = new ComplexityAnalyzer();
+
+    const message = `
+-   deploy    the    pipeline
+*   verify     the     QA     checklist
+`;
+
+    const result = analyzer.analyzeComplexity(message);
+
+    expect(result.detectedTasks).toEqual([
+      'deploy the pipeline',
+      'verify the QA checklist',
+    ]);
+  });
+
+  it('normalizes excessive whitespace in natural language tasks', () => {
+    const analyzer = new ComplexityAnalyzer();
+
+    const message =
+      'I must   coordinate     the   release, and   document    the   decisions.';
+
+    const result = analyzer.analyzeComplexity(message);
+
+    expect(result.detectedTasks).toEqual([
+      'coordinate the release',
+      'document the decisions',
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- narrow regex captures for list bullet patterns to avoid unbounded backtracking and reduce attack surface
- normalize extracted task strings across list, sentence, and separator flows to collapse repeated whitespace
- add regression tests covering whitespace normalization so the behavior stays stable

## Testing
- npm run test:ci
- npm run test
- npm run format:check
- npm run lint
- npm run typecheck
- npm run build
- node scripts/start.js --profile-load synthetic --prompt "write me a haiku"