### PR TITLE
Ensure /clear fully resets foreground agent context (#509)

### DIFF
--- a/packages/cli/src/ui/commands/clearCommand.ts
+++ b/packages/cli/src/ui/commands/clearCommand.ts
@@ -4,15 +4,30 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { uiTelemetryService } from '@vybestack/llxprt-code-core';
-import { CommandKind, SlashCommand } from './types.js';
+import { GeminiClient, uiTelemetryService } from '@vybestack/llxprt-code-core';
+import { CommandKind, SlashCommand, type CommandContext } from './types.js';
+import { getCliRuntimeServices } from '../../runtime/runtimeSettings.js';
+
+function resolveForegroundGeminiClient(
+  context: CommandContext,
+): GeminiClient | null {
+  if (context.services.config) {
+    return context.services.config.getGeminiClient();
+  }
+
+  try {
+    return getCliRuntimeServices().config.getGeminiClient();
+  } catch {
+    return null;
+  }
+}
 
 export const clearCommand: SlashCommand = {
   name: 'clear',
   description: 'clear the screen and conversation history',
   kind: CommandKind.BUILT_IN,
   action: async (context, _args) => {
-    const geminiClient = context.services.config?.getGeminiClient();
+    const geminiClient = resolveForegroundGeminiClient(context);
 
     if (geminiClient) {
       context.ui.setDebugMessage('Clearing terminal and resetting chat.');


### PR DESCRIPTION
## Summary
- resolve gemini client via runtime services so /clear always resets foreground agent context
- add tests covering fallback path when command context lacks config
- document verification steps (format, lint, typecheck, test, build, start profile commands) referencing #509

## Testing
- npm run format:check
- npm run lint
- npm run typecheck
- npm run test
- npm run build
- node scripts/start.js --profile-load synthetic --prompt "just say hi"
- node scripts/start.js --profile-load cerebrasglm46 --prompt "just say hi"

Closes #509