### PR TITLE
fix(core): Resolve ReDoS vulnerability in number parsing regex

### DIFF
--- a/packages/core/src/tools/doubleEscapeUtils.ts
+++ b/packages/core/src/tools/doubleEscapeUtils.ts
@@ -243,20 +243,12 @@ export function processToolParameters(
  * @returns The object with numeric strings converted to numbers
  */
 function convertStringNumbersToNumbers(obj: unknown): unknown {
-  if (obj === null || obj === undefined) {
-    return obj;
-  }
+  if (obj == null) return obj;
 
   if (typeof obj === 'string') {
-    // Check if it's a numeric string
-    if (/^-?\d+$/.test(obj)) {
-      // Integer
-      const num = parseInt(obj, 10);
-      if (!isNaN(num)) return num;
-    } else if (/^-?\d*\.?\d+$/.test(obj)) {
-      // Float
-      const num = parseFloat(obj);
-      if (!isNaN(num)) return num;
+    if (/^-?(?:\d+|\d*\.\d+)(?:[eE][+-]?\d+)?$/.test(obj)) {
+      const num = Number(obj);
+      if (Number.isFinite(num)) return num;
     }
     return obj;
   }
@@ -265,7 +257,10 @@ function convertStringNumbersToNumbers(obj: unknown): unknown {
     return obj.map(convertStringNumbersToNumbers);
   }
 
-  if (typeof obj === 'object') {
+  if (
+    typeof obj === 'object' &&
+    Object.getPrototypeOf(obj) === Object.prototype
+  ) {
     const result: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(obj)) {
       result[key] = convertStringNumbersToNumbers(value);


### PR DESCRIPTION
## TLDR

The regular expression used to validate numeric strings in `convertStringNumbersToNumbers` was flagged by CodeQL (js/polynomial-redos) for being susceptible to Regular Expression Denial of Service (ReDoS).

The problematic pattern, `/^-?\d*\.?\d+$/`, could cause catastrophic backtracking when processing long strings of digits due to the ambiguous combination of `\d*` and `\d+`.

This commit replaces the vulnerable regex with `/^-?(?:\d+|\d*\.\d+)(?:[eE][+-]?\d+)?$/`. The new expression is more efficient and safer because it uses a non-capturing group with an OR condition (`(?:\d+|\d*\\.\d+)`) to handle integer and float cases distinctly, preventing excessive backtracking.

Additionally, this change introduces the following improvements:
- Adds support for scientific notation (e.g., '1.23e-4').
- Replaces `parseFloat` and `parseInt` with a single, more robust `Number()` conversion.
- Uses `Number.isFinite()` for stricter validation, correctly excluding `Infinity`.
## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #305

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
