### PR TITLE
fix: Update subagent tool name to self_emitvalue for CLI tool generation (#482)

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -75,7 +75,7 @@ export const READ_ONLY_TOOL_NAMES = [
   'web_fetch',
   'todo_read',
   'task',
-  'self.emitvalue',
+  'self_emitvalue',
 ] as const;
 
 const EDIT_TOOL_NAME = 'replace';

--- a/packages/core/src/core/subagent.test.ts
+++ b/packages/core/src/core/subagent.test.ts
@@ -967,7 +967,7 @@ describe('subagent.ts', () => {
           'you MUST emit the required output variables',
         );
         expect(systemInstruction).toContain(
-          "Use 'self.emitvalue' to emit the 'result1' key",
+          "Use 'self_emitvalue' to emit the 'result1' key",
         );
       });
 
@@ -1151,7 +1151,7 @@ describe('subagent.ts', () => {
         expect(scope.output.terminate_reason).toBe(SubagentTerminateMode.GOAL);
       });
 
-      it('should handle self.emitvalue and terminate with GOAL when outputs are met', async () => {
+      it('should handle self_emitvalue and terminate with GOAL when outputs are met', async () => {
         const { config } = await createMockConfig();
         const outputConfig: OutputConfig = {
           outputs: { result: 'The final result' },
@@ -1163,7 +1163,7 @@ describe('subagent.ts', () => {
           createMockStream([
             [
               {
-                name: 'self.emitvalue',
+                name: 'self_emitvalue',
                 args: {
                   emit_variable_name: 'result',
                   emit_variable_value: 'Success!',
@@ -1482,7 +1482,7 @@ describe('subagent.ts', () => {
             'stop',
             [
               {
-                name: 'self.emitvalue',
+                name: 'self_emitvalue',
                 args: {
                   emit_variable_name: 'required_var',
                   emit_variable_value: 'Here it is',
@@ -1536,20 +1536,20 @@ describe('subagent.ts', () => {
           createMockStream([
             [
               {
-                name: 'self.emitvalue',
+                name: 'self_emitvalue',
                 args: { emit_variable_name: 'loop', emit_variable_value: 'v1' },
               },
             ],
             [
               {
-                name: 'self.emitvalue',
+                name: 'self_emitvalue',
                 args: { emit_variable_name: 'loop', emit_variable_value: 'v2' },
               },
             ],
             // This turn should not happen
             [
               {
-                name: 'self.emitvalue',
+                name: 'self_emitvalue',
                 args: { emit_variable_name: 'loop', emit_variable_value: 'v3' },
               },
             ],

--- a/packages/core/src/core/subagent.ts
+++ b/packages/core/src/core/subagent.ts
@@ -701,7 +701,7 @@ export class SubAgentScope {
           const schedulerRequests: ToolCallRequestInfo[] = [];
 
           for (const request of toolRequests) {
-            if (request.name === 'self.emitvalue') {
+            if (request.name === 'self_emitvalue') {
               manualParts.push(...this.handleEmitValueCall(request));
             } else {
               schedulerRequests.push(request);
@@ -795,7 +795,7 @@ export class SubAgentScope {
 
         const nudgeMessage = `You have stopped calling tools but have not emitted the following required variables: ${remainingVars.join(
           ', ',
-        )}. Please use the 'self.emitvalue' tool to emit them now, or continue working if necessary.`;
+        )}. Please use the 'self_emitvalue' tool to emit them now, or continue working if necessary.`;
 
         this.logger.debug(
           () =>
@@ -1057,7 +1057,7 @@ export class SubAgentScope {
 
           const nudgeMessage = `You have stopped calling tools but have not emitted the following required variables: ${remainingVars.join(
             ', ',
-          )}. Please use the 'self.emitvalue' tool to emit them now, or continue working if necessary.`;
+          )}. Please use the 'self_emitvalue' tool to emit them now, or continue working if necessary.`;
 
           this.logger.debug(
             () =>
@@ -1107,7 +1107,7 @@ export class SubAgentScope {
   /**
    * Processes a list of function calls, executing each one and collecting their responses.
    * This method iterates through the provided function calls, executes them using the
-   * `executeToolCall` function (or handles `self.emitvalue` internally), and aggregates
+   * `executeToolCall` function (or handles `self_emitvalue` internally), and aggregates
    * their results. It also manages error reporting for failed tool executions.
    * @param {FunctionCall[]} functionCalls - An array of `FunctionCall` objects to process.
    * @param {ToolRegistry} toolRegistry - The tool registry to look up and execute tools.
@@ -1141,7 +1141,7 @@ export class SubAgentScope {
       let toolResponse;
 
       // Handle scope-local tools first.
-      if (functionCall.name === 'self.emitvalue') {
+      if (functionCall.name === 'self_emitvalue') {
         const valName = String(requestInfo.args['emit_variable_name']);
         const valVal = String(requestInfo.args['emit_variable_value']);
         this.output.emitted_vars[valName] = valVal;
@@ -1388,7 +1388,7 @@ export class SubAgentScope {
     }
 
     const errorMessage =
-      'self.emitvalue requires emit_variable_name and emit_variable_value arguments.';
+      'self_emitvalue requires emit_variable_name and emit_variable_value arguments.';
     this.logger.warn(
       () => `Subagent ${this.subagentId} failed to emit value: ${errorMessage}`,
     );
@@ -1658,12 +1658,12 @@ export class SubAgentScope {
 
   /**
    * Returns an array of FunctionDeclaration objects for tools that are local to the subagent's scope.
-   * Currently, this includes the `self.emitvalue` tool for emitting variables.
+   * Currently, this includes the `self_emitvalue` tool for emitting variables.
    * @returns An array of `FunctionDeclaration` objects.
    */
   private getScopeLocalFuncDefs() {
     const emitValueTool: FunctionDeclaration = {
-      name: 'self.emitvalue',
+      name: 'self_emitvalue',
       description: `* This tool emits A SINGLE return value from this execution, such that it can be collected and presented to the calling function.
         * You can only emit ONE VALUE each time you call this tool. You are expected to call this tool MULTIPLE TIMES if you have MULTIPLE OUTPUTS.`,
       parameters: {
@@ -1746,10 +1746,10 @@ export class SubAgentScope {
     // Add instructions for emitting variables if needed.
     if (this.outputConfig && this.outputConfig.outputs) {
       let outputInstructions =
-        '\n\nAfter you have achieved all other goals, you MUST emit the required output variables. For each expected output, make one final call to the `self.emitvalue` tool.';
+        '\n\nAfter you have achieved all other goals, you MUST emit the required output variables. For each expected output, make one final call to the `self_emitvalue` tool.';
 
       for (const [key, value] of Object.entries(this.outputConfig.outputs)) {
-        outputInstructions += `\n* Use 'self.emitvalue' to emit the '${key}' key, with a value described as: '${value}'`;
+        outputInstructions += `\n* Use 'self_emitvalue' to emit the '${key}' key, with a value described as: '${value}'`;
       }
       finalPrompt += outputInstructions;
     }


### PR DESCRIPTION
## Description
Fix inconsistent naming between the FunctionDeclaration name 'self.emitvalue' and the SubAgentScope tool registry name 'self_emitvalue'. This was causing CLI tool generation to fail with 'No such tool' errors when updating the tool registry.

## Problem
In interactive CLI mode, users could launch subagents but encountered "No such tool" errors when the system tried to update the tool registry. This happened because:

- The `FunctionDeclaration` used the name `'self.emitvalue'`
- The `SubAgentScope` tool registry used the name `'self_emitvalue'`
- `self.emitvalue` was also in READ_ONLY_TOOL_NAMES list

## Solution
Standardized the naming to use underscores consistently:

- FunctionDeclaration name: `'self.emitvalue'` → `'self_emitvalue'`
- Updated all references in config, tests, and documentation
- Maintains compatibility for existing subagent functionality

## Changes
- **packages/cli/src/config/config.ts**: Updated READ_ONLY_TOOL_NAMES list
- **packages/core/src/core/subagent.ts**: Fixed FunctionDeclaration names and error messages
- **packages/core/src/core/subagent.test.ts**: Updated test cases and assertions

## Testing
- All existing tests pass with updated names
- Verified subagent functionality works correctly
- Pre-commit checks (lint, typecheck, format) pass

Fixes #482