### PR TITLE
Reduce idle memory churn and dispose Gemini client (#517)

### DIFF
--- a/packages/cli/src/ui/contexts/SessionContext.test.tsx
+++ b/packages/cli/src/ui/contexts/SessionContext.test.tsx
@@ -128,4 +128,25 @@ describe('SessionStatsContext', () => {
       consoleSpy.mockRestore();
     }
   });
+
+  it('should not trigger re-render when history token count is unchanged', () => {
+    const { result } = renderHook(() => useSessionStats(), {
+      wrapper: SessionStatsProvider,
+    });
+
+    const initialRenderCount = result.all.length;
+
+    act(() => {
+      result.current.updateHistoryTokenCount(256);
+    });
+
+    expect(result.current.stats.historyTokenCount).toBe(256);
+    expect(result.all.length).toBe(initialRenderCount + 1);
+
+    act(() => {
+      result.current.updateHistoryTokenCount(256);
+    });
+
+    expect(result.all.length).toBe(initialRenderCount + 1);
+  });
 });

--- a/packages/cli/src/ui/contexts/SessionContext.tsx
+++ b/packages/cli/src/ui/contexts/SessionContext.tsx
@@ -115,10 +115,15 @@ export const SessionStatsProvider: React.FC<{ children: React.ReactNode }> = ({
   }, []);
 
   const updateHistoryTokenCount = useCallback((count: number) => {
-    setStats((prevState) => ({
-      ...prevState,
-      historyTokenCount: count,
-    }));
+    setStats((prevState) => {
+      if (prevState.historyTokenCount === count) {
+        return prevState;
+      }
+      return {
+        ...prevState,
+        historyTokenCount: count,
+      };
+    });
   }, []);
 
   // FIX: Use a ref to provide stable callback that always returns latest value

--- a/packages/cli/src/ui/utils/tokenMetricsTracker.test.ts
+++ b/packages/cli/src/ui/utils/tokenMetricsTracker.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { shouldUpdateTokenMetrics } from './tokenMetricsTracker.js';
+
+const baseMetrics = {
+  tokensPerMinute: 12,
+  throttleWaitTimeMs: 1200,
+};
+
+const baseUsage = {
+  input: 10,
+  output: 20,
+  cache: 0,
+  tool: 0,
+  thought: 0,
+  total: 30,
+};
+
+describe('tokenMetricsTracker', () => {
+  it('should request update when there is no previous snapshot', () => {
+    expect(shouldUpdateTokenMetrics(null, baseMetrics, baseUsage)).toBe(true);
+  });
+
+  it('should skip update when metrics and usage are unchanged', () => {
+    const prevSnapshot = {
+      tokensPerMinute: 12,
+      throttleWaitTimeMs: 1200,
+      sessionTokenTotal: 30,
+    };
+    expect(shouldUpdateTokenMetrics(prevSnapshot, baseMetrics, baseUsage)).toBe(
+      false,
+    );
+  });
+
+  it('should update when tokens per minute change', () => {
+    const prevSnapshot = {
+      tokensPerMinute: 12,
+      throttleWaitTimeMs: 1200,
+      sessionTokenTotal: 30,
+    };
+    expect(
+      shouldUpdateTokenMetrics(
+        prevSnapshot,
+        { ...baseMetrics, tokensPerMinute: 18 },
+        baseUsage,
+      ),
+    ).toBe(true);
+  });
+
+  it('should update when throttle wait time changes', () => {
+    const prevSnapshot = {
+      tokensPerMinute: 12,
+      throttleWaitTimeMs: 1200,
+      sessionTokenTotal: 30,
+    };
+    expect(
+      shouldUpdateTokenMetrics(
+        prevSnapshot,
+        { ...baseMetrics, throttleWaitTimeMs: 800 },
+        baseUsage,
+      ),
+    ).toBe(true);
+  });
+
+  it('should update when session token total changes', () => {
+    const prevSnapshot = {
+      tokensPerMinute: 12,
+      throttleWaitTimeMs: 1200,
+      sessionTokenTotal: 30,
+    };
+    expect(
+      shouldUpdateTokenMetrics(prevSnapshot, baseMetrics, {
+        ...baseUsage,
+        total: 31,
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/cli/src/ui/utils/tokenMetricsTracker.ts
+++ b/packages/cli/src/ui/utils/tokenMetricsTracker.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface TokenMetricsSnapshot {
+  tokensPerMinute: number;
+  throttleWaitTimeMs: number;
+  sessionTokenTotal: number;
+}
+
+export interface ProviderMetricsLike {
+  tokensPerMinute?: number | null;
+  throttleWaitTimeMs?: number | null;
+}
+
+export interface SessionTokenUsage {
+  input: number;
+  output: number;
+  cache: number;
+  tool: number;
+  thought: number;
+  total: number;
+}
+
+export function toTokenMetricsSnapshot(
+  metrics: ProviderMetricsLike | null | undefined,
+  usage: SessionTokenUsage | null | undefined,
+): TokenMetricsSnapshot {
+  return {
+    tokensPerMinute: metrics?.tokensPerMinute ?? 0,
+    throttleWaitTimeMs: metrics?.throttleWaitTimeMs ?? 0,
+    sessionTokenTotal: usage?.total ?? 0,
+  };
+}
+
+export function shouldUpdateTokenMetrics(
+  previous: TokenMetricsSnapshot | null,
+  metrics: ProviderMetricsLike | null | undefined,
+  usage: SessionTokenUsage | null | undefined,
+): boolean {
+  if (!previous) {
+    return true;
+  }
+  const next = toTokenMetricsSnapshot(metrics, usage);
+  return (
+    next.tokensPerMinute !== previous.tokensPerMinute ||
+    next.throttleWaitTimeMs !== previous.throttleWaitTimeMs ||
+    next.sessionTokenTotal !== previous.sessionTokenTotal
+  );
+}

--- a/packages/core/src/core/__tests__/geminiClient.dispose.test.ts
+++ b/packages/core/src/core/__tests__/geminiClient.dispose.test.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { GeminiClient } from '../client.js';
+
+describe('GeminiClient.dispose', () => {
+  it('invokes the runtime unsubscribe exactly once', () => {
+    const client = Object.create(GeminiClient.prototype) as GeminiClient & {
+      _unsubscribe?: () => void;
+    };
+    const unsubscribe = vi.fn();
+    client['_unsubscribe'] = unsubscribe;
+
+    client.dispose();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+    expect(client['_unsubscribe']).toBeUndefined();
+
+    client.dispose();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -247,6 +247,13 @@ export class GeminiClient {
     this.todoReminderService = new TodoReminderService();
   }
 
+  dispose(): void {
+    if (this._unsubscribe) {
+      this._unsubscribe();
+      this._unsubscribe = undefined;
+    }
+  }
+
   async initialize(contentGeneratorConfig: ContentGeneratorConfig) {
     // Preserve chat history before resetting, but only if we don't already have stored history
     // (e.g., from storeHistoryForLaterUse called before initialize)


### PR DESCRIPTION
Fixes #517\n\n## Summary\n- dedupe history/token telemetry updates so the Ink tree stays idle when nothing changes\n- add token metrics snapshot helper + hook coverage\n- make GeminiClient disposable and ensure Config.refreshAuth tears down old clients\n\n## Testing\n- npm run format:check\n- npm run lint\n- npm run typecheck\n- npm run test\n- npm run build\n- node scripts/start.js --profile-load synthetic --prompt 'just say hi'