### PR TITLE
Fix Gemini subagent auto prompt (#568 #570)

### DIFF
--- a/packages/cli/src/runtime/runtimeSettings.ts
+++ b/packages/cli/src/runtime/runtimeSettings.ts
@@ -860,6 +860,8 @@ const PROFILE_EPHEMERAL_KEYS: readonly string[] = [
   'context-limit',
   'compression-threshold',
   'base-url',
+  'GOOGLE_CLOUD_PROJECT',
+  'GOOGLE_CLOUD_LOCATION',
   'tool-format',
   'api-version',
   'custom-headers',
@@ -921,6 +923,20 @@ export function buildRuntimeProfileSnapshot(): Profile {
     const baseUrl = providerSettings.baseUrl as string | undefined;
     if (baseUrl) {
       snapshot['base-url'] = baseUrl;
+    }
+  }
+
+  if (snapshot['GOOGLE_CLOUD_PROJECT'] === undefined) {
+    const project = process.env.GOOGLE_CLOUD_PROJECT;
+    if (typeof project === 'string' && project.trim().length > 0) {
+      snapshot['GOOGLE_CLOUD_PROJECT'] = project;
+    }
+  }
+
+  if (snapshot['GOOGLE_CLOUD_LOCATION'] === undefined) {
+    const location = process.env.GOOGLE_CLOUD_LOCATION;
+    if (typeof location === 'string' && location.trim().length > 0) {
+      snapshot['GOOGLE_CLOUD_LOCATION'] = location;
     }
   }
 

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -682,6 +682,13 @@ export class GeminiClient {
     this.getChat().setTools(tools);
   }
 
+  clearTools(): void {
+    delete this.generateContentConfig.tools;
+    if (this.chat && typeof this.chat.clearTools === 'function') {
+      this.chat.clearTools();
+    }
+  }
+
   async resetChat(): Promise<void> {
     // If chat exists, clear its history service
     if (this.chat) {

--- a/packages/core/src/core/subagentOrchestrator.ts
+++ b/packages/core/src/core/subagentOrchestrator.ts
@@ -343,6 +343,10 @@ export class SubagentOrchestrator {
     ]);
     if (baseUrl) {
       service.set(`providers.${provider}.baseUrl`, baseUrl);
+      service.set(`providers.${provider}.baseURL`, baseUrl);
+    } else {
+      service.set(`providers.${provider}.baseUrl`, undefined);
+      service.set(`providers.${provider}.baseURL`, undefined);
     }
 
     const authKey = profile.ephemeralSettings['auth-key'];
@@ -488,6 +492,9 @@ export class SubagentOrchestrator {
         : AuthType.USE_PROVIDER;
 
     const sessionId = `${this.baseSessionId()}::${agentRuntimeId}`;
+    const baseUrl = this.getStringSetting(profile.ephemeralSettings, [
+      'base-url',
+    ]);
 
     return createAgentRuntimeState({
       runtimeId: agentRuntimeId,
@@ -496,6 +503,7 @@ export class SubagentOrchestrator {
       authType,
       authPayload:
         typeof authKey === 'string' ? { apiKey: authKey } : undefined,
+      baseUrl,
       proxyUrl: this.getStringSetting(profile.ephemeralSettings, [
         'proxy',
         'proxy-url',

--- a/packages/core/src/providers/gemini/__tests__/gemini.stateless.test.ts
+++ b/packages/core/src/providers/gemini/__tests__/gemini.stateless.test.ts
@@ -617,7 +617,10 @@ describe('Gemini provider stateless contract tests', () => {
       | { config?: Record<string, unknown> }
       | undefined;
     expect(lastRequest).toBeDefined();
-    expect(lastRequest?.config).toMatchObject({ temperature: 0.23 });
+    expect(lastRequest?.config).toMatchObject({
+      temperature: 0.23,
+      serverTools: ['web_search', 'web_fetch'],
+    });
     expect(getEphemerals).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/types/modelParams.ts
+++ b/packages/core/src/types/modelParams.ts
@@ -80,6 +80,10 @@ export interface EphemeralSettings {
   'tools.allowed'?: string[];
   /** Explicit disable-list of tool names */
   'tools.disabled'?: string[];
+  /** Google Cloud project identifier for Gemini auth */
+  GOOGLE_CLOUD_PROJECT?: string;
+  /** Google Cloud location identifier for Gemini auth */
+  GOOGLE_CLOUD_LOCATION?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- ensure detached Gemini subagent clients start with an empty tool state and log their auto prompt payload
- strip governance `tools` config from Gemini provider calls while still honoring ephemerals and metadata overrides
- persist/restore GOOGLE_CLOUD_PROJECT/LOCATION in profiles and sync OAuth enablement when tokens are saved

## Testing
- npm run format:check
- npm run lint
- npm run typecheck
- npm run test
- npm run build
- node scripts/start.js --profile-load synthetic --prompt "just say hi"

Resolves #568, #570.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Google Cloud project and location environment variables for enhanced cloud integration.
  * Enhanced subagent auto-prompt functionality with improved client handling and fallback mechanisms.

* **Improvements**
  * Improved OAuth provider state initialization and management.
  * Enhanced server tools configuration propagation and handling.
  * Better base URL compatibility across provider configurations.
  * Added tool clearing capability for Gemini configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->