### PR TITLE
Preserve overrides when switching providers (#458)

### DIFF
--- a/packages/cli/src/integration-tests/provider-switching.integration.test.ts
+++ b/packages/cli/src/integration-tests/provider-switching.integration.test.ts
@@ -185,6 +185,11 @@ describe('Runtime Provider Switching Integration', () => {
       'baseUrl',
       'https://legacy.example/v1',
     );
+    settingsService.setProviderSetting(
+      'providerA',
+      'baseURL',
+      'https://legacy.example/v1',
+    );
     settingsService.setProviderSetting('providerA', 'model', 'legacy-model');
     config.setEphemeralSetting('base-url', 'https://legacy.example/v1');
     config.setModel('legacy-model');
@@ -194,8 +199,10 @@ describe('Runtime Provider Switching Integration', () => {
 
     const refreshedSettings = settingsService.getProviderSettings('providerA');
     expect(refreshedSettings.baseUrl).toBeUndefined();
+    expect(refreshedSettings.baseURL).toBeUndefined();
     expect(refreshedSettings.model).toBe('providerA-default');
     expect(config.getModel()).toBe('providerA-default');
+    expect(config.getEphemeralSetting('base-url')).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary
- snapshot existing model/base URL overrides before clearing provider settings
- reuse CLI/profile base URL & model when rehydrating the target provider
- mirror both baseUrl/baseURL and expand integration/unit coverage for switchActiveProvider

## Testing
- npm run format:check
- npm run lint
- npm run typecheck
- npm run test
- npm run build
- node scripts/start.js --provider openai --baseurl "https://api.synthetic.new/openai/v1" --model "hf:zai-org/GLM-4.6" --key "syn_61c714e509ef00d99ca88f2f587e05b6" --prompt "hello"
- node packages/cli/dist/index.js --provider openai --baseurl "https://api.synthetic.new/openai/v1" --model "hf:zai-org/GLM-4.6" --key "syn_61c714e509ef00d99ca88f2f587e05b6" --prompt "hello"
- node packages/cli/dist/index.js --profile-load synthetic --key "syn_61c714e509ef00d99ca88f2f587e05b6" --prompt "say hi"