### PR TITLE
Fix provider alias resolution in bundle environments (--provider xAI, --provider Fireworks)

### DIFF
--- a/packages/cli/src/providers/providerAliases.ts
+++ b/packages/cli/src/providers/providerAliases.ts
@@ -18,17 +18,13 @@ const __dirname = path.dirname(__filename);
 // Handle different directory structures between development and bundle environments
 // In development: packages/cli/src/providers/aliases/
 // In bundle: bundle/providers/aliases/
-let BUILTIN_ALIAS_DIR: string;
-if (
-  __dirname.includes('bundle') ||
-  fs.existsSync(path.join(__dirname, 'providers'))
-) {
-  // Bundle environment: __dirname is bundle/, aliases at providers/aliases/
-  BUILTIN_ALIAS_DIR = path.join(__dirname, 'providers', 'aliases');
-} else {
-  // Development environment: __dirname is packages/cli/src/providers/, aliases at aliases/
-  BUILTIN_ALIAS_DIR = path.join(__dirname, 'aliases');
-}
+const BUNDLE_ALIAS_DIR = path.join(__dirname, 'providers', 'aliases');
+const DEV_ALIAS_DIR = path.join(__dirname, 'aliases');
+
+// Prefer the bundle layout if it actually exists, otherwise fall back to dev layout.
+const BUILTIN_ALIAS_DIR = fs.existsSync(BUNDLE_ALIAS_DIR)
+  ? BUNDLE_ALIAS_DIR
+  : DEV_ALIAS_DIR;
 
 export type ProviderAliasSource = 'user' | 'builtin';
 


### PR DESCRIPTION
## TLDR

Fix provider aliases (e.g., `--provider xAI`, `--provider Fireworks`) that were working in development but failing in bundle/production environments with "Provider not found" error.


## Dive Deeper

  ### Root Cause
  
  Incorrect path resolution in `providerAliases.ts` when running in bundle environments where `__dirname` differs from development. The code assumed `__dirname` would always be `packages/cli/src/providers/`, but in bundle environments it's just `bundle/`.
  
  ### Changes
  
  **packages/cli/src/providers/providerAliases.ts**: Implemented environment-aware path resolution to correctly locate alias configuration files in both development and bundle environments.
  
  ```typescript
  // Environment-aware path resolution
  let BUILTIN_ALIAS_DIR: string;
  if (
    __dirname.includes('bundle') ||
    fs.existsSync(path.join(__dirname, 'providers'))
  ) {
    // Bundle environment: __dirname is bundle/, aliases at providers/aliases/
    BUILTIN_ALIAS_DIR = path.join(__dirname, 'providers', 'aliases');
  } else {
    // Development environment: __dirname is packages/cli/src/providers/, aliases at aliases/
    BUILTIN_ALIAS_DIR = path.join(__dirname, 'aliases');
  }
  ```

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CLI runtime detection for alias file locations so the tool prefers bundled layouts when present and falls back to development layouts, increasing deployment flexibility and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->