### PR TITLE
Fix provider switching ephemerals (#453)

### DIFF
--- a/packages/cli/src/integration-tests/provider-switching.integration.test.ts
+++ b/packages/cli/src/integration-tests/provider-switching.integration.test.ts
@@ -170,6 +170,33 @@ describe('Runtime Provider Switching Integration', () => {
     expect(result.changed).toBe(false);
     expect(providerA.clearState).not.toHaveBeenCalled();
   });
+
+  it('clears legacy base URL and resets model when switching back to provider', async () => {
+    const providerA = createMockProvider('providerA');
+    providerA.getDefaultModel = vi.fn(() => 'providerA-default');
+    const providerB = createMockProvider('providerB');
+
+    providerManager.registerProvider(providerA);
+    providerManager.registerProvider(providerB);
+
+    providerManager.setActiveProvider('providerA');
+    settingsService.setProviderSetting(
+      'providerA',
+      'baseUrl',
+      'https://legacy.example/v1',
+    );
+    settingsService.setProviderSetting('providerA', 'model', 'legacy-model');
+    config.setEphemeralSetting('base-url', 'https://legacy.example/v1');
+    config.setModel('legacy-model');
+
+    await switchActiveProvider('providerB');
+    await switchActiveProvider('providerA');
+
+    const refreshedSettings = settingsService.getProviderSettings('providerA');
+    expect(refreshedSettings.baseUrl).toBeUndefined();
+    expect(refreshedSettings.model).toBe('providerA-default');
+    expect(config.getModel()).toBe('providerA-default');
+  });
 });
 
 function createMockProvider(name: string): IProvider & {

--- a/packages/cli/src/runtime/__tests__/runtimeIsolation.test.ts
+++ b/packages/cli/src/runtime/__tests__/runtimeIsolation.test.ts
@@ -131,9 +131,6 @@ describe('CLI runtime isolation', () => {
       runWithRuntime(runtimeA, barrier, async () => {
         await switchActiveProvider(runtimeA.secondaryProvider);
         await setActiveModel('alpha-secondary-tuned');
-        setEphemeralSetting('custom-headers', {
-          'x-runtime': runtimeA.id,
-        });
         setActiveModelParam('temperature', 0.2);
         const profile: Profile = {
           version: 1,
@@ -154,6 +151,10 @@ describe('CLI runtime isolation', () => {
           'auth-keyfile',
           `${runtimeA.tempDir}/alpha-keyfile`,
         );
+        // Set custom-headers AFTER profile load to ensure it persists
+        setEphemeralSetting('custom-headers', {
+          'x-runtime': runtimeA.id,
+        });
       }),
       runWithRuntime(
         runtimeB,
@@ -161,9 +162,6 @@ describe('CLI runtime isolation', () => {
         async () => {
           await switchActiveProvider(runtimeB.secondaryProvider);
           await setActiveModel('beta-secondary-tuned');
-          setEphemeralSetting('custom-headers', {
-            'x-runtime': runtimeB.id,
-          });
           setActiveModelParam('temperature', 0.9);
           const profile: Profile = {
             version: 1,
@@ -186,6 +184,10 @@ describe('CLI runtime isolation', () => {
             'auth-keyfile',
             `${runtimeB.tempDir}/beta-keyfile`,
           );
+          // Set custom-headers AFTER profile load to ensure it persists
+          setEphemeralSetting('custom-headers', {
+            'x-runtime': runtimeB.id,
+          });
         },
         { delayBeforeActivationMs: 5 },
       ),

--- a/packages/cli/src/runtime/profileApplication.ts
+++ b/packages/cli/src/runtime/profileApplication.ts
@@ -258,18 +258,9 @@ export async function applyProfileWithGuards(
     setEphemeralSetting(key, value);
   }
 
-  const profileEphemeralKeys = new Set(
-    appliedEphemeralEntries.map(([key]) => key),
-  );
-
-  for (const [key, value] of previousEphemeralEntries.entries()) {
-    if (key === 'activeProvider') {
-      continue;
-    }
-    if (!profileEphemeralKeys.has(key)) {
-      setEphemeralSetting(key, value);
-    }
-  }
+  // Issue #453: Do NOT restore old ephemeral settings that were not in the profile
+  // Ephemeral settings should only contain what's explicitly set in the loaded profile
+  // This prevents credentials and settings from leaking between profiles/providers
 
   modelResult = await setActiveModel(requestedModel || fallbackModel);
 

--- a/packages/cli/src/ui/commands/providerCommand.ts
+++ b/packages/cli/src/ui/commands/providerCommand.ts
@@ -16,32 +16,12 @@ import {
   refreshAliasProviders,
 } from '../../providers/providerManagerInstance.js';
 import { MessageType } from '../types.js';
-import { AuthType } from '@vybestack/llxprt-code-core';
-import type { SettingsService } from '@vybestack/llxprt-code-core/src/settings/SettingsService.js';
 import {
   writeProviderAliasConfig,
   type ProviderAliasConfig,
 } from '../../providers/providerAliases.js';
 import type { IProvider } from '@vybestack/llxprt-code-core/providers/IProvider.js';
-
-/**
- * Get SettingsService instance for provider switching
- */
-async function getSettingsServiceForProvider(): Promise<SettingsService> {
-  try {
-    const { getSettingsService } = await import('@vybestack/llxprt-code-core');
-
-    return getSettingsService();
-  } catch (error) {
-    if (process.env.DEBUG) {
-      console.warn(
-        'Failed to get SettingsService for provider switching:',
-        error,
-      );
-    }
-    throw error;
-  }
-}
+import { getRuntimeApi } from '../contexts/RuntimeContext.js';
 
 function unwrapProvider(provider: IProvider): IProvider {
   if (
@@ -221,9 +201,18 @@ export const providerCommand: SlashCommand = {
     const providerName = trimmedArgs;
 
     try {
-      const currentProvider = providerManager.getActiveProviderName();
+      const runtime = getRuntimeApi();
+      let currentProvider: string | null = null;
+      try {
+        currentProvider = runtime.getActiveProviderName();
+      } catch (_error) {
+        try {
+          currentProvider = providerManager.getActiveProviderName();
+        } catch {
+          currentProvider = null;
+        }
+      }
 
-      // Handle switching to same provider
       if (providerName === currentProvider) {
         return {
           type: 'message',
@@ -234,163 +223,29 @@ export const providerCommand: SlashCommand = {
 
       const fromProvider = currentProvider || 'none';
 
-      // Use conversion context to track available models
-      // const conversionContextJSON = {
-      //   availableModels: await providerManager.getAllAvailableModels(),
-      // };
-
-      // Clear auth and base-url ephemeral settings BEFORE switching providers
-      // This prevents cached auth from the old provider affecting the new provider
-      const config = context.services.config;
-      if (config) {
-        // Clear auth settings to ensure clean auth state
-        config.setEphemeralSetting('auth-key', undefined);
-        config.setEphemeralSetting('auth-keyfile', undefined);
-        config.setEphemeralSetting('base-url', undefined);
-      }
-
-      // Get the target provider to clear its caches before activating it
-      // This is important for providers like qwen that might have stale auth
-      // Access the providers Map directly since there's no getAllProviders method
-      const providersMap = (
-        providerManager as unknown as { providers?: Map<string, unknown> }
-      ).providers;
-      if (providersMap && providersMap instanceof Map) {
-        const targetProvider = providersMap.get(providerName) as
-          | { clearState?: () => void }
-          | undefined;
-        if (targetProvider && targetProvider.clearState) {
-          targetProvider.clearState();
-        }
-      }
-
-      // Switch provider (this will clear state from previous provider via ProviderManager)
-      providerManager.setActiveProvider(providerName);
-
-      // Also clear base URL on the new provider if it has the method
-      const newProvider = providerManager.getActiveProvider();
-      if (
-        newProvider &&
-        'setBaseUrl' in newProvider &&
-        typeof (
-          newProvider as { setBaseUrl?: (url: string | undefined) => void }
-        ).setBaseUrl === 'function'
-      ) {
-        (
-          newProvider as { setBaseUrl: (url: string | undefined) => void }
-        ).setBaseUrl(undefined);
-      }
-
-      // Use SettingsService for provider switching
+      let switchResult;
       try {
-        const settingsService = await getSettingsServiceForProvider();
-        await settingsService.switchProvider(providerName);
-
-        // Also set the default model for this provider
-        const activeProvider = providerManager.getActiveProvider();
-        const defaultModel = activeProvider.getDefaultModel();
-        settingsService.setProviderSetting(providerName, 'model', defaultModel);
-
-        // Don't return early - continue with the rest of the setup
+        switchResult = await runtime.switchActiveProvider(providerName);
       } catch (error) {
-        if (process.env.DEBUG) {
-          console.warn(
-            'SettingsService provider switch failed, falling back to legacy method:',
-            error,
-          );
-        }
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          type: 'message',
+          messageType: 'error',
+          content: `Failed to switch provider: ${message}`,
+        };
       }
 
-      // Update config if available
-      if (context.services.config) {
-        // Clear ephemeral settings when switching providers
-        // Get current ephemeral settings and clear them one by one
-        const ephemeralKeys = [
-          'auth-key',
-          'auth-keyfile',
-          'base-url',
-          'context-limit',
-          'compression-threshold',
-          'tool-format',
-          'api-version',
-          'custom-headers',
-        ];
-        for (const key of ephemeralKeys) {
-          context.services.config.setEphemeralSetting(key, undefined);
+      for (const info of switchResult.infoMessages ?? []) {
+        if (!info) {
+          continue;
         }
-
-        // Ensure provider manager is set on config
-        context.services.config.setProviderManager(providerManager);
-
-        // Update the provider in config
-        context.services.config.setProvider(providerName);
-
-        // Get the active provider and ensure it uses a valid default model
-        const activeProvider = providerManager.getActiveProvider();
-
-        // Get the default model from the provider
-        const defaultModel = activeProvider.getDefaultModel();
-        let baseUrl: string | undefined;
-
-        // Set base URL for specific providers
-        if (providerName === 'qwen') {
-          baseUrl = 'https://portal.qwen.ai/v1';
-        }
-
-        // Set the base URL if needed (for qwen)
-        if (baseUrl) {
-          context.services.config.setEphemeralSetting('base-url', baseUrl);
-          // Also set it directly on the provider if it has the method
-          if (
-            'setBaseUrl' in activeProvider &&
-            typeof activeProvider.setBaseUrl === 'function'
-          ) {
-            const providerWithSetBaseUrl = activeProvider as {
-              setBaseUrl: (url: string) => void;
-            };
-            providerWithSetBaseUrl.setBaseUrl(baseUrl);
-          }
-        }
-
-        // Set the model on both the provider and config
-        if (defaultModel) {
-          if (
-            'setModel' in activeProvider &&
-            typeof (activeProvider as { setModel?: (model: string) => void })
-              .setModel === 'function'
-          ) {
-            (activeProvider as { setModel: (model: string) => void }).setModel(
-              defaultModel,
-            );
-          }
-          context.services.config.setModel(defaultModel);
-        }
-
-        // With HistoryService and ContentConverters, we can now keep conversation history
-        // when switching providers as the conversion handles format differences
-
-        // Keep the current auth type - auth only affects GeminiProvider internally
-        const currentAuthType =
-          context.services.config.getContentGeneratorConfig()?.authType ||
-          AuthType.LOGIN_WITH_GOOGLE;
-
-        // Refresh auth to ensure provider manager is attached
-        await context.services.config.refreshAuth(currentAuthType);
-
-        // Show info about API key if needed for non-Gemini providers
-        if (providerName !== 'gemini') {
-          context.ui.addItem(
-            {
-              type: MessageType.INFO,
-              text: `Switched to ${providerName}. Use /key to set API key if needed.`,
-            },
-            Date.now(),
-          );
-        }
-
-        // Note: We no longer clear UI history when switching providers
-        // The whole point of provider switching is to maintain conversation context
-        // Tool call ID conversion is handled by the content converters
+        context.ui.addItem(
+          {
+            type: MessageType.INFO,
+            text: info,
+          },
+          Date.now(),
+        );
       }
 
       // Trigger payment mode check if available
@@ -407,7 +262,7 @@ export const providerCommand: SlashCommand = {
       return {
         type: 'message',
         messageType: 'info',
-        content: `Switched from ${fromProvider} to ${providerName}`,
+        content: `Switched from ${fromProvider} to ${switchResult.nextProvider}`,
       };
     } catch (error) {
       return {


### PR DESCRIPTION
## Summary
- clear every provider-specific setting and config ephemeral when switching providers
- ensure qwen base URL is stored in both baseUrl and baseURL so runtime normalization succeeds
- update provider command/tests to rely on runtime helpers and add regression coverage

## Testing
- npm run format:check
- npm run lint
- npm run typecheck
- npm run test
- npm run build
- node scripts/start.js --profile-load synthetic --prompt "just say hi"
- node scripts/start.js --provider qwen --model qwen3-coder-plus --prompt "say hi"
- node scripts/start.js --profile-load zai --prompt "what's up"