### PR TITLE
Enable yolo mode for Luther

### DIFF
--- a/.github/workflows/luther.yml
+++ b/.github/workflows/luther.yml
@@ -316,6 +316,7 @@ jobs:
             node scripts/start.js \
               --provider openai \
               --model zai-glm-4.6 \
+              --yolo \
               --key "${CEREBRAS_API_KEY}" \
               --set modelparam.temperature=1 \
               --set modelparam.max_tokens=10000 \


### PR DESCRIPTION
## Summary
- add the legacy `--yolo` flag when Luther launches `node scripts/start.js`
- ensures the automatic agent run can write files without approval prompts (issue #539)

## Testing
- npm run format:check
