### PR TITLE
Fix: E2E fail in simple-mcp-server.test.ts

### DIFF
--- a/integration-tests/simple-mcp-server.test.ts
+++ b/integration-tests/simple-mcp-server.test.ts
@@ -205,7 +205,9 @@ rpc.send({
       'You MUST use the "add" tool to add 5 and 10. Do NOT calculate it yourself - use the add tool.',
     );
 
-    const foundToolCall = await rig.waitForToolCall('add');
+    const foundToolCall = await rig.waitForToolCall(
+      'mcp__addition-server__add',
+    );
 
     expect(foundToolCall, 'Expected to find an add tool call').toBeTruthy();
 


### PR DESCRIPTION
## TLDR

 - Changed waitForToolCall to expect 'mcp__addition-server__add' instead of just 'add'
 - This aligns with the expected tool naming convention that includes the server identifier
 - Fix ensures the test properly waits for the fully qualified tool name used in MCP protocol 

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
