### PR TITLE
Ensure Luther hits CI test suite

### DIFF
--- a/.github/workflows/luther.yml
+++ b/.github/workflows/luther.yml
@@ -253,7 +253,7 @@ jobs:
           results_file="luther/state/failure-summary.txt"
           : > "$results_file"
           qa_names=("format" "lint" "typecheck" "test" "build")
-          qa_commands=("npm run format" "npm run lint" "npm run typecheck" "npm run test" "npm run build")
+          qa_commands=("npm run format" "npm run lint" "npm run typecheck" "npm run test:ci" "npm run build")
 
           max_attempts="${LUTHER_MAX_ATTEMPTS:-3}"
           success_attempt=""


### PR DESCRIPTION
## Summary
- update the Luther workflow to run `npm run test:ci` (with CI env) instead of the lighter `npm run test`
- this matches the repo’s standard pipeline so Luther sees the same failures GitHub CI would surface (issue #542)

## Testing
- npm run format:check
