### PR TITLE
Fix Polaris tool replay (#501)

### DIFF
--- a/packages/core/src/providers/openai/OpenAIProvider.convertToOpenAIMessages.test.ts
+++ b/packages/core/src/providers/openai/OpenAIProvider.convertToOpenAIMessages.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+import { OpenAIProvider } from './OpenAIProvider.js';
+import type { IContent } from '../../services/history/IContent.js';
+
+function callConvert(
+  provider: OpenAIProvider,
+  contents: IContent[],
+  mode: 'native' | 'textual' = 'native',
+) {
+  return (
+    (
+      provider as unknown as {
+        convertToOpenAIMessages(
+          c: IContent[],
+          m?: 'native' | 'textual',
+        ): ReturnType<OpenAIProvider['convertToOpenAIMessages']>;
+      }
+    ).convertToOpenAIMessages(contents, mode) ?? []
+  );
+}
+
+describe('OpenAIProvider.convertToOpenAIMessages', () => {
+  const provider = new OpenAIProvider('test-key');
+
+  it('normalizes tool-call arguments that are undefined or non-JSON strings', () => {
+    const contents: IContent[] = [
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'hist_tool_123',
+            name: 'lookup',
+            parameters: undefined,
+          },
+        ],
+      },
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'hist_tool_456',
+            name: 'lookup',
+            parameters: '{"city":"sf"}',
+          },
+        ],
+      },
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call',
+            id: 'hist_tool_789',
+            name: 'lookup',
+            parameters: '--raw-text--',
+          },
+        ],
+      },
+    ];
+
+    const messages = callConvert(provider, contents);
+    const assistantMessages = messages.filter(
+      (m): m is Extract<typeof m, { role: 'assistant' }> =>
+        'role' in m && m.role === 'assistant',
+    );
+    const [first, second, third] = assistantMessages;
+
+    expect(first?.tool_calls?.[0]?.function.arguments).toBe('{}');
+    expect(second?.tool_calls?.[0]?.function.arguments).toBe('{"city":"sf"}');
+    expect(
+      JSON.parse(third?.tool_calls?.[0]?.function.arguments || '{}').raw,
+    ).toBe('--raw-text--');
+  });
+
+  it('builds structured tool responses with error info and truncation', () => {
+    const hugeResult = 'a'.repeat(6000);
+    const contents: IContent[] = [
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'hist_tool_abc',
+            toolName: 'read_file',
+            result: hugeResult,
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'hist_tool_err',
+            toolName: 'write_file',
+            result: undefined,
+            error: 'validation failed',
+          },
+        ],
+      },
+    ];
+
+    const messages = callConvert(provider, contents);
+    const toolMessages = messages.filter(
+      (m): m is Extract<typeof m, { role: 'tool' }> =>
+        'role' in m && m.role === 'tool',
+    );
+
+    expect(toolMessages).toHaveLength(2);
+
+    const successPayload = JSON.parse(toolMessages[0]?.content as string);
+    expect(toolMessages[0]?.tool_call_id).toBe('call_abc');
+    expect(successPayload.status).toBe('success');
+    expect(successPayload.toolName).toBe('read_file');
+    expect(successPayload.result).toContain('[truncated');
+
+    const errorPayload = JSON.parse(toolMessages[1]?.content as string);
+    expect(toolMessages[1]?.tool_call_id).toBe('call_err');
+    expect(errorPayload.status).toBe('error');
+    expect(errorPayload.error).toBe('validation failed');
+    expect(errorPayload.result).toBe('[no tool result]');
+  });
+
+  it('replays tool transcripts as text when textual mode is requested', () => {
+    const contents: IContent[] = [
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'please inspect file' }],
+      },
+      {
+        speaker: 'ai',
+        blocks: [
+          { type: 'text', text: 'Checking file contents' },
+          {
+            type: 'tool_call',
+            id: 'hist_tool_001',
+            name: 'read_file',
+            parameters: { path: '/tmp/file.txt' },
+          },
+        ],
+      },
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'hist_tool_001',
+            toolName: 'read_file',
+            result: 'line1\nline2',
+          },
+        ],
+      },
+    ];
+
+    const messages = callConvert(provider, contents, 'textual');
+    expect(messages).toHaveLength(3);
+    expect(messages[0]).toMatchObject({
+      role: 'user',
+      content: 'please inspect file',
+    });
+    expect(messages[1]?.role).toBe('assistant');
+    expect(messages[1]?.content).toContain('[TOOL CALL');
+    expect(messages[1]?.content).toContain('Checking file contents');
+    expect(messages[2]?.role).toBe('user');
+    expect(messages[2]?.content).toContain('[TOOL RESULT]');
+    expect(messages[2]?.content).toContain('line1');
+  });
+});

--- a/packages/core/src/providers/openai/OpenAIProvider.ts
+++ b/packages/core/src/providers/openai/OpenAIProvider.ts
@@ -20,6 +20,7 @@
  */
 
 import OpenAI from 'openai';
+import crypto from 'node:crypto';
 import * as http from 'http';
 import * as https from 'https';
 import * as net from 'net';
@@ -46,6 +47,18 @@ import { retryWithBackoff } from '../../utils/retry.js';
 import { resolveUserMemory } from '../utils/userMemory.js';
 import { resolveRuntimeAuthToken } from '../utils/authToken.js';
 import { filterOpenAIRequestParams } from './openaiRequestParams.js';
+import {
+  ensureJsonSafe,
+  hasUnicodeReplacements,
+} from '../../utils/unicodeUtils.js';
+
+const MAX_TOOL_RESPONSE_CHARS = 1024;
+const MAX_TOOL_RESPONSE_RETRY_CHARS = 512;
+const MAX_TOOL_RESPONSE_TEXT_CHARS = 512;
+const TOOL_ARGS_PREVIEW_LENGTH = 500;
+const EMPTY_TOOL_RESULT_PLACEHOLDER = '[no tool result]';
+type ToolReplayMode = 'native' | 'textual';
+const TEXTUAL_TOOL_REPLAY_MODELS = new Set(['openrouter/polaris-alpha']);
 
 export class OpenAIProvider extends BaseProvider implements IProvider {
   override readonly name: string = 'openai';
@@ -504,25 +517,28 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
    * Handles IDs from OpenAI (call_xxx), Anthropic (toolu_xxx), and history (hist_tool_xxx)
    */
   private normalizeToOpenAIToolId(id: string): string {
+    const sanitize = (value: string) =>
+      value.replace(/[^a-zA-Z0-9_]/g, '') ||
+      'call_' + crypto.randomUUID().replace(/-/g, '');
     // If already in OpenAI format, return as-is
     if (id.startsWith('call_')) {
-      return id;
+      return sanitize(id);
     }
 
     // For history format, extract the UUID and add OpenAI prefix
     if (id.startsWith('hist_tool_')) {
       const uuid = id.substring('hist_tool_'.length);
-      return 'call_' + uuid;
+      return sanitize('call_' + uuid);
     }
 
     // For Anthropic format, extract the UUID and add OpenAI prefix
     if (id.startsWith('toolu_')) {
       const uuid = id.substring('toolu_'.length);
-      return 'call_' + uuid;
+      return sanitize('call_' + uuid);
     }
 
     // Unknown format - assume it's a raw UUID
-    return 'call_' + id;
+    return sanitize('call_' + id);
   }
 
   /**
@@ -599,11 +615,284 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
     }
   }
 
+  private normalizeToolCallArguments(parameters: unknown): string {
+    if (parameters === undefined || parameters === null) {
+      return '{}';
+    }
+
+    if (typeof parameters === 'string') {
+      const trimmed = parameters.trim();
+      if (!trimmed) {
+        return '{}';
+      }
+      try {
+        const parsed = JSON.parse(trimmed);
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          return JSON.stringify(parsed);
+        }
+        return JSON.stringify({ value: parsed });
+      } catch {
+        return JSON.stringify({ raw: trimmed });
+      }
+    }
+
+    if (typeof parameters === 'object') {
+      try {
+        return JSON.stringify(parameters);
+      } catch {
+        return JSON.stringify({ raw: '[unserializable object]' });
+      }
+    }
+
+    return JSON.stringify({ value: parameters });
+  }
+
+  private determineToolReplayMode(model?: string): ToolReplayMode {
+    if (!model) {
+      return 'native';
+    }
+    const normalized = model.toLowerCase();
+    if (TEXTUAL_TOOL_REPLAY_MODELS.has(normalized)) {
+      return 'textual';
+    }
+    return 'native';
+  }
+
+  private coerceToString(value: unknown): string {
+    if (typeof value === 'string') {
+      return value;
+    }
+
+    try {
+      return JSON.stringify(value);
+    } catch {
+      try {
+        return String(value);
+      } catch {
+        return '[unserializable value]';
+      }
+    }
+  }
+
+  private formatToolResult(result: unknown): {
+    value?: string;
+    truncated?: boolean;
+    originalLength?: number;
+  } {
+    if (result === undefined || result === null) {
+      return {};
+    }
+    if (typeof result === 'string') {
+      const limited = this.limitToolResponseText(result);
+      return limited;
+    }
+    try {
+      return { value: JSON.stringify(result) };
+    } catch {
+      return { value: this.coerceToString(result) };
+    }
+  }
+
+  private sanitizeResultString(result: string): {
+    text: string;
+    truncated: boolean;
+    originalLength: number;
+  } {
+    const sanitized = hasUnicodeReplacements(result)
+      ? ensureJsonSafe(result)
+      : result;
+
+    if (sanitized.length <= MAX_TOOL_RESPONSE_CHARS) {
+      return {
+        text: sanitized,
+        truncated: false,
+        originalLength: sanitized.length,
+      };
+    }
+
+    const truncatedText = `${sanitized.slice(
+      0,
+      MAX_TOOL_RESPONSE_CHARS,
+    )}… [truncated ${sanitized.length - MAX_TOOL_RESPONSE_CHARS} chars]`;
+
+    return {
+      text: truncatedText,
+      truncated: true,
+      originalLength: sanitized.length,
+    };
+  }
+
+  private limitToolResponseText(text: string): {
+    value: string;
+    truncated: boolean;
+    originalLength: number;
+  } {
+    let limited = text;
+    let truncated = false;
+    const originalLength = text.length;
+
+    const lines = limited.split('\n');
+    if (lines.length > 1) {
+      limited = `${lines[0]}\n[+${lines.length - 1} more lines omitted]`;
+      truncated = true;
+    }
+
+    if (limited.length > MAX_TOOL_RESPONSE_TEXT_CHARS) {
+      limited = `${limited.slice(0, MAX_TOOL_RESPONSE_TEXT_CHARS)}… [truncated ${limited.length - MAX_TOOL_RESPONSE_TEXT_CHARS} chars]`;
+      truncated = true;
+    }
+
+    return { value: limited, truncated, originalLength };
+  }
+
+  private describeToolCallForText(block: ToolCallBlock): string {
+    const normalizedArgs = this.normalizeToolCallArguments(block.parameters);
+    const preview =
+      normalizedArgs.length > MAX_TOOL_RESPONSE_CHARS
+        ? `${normalizedArgs.slice(0, MAX_TOOL_RESPONSE_CHARS)}… [truncated ${normalizedArgs.length - MAX_TOOL_RESPONSE_CHARS} chars]`
+        : normalizedArgs;
+    const callId = block.id ? ` ${this.normalizeToOpenAIToolId(block.id)}` : '';
+    return `[TOOL CALL${callId ? ` ${callId}` : ''}] ${block.name ?? 'unknown_tool'} args=${preview}`;
+  }
+
+  private describeToolResponseForText(block: ToolResponseBlock): string {
+    const payloadString = this.buildToolResponseContent(block);
+    try {
+      const parsed = JSON.parse(payloadString) as {
+        status?: string;
+        result?: string;
+        error?: string;
+        toolName?: string;
+      };
+      const header = `[TOOL RESULT] ${parsed.toolName ?? block.toolName ?? 'unknown_tool'} (${parsed.status ?? 'unknown'})`;
+      const bodyParts: string[] = [];
+      if (parsed.error) {
+        bodyParts.push(`error: ${parsed.error}`);
+      }
+      if (parsed.result && parsed.result !== EMPTY_TOOL_RESULT_PLACEHOLDER) {
+        bodyParts.push(parsed.result);
+      }
+      return bodyParts.length > 0
+        ? `${header}\n${bodyParts.join('\n')}`
+        : header;
+    } catch {
+      return `[TOOL RESULT] ${block.toolName ?? 'unknown_tool'} ${payloadString}`;
+    }
+  }
+
+  private buildToolResponseContent(block: ToolResponseBlock): string {
+    const payload: {
+      status: 'success' | 'error';
+      toolName?: string;
+      result: string;
+      error?: string;
+      truncated?: boolean;
+      originalLength?: number;
+    } = {
+      status: block.error ? 'error' : 'success',
+      toolName: block.toolName,
+      result: EMPTY_TOOL_RESULT_PLACEHOLDER,
+    };
+
+    const formatted = this.formatToolResult(block.result);
+    const serializedResult = formatted.value;
+    if (serializedResult) {
+      const normalized = this.sanitizeResultString(serializedResult);
+      payload.result = normalized.text;
+      if (normalized.truncated) {
+        payload.truncated = true;
+        payload.originalLength = normalized.originalLength;
+      }
+    }
+    if (formatted.truncated) {
+      payload.truncated = true;
+      payload.originalLength =
+        formatted.originalLength ?? payload.originalLength;
+    }
+
+    if (block.error) {
+      payload.error = this.coerceToString(block.error);
+    }
+
+    return ensureJsonSafe(JSON.stringify(payload));
+  }
+
+  private shouldCompressToolMessages(
+    error: unknown,
+    logger: DebugLogger,
+  ): boolean {
+    if (
+      error &&
+      typeof error === 'object' &&
+      'status' in error &&
+      (error as { status?: number }).status === 400
+    ) {
+      const raw =
+        error &&
+        typeof error === 'object' &&
+        'error' in error &&
+        typeof (error as { error?: { metadata?: { raw?: string } } }).error ===
+          'object'
+          ? ((error as { error?: { metadata?: { raw?: string } } }).error ?? {})
+              .metadata?.raw
+          : undefined;
+      if (raw === 'ERROR') {
+        logger.debug(
+          () =>
+            `[OpenAIProvider] Detected OpenRouter 400 response with raw metadata. Will attempt tool-response compression.`,
+        );
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private compressToolMessages(
+    messages: OpenAI.Chat.ChatCompletionMessageParam[],
+    maxLength: number,
+    logger: DebugLogger,
+  ): boolean {
+    let modified = false;
+    messages.forEach((message, index) => {
+      if (message.role !== 'tool' || typeof message.content !== 'string') {
+        return;
+      }
+      const original = message.content;
+      if (original.length <= maxLength) {
+        return;
+      }
+
+      let nextContent = original;
+      try {
+        const parsed = JSON.parse(original) as {
+          result?: unknown;
+          truncated?: boolean;
+          originalLength?: number;
+        };
+        parsed.result = `[omitted ${original.length} chars due to provider limits]`;
+        parsed.truncated = true;
+        parsed.originalLength = original.length;
+        nextContent = JSON.stringify(parsed);
+      } catch {
+        nextContent = `${original.slice(0, maxLength)}… [truncated ${original.length - maxLength} chars]`;
+      }
+
+      message.content = ensureJsonSafe(nextContent);
+      modified = true;
+      logger.debug(
+        () =>
+          `[OpenAIProvider] Compressed tool message #${index} from ${original.length} chars to ${message.content.length} chars`,
+      );
+    });
+    return modified;
+  }
+
   /**
    * Convert IContent array to OpenAI ChatCompletionMessageParam array
    */
   private convertToOpenAIMessages(
     contents: IContent[],
+    mode: ToolReplayMode = 'native',
   ): OpenAI.Chat.ChatCompletionMessageParam[] {
     const messages: OpenAI.Chat.ChatCompletionMessageParam[] = [];
 
@@ -625,31 +914,44 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
         const textBlocks = content.blocks.filter(
           (b) => b.type === 'text',
         ) as TextBlock[];
+        const text = textBlocks.map((b) => b.text).join('\n');
         const toolCalls = content.blocks.filter(
           (b) => b.type === 'tool_call',
         ) as ToolCallBlock[];
 
         if (toolCalls.length > 0) {
-          // Assistant message with tool calls
-          const text = textBlocks.map((b) => b.text).join('\n');
-          messages.push({
-            role: 'assistant',
-            content: text || null,
-            tool_calls: toolCalls.map((tc) => ({
-              id: this.normalizeToOpenAIToolId(tc.id),
-              type: 'function' as const,
-              function: {
-                name: tc.name,
-                arguments:
-                  typeof tc.parameters === 'string'
-                    ? tc.parameters
-                    : JSON.stringify(tc.parameters),
-              },
-            })),
-          });
+          if (mode === 'textual') {
+            const segments: string[] = [];
+            if (text) {
+              segments.push(text);
+            }
+            for (const tc of toolCalls) {
+              segments.push(this.describeToolCallForText(tc));
+            }
+            const combined = segments.join('\n\n').trim();
+            if (combined) {
+              messages.push({
+                role: 'assistant',
+                content: combined,
+              });
+            }
+          } else {
+            // Assistant message with tool calls
+            messages.push({
+              role: 'assistant',
+              content: text || null,
+              tool_calls: toolCalls.map((tc) => ({
+                id: this.normalizeToOpenAIToolId(tc.id),
+                type: 'function' as const,
+                function: {
+                  name: tc.name,
+                  arguments: this.normalizeToolCallArguments(tc.parameters),
+                },
+              })),
+            });
+          }
         } else if (textBlocks.length > 0) {
           // Plain assistant message
-          const text = textBlocks.map((b) => b.text).join('\n');
           messages.push({
             role: 'assistant',
             content: text,
@@ -660,20 +962,73 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
         const toolResponses = content.blocks.filter(
           (b) => b.type === 'tool_response',
         ) as ToolResponseBlock[];
-        for (const tr of toolResponses) {
-          messages.push({
-            role: 'tool',
-            content:
-              typeof tr.result === 'string'
-                ? tr.result
-                : JSON.stringify(tr.result),
-            tool_call_id: this.normalizeToOpenAIToolId(tr.callId),
-          });
+        if (mode === 'textual') {
+          const segments = toolResponses
+            .map((tr) => this.describeToolResponseForText(tr))
+            .filter(Boolean);
+          if (segments.length > 0) {
+            messages.push({
+              role: 'user',
+              content: segments.join('\n\n'),
+            });
+          }
+        } else {
+          for (const tr of toolResponses) {
+            messages.push({
+              role: 'tool',
+              content: this.buildToolResponseContent(tr),
+              tool_call_id: this.normalizeToOpenAIToolId(tr.callId),
+            });
+          }
         }
       }
     }
 
     return messages;
+  }
+
+  private getContentPreview(
+    content: OpenAI.Chat.ChatCompletionMessageParam['content'],
+    maxLength = 200,
+  ): string | undefined {
+    if (content === null || content === undefined) {
+      return undefined;
+    }
+
+    if (typeof content === 'string') {
+      if (content.length <= maxLength) {
+        return content;
+      }
+      return `${content.slice(0, maxLength)}…`;
+    }
+
+    if (Array.isArray(content)) {
+      const textParts = content
+        .filter(
+          (part): part is { type: 'text'; text: string } =>
+            typeof part === 'object' && part !== null && 'type' in part,
+        )
+        .map((part) =>
+          part.type === 'text' && typeof part.text === 'string'
+            ? part.text
+            : JSON.stringify(part),
+        );
+      const joined = textParts.join('\n');
+      if (joined.length <= maxLength) {
+        return joined;
+      }
+      return `${joined.slice(0, maxLength)}…`;
+    }
+
+    try {
+      const serialized = JSON.stringify(content);
+      if (serialized.length <= maxLength) {
+        return serialized;
+      }
+      return `${serialized.slice(0, maxLength)}…`;
+    } catch {
+      return '[unserializable content]';
+    }
   }
 
   /**
@@ -689,6 +1044,7 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
   ): AsyncGenerator<IContent, void, unknown> {
     const { contents, tools, metadata } = options;
     const model = options.resolved.model || this.getDefaultModel();
+    const toolReplayMode = this.determineToolReplayMode(model);
     const abortSignal = metadata?.abortSignal as AbortSignal | undefined;
     const ephemeralSettings = options.invocation?.ephemerals ?? {};
 
@@ -707,7 +1063,13 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
     }
 
     // Convert IContent to OpenAI messages format
-    const messages = this.convertToOpenAIMessages(contents);
+    const messages = this.convertToOpenAIMessages(contents, toolReplayMode);
+    if (logger.enabled && toolReplayMode !== 'native') {
+      logger.debug(
+        () =>
+          `[OpenAIProvider] Using textual tool replay mode for model '${model}'`,
+      );
+    }
 
     // Detect the tool format to use (once at the start of the method)
     const detectedFormat = this.detectToolFormat();
@@ -768,6 +1130,9 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
         outputToolsLength: formattedTools?.length,
         outputToolNames: formattedTools?.map((t) => t.function.name),
       });
+      logger.debug(() => `[OpenAIProvider] Tool conversion detail`, {
+        tools: formattedTools,
+      });
     }
 
     // Get streaming setting from ephemeral settings (default: enabled)
@@ -804,6 +1169,46 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
       { role: 'system', content: systemPrompt },
       ...messages,
     ];
+
+    if (logger.enabled) {
+      logger.debug(() => `[OpenAIProvider] Chat payload snapshot`, {
+        messageCount: messagesWithSystem.length,
+        messages: messagesWithSystem.map((msg) => ({
+          role: msg.role,
+          contentPreview: this.getContentPreview(msg.content),
+          contentLength:
+            typeof msg.content === 'string' ? msg.content.length : undefined,
+          rawContent: typeof msg.content === 'string' ? msg.content : undefined,
+          toolCallCount:
+            'tool_calls' in msg && Array.isArray(msg.tool_calls)
+              ? msg.tool_calls.length
+              : undefined,
+          toolCalls:
+            'tool_calls' in msg && Array.isArray(msg.tool_calls)
+              ? msg.tool_calls.map((call) => {
+                  if (call.type === 'function') {
+                    const args = call.function.arguments ?? '';
+                    const preview =
+                      typeof args === 'string' &&
+                      args.length > TOOL_ARGS_PREVIEW_LENGTH
+                        ? `${args.slice(0, TOOL_ARGS_PREVIEW_LENGTH)}…`
+                        : args;
+                    return {
+                      id: call.id,
+                      name: call.function.name,
+                      argumentsPreview: preview,
+                    };
+                  }
+                  return { id: call.id, type: call.type };
+                })
+              : undefined,
+          toolCallId:
+            'tool_call_id' in msg
+              ? (msg as { tool_call_id?: string }).tool_call_id
+              : undefined,
+        })),
+      });
+    }
 
     const maxTokens =
       (metadata?.maxTokens as number | undefined) ??
@@ -898,9 +1303,10 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
         requestHasSystemPrompt: Boolean(systemPrompt?.length),
         messageCount: messagesWithSystem.length,
       });
+      logger.debug(() => `[OpenAIProvider] Request body detail`, {
+        body: requestBody,
+      });
     }
-    let response;
-
     // Debug log throttle tracker status
     logger.debug(() => `Retry configuration:`, {
       hasThrottleTracker: !!this.throttleTracker,
@@ -910,6 +1316,11 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
     });
 
     const customHeaders = this.getCustomHeaders();
+    if (logger.enabled && customHeaders) {
+      logger.debug(() => `[OpenAIProvider] Applying custom headers`, {
+        headerKeys: Object.keys(customHeaders),
+      });
+    }
 
     if (logger.enabled) {
       logger.debug(() => `[OpenAIProvider] Request body preview`, {
@@ -921,70 +1332,113 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
       });
     }
 
-    try {
-      response = await retryWithBackoff(
-        () =>
-          client.chat.completions.create(requestBody, {
-            ...(abortSignal ? { signal: abortSignal } : {}),
-            ...(customHeaders ? { headers: customHeaders } : {}),
-          }),
-        {
-          maxAttempts: maxRetries,
-          initialDelayMs,
-          shouldRetry: this.shouldRetryResponse.bind(this),
-          trackThrottleWaitTime: this.throttleTracker,
-        },
-      );
-    } catch (error) {
-      // Special handling for Cerebras/Qwen "Tool not present" errors
-      const errorMessage = String(error);
-      if (
-        errorMessage.includes('Tool is not present in the tools list') &&
-        (model.toLowerCase().includes('qwen') ||
-          this.getBaseURL()?.includes('cerebras'))
-      ) {
-        logger.error(
-          'Cerebras/Qwen API error: Tool not found despite being in request. This is a known API issue.',
-          {
-            error,
-            model,
-            toolsProvided: formattedTools?.length || 0,
-            toolNames: formattedTools?.map((t) => t.function.name),
-            streamingEnabled,
-          },
-        );
-        // Re-throw but with better context
-        const enhancedError = new Error(
-          `Cerebras/Qwen API bug: Tool not found in list. We sent ${formattedTools?.length || 0} tools. Known API issue.`,
-        );
-        (enhancedError as Error & { originalError?: unknown }).originalError =
-          error;
-        throw enhancedError;
-      }
-      // Re-throw other errors as-is
-      const capturedErrorMessage =
-        error instanceof Error ? error.message : String(error);
-      const status =
-        typeof error === 'object' &&
-        error !== null &&
-        'status' in error &&
-        typeof (error as { status: unknown }).status === 'number'
-          ? (error as { status: number }).status
-          : undefined;
+    const executeRequest = () =>
+      client.chat.completions.create(requestBody, {
+        ...(abortSignal ? { signal: abortSignal } : {}),
+        ...(customHeaders ? { headers: customHeaders } : {}),
+      });
 
-      logger.error(
-        () =>
-          `[OpenAIProvider] Chat completion failed for model '${model}' at '${baseURL ?? this.getBaseURL() ?? 'default'}': ${capturedErrorMessage}`,
-        {
-          model,
-          baseURL: baseURL ?? this.getBaseURL(),
-          streamingEnabled,
-          hasTools: formattedTools?.length ?? 0,
-          requestHasSystemPrompt: !!systemPrompt,
-          status,
-        },
-      );
-      throw error;
+    let response:
+      | OpenAI.Chat.Completions.ChatCompletion
+      | AsyncIterable<OpenAI.Chat.Completions.ChatCompletionChunk>
+      | undefined;
+
+    if (streamingEnabled) {
+      response = await retryWithBackoff(executeRequest, {
+        maxAttempts: maxRetries,
+        initialDelayMs,
+        shouldRetry: this.shouldRetryResponse.bind(this),
+        trackThrottleWaitTime: this.throttleTracker,
+      });
+    } else {
+      let compressedOnce = false;
+      while (true) {
+        try {
+          response = (await retryWithBackoff(executeRequest, {
+            maxAttempts: maxRetries,
+            initialDelayMs,
+            shouldRetry: this.shouldRetryResponse.bind(this),
+            trackThrottleWaitTime: this.throttleTracker,
+          })) as OpenAI.Chat.Completions.ChatCompletion;
+          break;
+        } catch (error) {
+          const errorMessage = String(error);
+          logger.debug(() => `[OpenAIProvider] Chat request error`, {
+            errorType: error?.constructor?.name,
+            status:
+              typeof error === 'object' && error && 'status' in error
+                ? (error as { status?: number }).status
+                : undefined,
+            errorKeys:
+              error && typeof error === 'object' ? Object.keys(error) : [],
+          });
+          const isCerebrasToolError =
+            errorMessage.includes('Tool is not present in the tools list') &&
+            (model.toLowerCase().includes('qwen') ||
+              this.getBaseURL()?.includes('cerebras'));
+
+          if (isCerebrasToolError) {
+            logger.error(
+              'Cerebras/Qwen API error: Tool not found despite being in request. This is a known API issue.',
+              {
+                error,
+                model,
+                toolsProvided: formattedTools?.length || 0,
+                toolNames: formattedTools?.map((t) => t.function.name),
+                streamingEnabled,
+              },
+            );
+            const enhancedError = new Error(
+              `Cerebras/Qwen API bug: Tool not found in list. We sent ${formattedTools?.length || 0} tools. Known API issue.`,
+            );
+            (
+              enhancedError as Error & { originalError?: unknown }
+            ).originalError = error;
+            throw enhancedError;
+          }
+
+          if (
+            !compressedOnce &&
+            this.shouldCompressToolMessages(error, logger) &&
+            this.compressToolMessages(
+              requestBody.messages,
+              MAX_TOOL_RESPONSE_RETRY_CHARS,
+              logger,
+            )
+          ) {
+            compressedOnce = true;
+            logger.warn(
+              () =>
+                `[OpenAIProvider] Retrying request after compressing tool responses due to provider 400`,
+            );
+            continue;
+          }
+
+          const capturedErrorMessage =
+            error instanceof Error ? error.message : String(error);
+          const status =
+            typeof error === 'object' &&
+            error !== null &&
+            'status' in error &&
+            typeof (error as { status: unknown }).status === 'number'
+              ? (error as { status: number }).status
+              : undefined;
+
+          logger.error(
+            () =>
+              `[OpenAIProvider] Chat completion failed for model '${model}' at '${baseURL ?? this.getBaseURL() ?? 'default'}': ${capturedErrorMessage}`,
+            {
+              model,
+              baseURL: baseURL ?? this.getBaseURL(),
+              streamingEnabled,
+              hasTools: formattedTools?.length ?? 0,
+              requestHasSystemPrompt: !!systemPrompt,
+              status,
+            },
+          );
+          throw error;
+        }
+      }
     }
 
     // Check if response is streaming or not
@@ -1633,6 +2087,10 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
       status,
       errorMessage: error instanceof Error ? error.message : String(error),
       errorKeys: error && typeof error === 'object' ? Object.keys(error) : [],
+      errorData:
+        error && typeof error === 'object' && 'error' in error
+          ? (error as { error?: unknown }).error
+          : undefined,
     });
 
     // Retry on 429 rate limit errors or 5xx server errors

--- a/project-plans/20251108fix501/plan.md
+++ b/project-plans/20251108fix501/plan.md
@@ -1,0 +1,46 @@
+# Issue #501 – Chat Completions Tool Failure Visibility
+
+## Goals
+- Preserve tool responses (including failures) in OpenAI Chat Completion payloads so `tool_call_id` relationships remain valid and models see structured errors.
+- Prevent malformed requests created by `undefined` parameters/results and oversized tool outputs.
+- Validate the fix end-to-end via the `polaris-alpha` profile and ensure CI + e2e suites pass.
+
+## Test-First Workflow
+1. **Characterize the bug**
+   - Read the relevant sections of `packages/core/src/providers/openai/OpenAIProvider.ts` and `packages/core/src/services/history/IContent.ts`.
+   - Inspect recent traces in `~/.llxprt/debug/*.jsonl` to confirm how tool failures are currently serialized.
+2. **Add/adjust unit tests**
+   - Extend/introduce `convertToOpenAIMessages` tests covering:
+     - tool calls with `undefined`, stringified, and object parameters;
+     - tool responses with error-only payloads;
+     - oversized outputs and Unicode replacement characters.
+   - Run `npx vitest run packages/core/src/providers/openai/OpenAIProvider.convertToOpenAIMessages.test.ts` to prove they fail.
+3. **Implement fixes**
+   - Normalize tool-call arguments (always valid JSON string, `{}` fallback).
+   - Map `ToolResponseBlock.error` into a structured error payload, truncate large blobs, and sanitize Unicode before sending to OpenAI.
+   - Re-run the focused tests to prove they now pass, then run the full workspace suite.
+
+## Polaris & Debug Validation
+- Use the Polaris alpha profile to exercise real tool calls:
+  ```bash
+  node scripts/start.js --profile-load polaris-alpha --prompt "review the source and tell me what it does" --yolo
+  ```
+  (The prompt explicitly asks the agent to inspect source via tools.)
+- After each run, inspect the latest `~/.llxprt/debug/llxprt-debug-*.jsonl` entries to verify tool responses carry `error` details and matching `tool_call_id`s.
+- Repeat until the transcript shows compliant tool call / tool response pairs without 400s.
+
+## Full CI / QA Matrix
+1. `npm run format:check`
+2. `npm run lint`
+3. `npm run typecheck`
+4. `npm run test` (workspace default)
+5. `npm run test:e2e`
+6. `npm run test:ci` (ensure `CI=1` plus any secrets pulled from the `cerebrasglm46` profile; fall back to `synthetic` profile variables if needed)
+7. `npm run build`
+8. `node scripts/start.js --profile-load synthetic --prompt "just say hi"`
+9. `node scripts/start.js --profile-load polaris-alpha --prompt "review the source and tell me what it does" --yolo`
+
+## Delivery
+- Stage all changes with `git add`.
+- Commit with a descriptive message referencing `#501` (e.g., `fix(openai): normalize chat tool responses (#501)`).
+- Push `issue501` and open a PR summarizing the bug, the new tests, the Polaris validation, and referencing `#501`.


### PR DESCRIPTION
## TLDR
- normalize the folder-structure block we inject into the system prompt so we stop sending megabyte-scale instructions to Polaris
- capture the exact Polaris payloads via curl and confirm the Stealth backend rejects `tool` + `tool_calls`, then add a textual replay fallback so we send valid chat-completions
- add targeted unit tests for the conversion and prompt logic, then run the full lint/type/test/e2e/ci/build matrix plus manual Polaris + synthetic prompts

## Dive Deeper
Polaris (OpenRouter Stealth) was still returning 400s even for tiny tool calls. Replaying the saved request bodies with `curl` showed every failure happened whenever our history contained an assistant `tool_calls` block or a `tool` role entry—the provider simply rejects that schema. I added a deterministic textual replay mode for models like `openrouter/polaris-alpha`: we convert historical tool requests/responses into plain assistant/user text while still exposing the real tools array so the model can ask for more tool calls. That keeps the payload valid and preserves context.

While debugging I also trimmed the folder-structure chunk in `getCoreSystemPromptAsync` (sub-100 lines plus summary) and added coverage in `prompts-async.test.ts` so the systematic context can’t explode again. New tests for `convertToOpenAIMessages` exercise both the native tool-call path and the textual replay fallback.

## Reviewer Test Plan
1. `DEBUG='llxprt:*' node scripts/start.js --profile-load polaris-alpha --prompt "review the source and tell me what it does" --yolo`
2. `node scripts/start.js --profile-load synthetic --prompt "just say hi"`

## Testing Matrix
|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | -   | -   |
| npx      | -   | -   | -   |
| Docker   | -   | -   | -   |
| Podman   | -   | -   | -   |
| Seatbelt | -   | -   | -   |

## Linked issues / bugs
Fixes #501
