### PR TITLE
Limit CLI history retention via settings #585

### DIFF
--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -61,6 +61,10 @@ import {
   loadEnvironment,
 } from './settings';
 import { FatalConfigError, LLXPRT_DIR } from '@vybestack/llxprt-code-core';
+import {
+  DEFAULT_HISTORY_MAX_BYTES,
+  DEFAULT_HISTORY_MAX_ITEMS,
+} from '../constants/historyLimits.js';
 
 const MOCK_WORKSPACE_DIR = '/mock/workspace';
 // Use the (mocked) SETTINGS_DIRECTORY_NAME for consistency
@@ -164,6 +168,8 @@ describe('Settings Loading and Merging', () => {
         hideModelInfo: false,
         hideSandboxStatus: false,
         showMemoryUsage: false,
+        historyMaxItems: DEFAULT_HISTORY_MAX_ITEMS,
+        historyMaxBytes: DEFAULT_HISTORY_MAX_BYTES,
         usageStatisticsEnabled: true,
         autoConfigureMaxOldSpaceSize: false,
         maxSessionTurns: -1,
@@ -253,6 +259,8 @@ describe('Settings Loading and Merging', () => {
         hideModelInfo: false,
         hideSandboxStatus: false,
         showMemoryUsage: false,
+        historyMaxItems: DEFAULT_HISTORY_MAX_ITEMS,
+        historyMaxBytes: DEFAULT_HISTORY_MAX_BYTES,
         usageStatisticsEnabled: true,
         autoConfigureMaxOldSpaceSize: false,
         maxSessionTurns: -1,
@@ -342,6 +350,8 @@ describe('Settings Loading and Merging', () => {
         hideModelInfo: false,
         hideSandboxStatus: false,
         showMemoryUsage: false,
+        historyMaxItems: DEFAULT_HISTORY_MAX_ITEMS,
+        historyMaxBytes: DEFAULT_HISTORY_MAX_BYTES,
         usageStatisticsEnabled: true,
         autoConfigureMaxOldSpaceSize: false,
         maxSessionTurns: -1,
@@ -430,6 +440,8 @@ describe('Settings Loading and Merging', () => {
         hideModelInfo: false,
         hideSandboxStatus: false,
         showMemoryUsage: false,
+        historyMaxItems: DEFAULT_HISTORY_MAX_ITEMS,
+        historyMaxBytes: DEFAULT_HISTORY_MAX_BYTES,
         usageStatisticsEnabled: true,
         autoConfigureMaxOldSpaceSize: false,
         maxSessionTurns: -1,
@@ -521,6 +533,8 @@ describe('Settings Loading and Merging', () => {
         hideModelInfo: false,
         hideSandboxStatus: false,
         showMemoryUsage: false,
+        historyMaxItems: DEFAULT_HISTORY_MAX_ITEMS,
+        historyMaxBytes: DEFAULT_HISTORY_MAX_BYTES,
         usageStatisticsEnabled: true,
         autoConfigureMaxOldSpaceSize: false,
         maxSessionTurns: -1,
@@ -623,6 +637,8 @@ describe('Settings Loading and Merging', () => {
         hideModelInfo: false,
         hideSandboxStatus: false,
         showMemoryUsage: false,
+        historyMaxItems: DEFAULT_HISTORY_MAX_ITEMS,
+        historyMaxBytes: DEFAULT_HISTORY_MAX_BYTES,
         usageStatisticsEnabled: true,
         autoConfigureMaxOldSpaceSize: false,
         maxSessionTurns: -1,
@@ -734,6 +750,8 @@ describe('Settings Loading and Merging', () => {
         hideModelInfo: false,
         hideSandboxStatus: false,
         showMemoryUsage: false,
+        historyMaxItems: DEFAULT_HISTORY_MAX_ITEMS,
+        historyMaxBytes: DEFAULT_HISTORY_MAX_BYTES,
         usageStatisticsEnabled: true,
         autoConfigureMaxOldSpaceSize: false,
         maxSessionTurns: -1,
@@ -1714,6 +1732,8 @@ describe('Settings Loading and Merging', () => {
           hideModelInfo: false,
           hideSandboxStatus: false,
           showMemoryUsage: false,
+          historyMaxItems: DEFAULT_HISTORY_MAX_ITEMS,
+          historyMaxBytes: DEFAULT_HISTORY_MAX_BYTES,
           usageStatisticsEnabled: true,
           autoConfigureMaxOldSpaceSize: false,
           maxSessionTurns: -1,

--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -14,6 +14,8 @@ describe('SettingsSchema', () => {
         'theme',
         'customThemes',
         'showMemoryUsage',
+        'historyMaxItems',
+        'historyMaxBytes',
         'usageStatisticsEnabled',
         'autoConfigureMaxOldSpaceSize',
         'preferredEditor',

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -12,6 +12,10 @@ import {
   ChatCompressionSettings,
 } from '@vybestack/llxprt-code-core';
 import { CustomTheme } from '../ui/themes/theme.js';
+import {
+  DEFAULT_HISTORY_MAX_BYTES,
+  DEFAULT_HISTORY_MAX_ITEMS,
+} from '../constants/historyLimits.js';
 
 export interface SettingDefinition {
   type: 'boolean' | 'string' | 'number' | 'array' | 'object' | 'enum';
@@ -124,6 +128,26 @@ export const SETTINGS_SCHEMA = {
     requiresRestart: false,
     default: false,
     description: 'Display memory usage information in the UI',
+    showInDialog: true,
+  },
+  historyMaxItems: {
+    type: 'number',
+    label: 'History Max Items',
+    category: 'UI',
+    requiresRestart: false,
+    default: DEFAULT_HISTORY_MAX_ITEMS,
+    description:
+      'Maximum number of history entries to keep in the scrollback before trimming the oldest ones. Set to -1 for unlimited.',
+    showInDialog: true,
+  },
+  historyMaxBytes: {
+    type: 'number',
+    label: 'History Max Bytes',
+    category: 'UI',
+    requiresRestart: false,
+    default: DEFAULT_HISTORY_MAX_BYTES,
+    description:
+      'Approximate maximum number of bytes to keep in history. Older entries are removed once this budget is exceeded. Set to -1 for unlimited.',
     showInDialog: true,
   },
   customWittyPhrases: {

--- a/packages/cli/src/constants/historyLimits.ts
+++ b/packages/cli/src/constants/historyLimits.ts
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Default UI history retention limits.
+ *
+ * The goal is to keep enough scrollback for users to review recent work
+ * without letting the in-memory transcript grow without bound.
+ */
+export const DEFAULT_HISTORY_MAX_ITEMS = 400;
+export const DEFAULT_HISTORY_MAX_BYTES = 4 * 1024 * 1024; // 4 MiB

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -56,6 +56,10 @@ import { ShellConfirmationDialog } from './components/ShellConfirmationDialog.js
 import { RadioButtonSelect } from './components/shared/RadioButtonSelect.js';
 import { Colors } from './colors.js';
 import { loadHierarchicalLlxprtMemory } from '../config/config.js';
+import {
+  DEFAULT_HISTORY_MAX_BYTES,
+  DEFAULT_HISTORY_MAX_ITEMS,
+} from '../constants/historyLimits.js';
 import { LoadedSettings, SettingScope } from '../config/settings.js';
 import { Tips } from './components/Tips.js';
 import { ConsolePatcher } from './utils/ConsolePatcher.js';
@@ -226,7 +230,21 @@ const App = (props: AppInternalProps) => {
   const [updateInfo, setUpdateInfo] = useState<UpdateObject | null>(null);
   const { stdout } = useStdout();
   const nightly = version.includes('nightly');
-  const { history, addItem, clearItems, loadHistory } = useHistory();
+  const historyLimits = useMemo(
+    () => ({
+      maxItems:
+        typeof settings.merged.historyMaxItems === 'number'
+          ? settings.merged.historyMaxItems
+          : DEFAULT_HISTORY_MAX_ITEMS,
+      maxBytes:
+        typeof settings.merged.historyMaxBytes === 'number'
+          ? settings.merged.historyMaxBytes
+          : DEFAULT_HISTORY_MAX_BYTES,
+    }),
+    [settings.merged.historyMaxItems, settings.merged.historyMaxBytes],
+  );
+  const { history, addItem, clearItems, loadHistory } =
+    useHistory(historyLimits);
   const { updateTodos } = useTodoContext();
   const todoPauseController = useMemo(() => new TodoPausePreserver(), []);
   const registerTodoPause = useCallback(() => {


### PR DESCRIPTION
## Summary
- add History Max Items/Bytes settings surfaced in /settings (Fixes #585)
- enforce those limits inside the useHistory hook and wire the CLI to the configured defaults
- cover the new trimming behaviour with unit tests and share the defaults across schema/UI

## Testing
- npm run format:check
- npm run lint
- npm run typecheck
- npm run test
- npm run build
- node scripts/start.js --profile-load synthetic --prompt "write me a haiku"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable settings for history management: maximum history items and memory budget, allowing users to customize scrollback behavior and retention limits.

* **Tests**
  * Added tests verifying history trimming behavior under various item count and memory constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->