### PR TITLE
Fix profile keyfile auth leak

### DIFF
--- a/packages/cli/src/runtime/__tests__/profileApplication.test.ts
+++ b/packages/cli/src/runtime/__tests__/profileApplication.test.ts
@@ -613,6 +613,7 @@ describe('profileApplication helpers', () => {
 
     // Verify auth-keyfile ephemeral was set (use expectedPath for cross-platform compatibility)
     expect(configStub.getEphemeralSetting('auth-keyfile')).toBe(expectedPath);
+    expect(configStub.getEphemeralSetting('auth-key')).toBeUndefined();
   });
 });
 

--- a/packages/cli/src/runtime/profileApplication.ts
+++ b/packages/cli/src/runtime/profileApplication.ts
@@ -260,6 +260,7 @@ export async function applyProfileWithGuards(
   // STEP 2: Load and IMMEDIATELY apply auth to SettingsService BEFORE provider switch
   // This makes auth available in SettingsService so switchActiveProvider() won't trigger OAuth
   let authKeyApplied = false;
+  let resolvedAuthKeyfilePath: string | null = null;
   const authKeyfile = sanitizedProfile.ephemeralSettings?.['auth-keyfile'];
   if (
     authKeyfile &&
@@ -281,6 +282,7 @@ export async function applyProfileWithGuards(
         setEphemeralSetting('auth-keyfile', filePath);
         setProviderApiKey(authKey);
         setProviderApiKeyfile(filePath);
+        resolvedAuthKeyfilePath = filePath;
         authKeyApplied = true;
         logger.debug(
           () =>
@@ -385,6 +387,10 @@ export async function applyProfileWithGuards(
     const { message } = await updateActiveProviderApiKey(currentAuthKey);
     if (message) {
       infoMessages.push(message);
+    }
+    if (authKeyApplied && resolvedAuthKeyfilePath) {
+      setEphemeralSetting('auth-key', undefined);
+      setEphemeralSetting('auth-keyfile', resolvedAuthKeyfilePath);
     }
   }
 

--- a/packages/cli/src/runtime/runtimeSettings.test.ts
+++ b/packages/cli/src/runtime/runtimeSettings.test.ts
@@ -626,6 +626,17 @@ describe('runtimeSettings helpers', () => {
     });
   });
 
+  it('buildRuntimeProfileSnapshot excludes auth-key when auth-keyfile is set', async () => {
+    const config = getCliRuntimeConfig() as unknown as StubConfigInstance;
+    config.setEphemeralSetting('auth-keyfile', '/tmp/apikey');
+    config.setEphemeralSetting('auth-key', 'file-derived-key');
+
+    const snapshot = buildRuntimeProfileSnapshot();
+
+    expect(snapshot.ephemeralSettings['auth-keyfile']).toBe('/tmp/apikey');
+    expect(snapshot.ephemeralSettings['auth-key']).toBeUndefined();
+  });
+
   it('buildRuntimeProfileSnapshot omits auth data from model params', async () => {
     const { settingsService, config } = getCliRuntimeServices() as unknown as {
       settingsService: StubSettingsServiceInstance;

--- a/packages/cli/src/ui/commands/keyfileCommand.ts
+++ b/packages/cli/src/ui/commands/keyfileCommand.ts
@@ -102,6 +102,7 @@ export const keyfileCommand: SlashCommand = {
 
       const result = await runtime.updateActiveProviderApiKey(apiKey);
       runtime.setEphemeralSetting('auth-keyfile', resolvedPath);
+      runtime.setEphemeralSetting('auth-key', undefined);
       context.services.settings.setProviderKeyfile?.(
         providerName,
         resolvedPath,


### PR DESCRIPTION
## Summary
- resolves #579 by keeping profile snapshots and runtime state from persisting plaintext API keys when a keyfile is used
- builds a snapshot only with auth-keyfile, clears auth-key after CLI keyfile load/profile application so saved profiles stop leaking

## Testing
- npm run format:check
- npm run lint
- npm run typecheck
- npm run test
- npm run build
- node scripts/start.js --profile-load synthetic --prompt "just say hi"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests to verify proper credential handling when using keyfile-based authentication.
  * Added test coverage for authentication state management across provider operations.

* **Bug Fixes**
  * Enhanced credential cleanup when loading API keys from keyfiles to prevent authentication conflicts.
  * Improved authentication state consistency and preservation during provider switching operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->