### PR TITLE
Fix /set schema completions (#587)

### DIFF
--- a/packages/cli/src/ui/commands/schema/index.ts
+++ b/packages/cli/src/ui/commands/schema/index.ts
@@ -198,10 +198,10 @@ function resolveActiveStep(
         remainingArgs.shift();
         consumedCount += 1;
         consumedLiterals += 1;
-        currentSchema = mergeSchemas(
-          matched.next,
-          currentSchema.slice(nextIndex),
-        );
+        const remainingSchema = matched.stopPropagation
+          ? []
+          : currentSchema.slice(nextIndex);
+        currentSchema = mergeSchemas(matched.next, remainingSchema);
         continue;
       }
 

--- a/packages/cli/src/ui/commands/schema/types.ts
+++ b/packages/cli/src/ui/commands/schema/types.ts
@@ -24,6 +24,7 @@ export interface LiteralArgument {
   readonly value: string;
   readonly description?: string;
   readonly next?: CommandArgumentSchema;
+  readonly stopPropagation?: boolean;
 }
 
 // Line 3: Option structure definition

--- a/packages/cli/src/ui/commands/setCommand.ts
+++ b/packages/cli/src/ui/commands/setCommand.ts
@@ -213,6 +213,7 @@ const createSettingLiteral = (spec: SettingLiteralSpec): LiteralArgument => ({
   kind: 'literal' as const,
   value: spec.value,
   description: `${toTitleCase(spec.value)} option`,
+  stopPropagation: true,
   next: [
     {
       kind: 'value' as const,
@@ -234,6 +235,7 @@ const setSchema: CommandArgumentSchema = [
     kind: 'literal',
     value: 'unset',
     description: 'Unset option',
+    stopPropagation: true,
     next: [
       {
         kind: 'value',
@@ -312,6 +314,7 @@ const setSchema: CommandArgumentSchema = [
     kind: 'literal',
     value: 'modelparam',
     description: 'Model parameter option',
+    stopPropagation: true,
     next: [
       {
         kind: 'value',
@@ -363,6 +366,7 @@ const setSchema: CommandArgumentSchema = [
     kind: 'literal',
     value: 'emojifilter',
     description: 'Emoji filter option',
+    stopPropagation: true,
     next: [
       {
         kind: 'value',

--- a/packages/cli/src/ui/commands/test/setCommand.phase09.test.ts
+++ b/packages/cli/src/ui/commands/test/setCommand.phase09.test.ts
@@ -187,6 +187,30 @@ describe('setCommand schema integration', () => {
     });
   });
 
+  describe('literal completion termination', () => {
+    it('should stop suggesting new keys after completing a literal value @plan:PLAN-20251013-AUTOCOMPLETE.P09 @requirement:REQ-006', async () => {
+      const result = await handler(
+        mockContext,
+        '',
+        '/set context-limit 50000 ',
+      );
+
+      expect(result.suggestions).toEqual([]);
+      expect(result.hint).toBe('');
+    });
+
+    it('should not reopen selection after socket-keepalive value @plan:PLAN-20251013-AUTOCOMPLETE.P09 @requirement:REQ-006', async () => {
+      const result = await handler(
+        mockContext,
+        '',
+        '/set socket-keepalive true ',
+      );
+
+      expect(result.suggestions).toEqual([]);
+      expect(result.hint).toBe('');
+    });
+  });
+
   describe('hint text correctness', () => {
     it('should show appropriate hints for context-limit setting @plan:PLAN-20251013-AUTOCOMPLETE.P09 @requirement:REQ-006', async () => {
       const result = await handler(mockContext, '', '/set context-limit ');

--- a/packages/cli/src/ui/commands/test/useSlashCompletion.schema.test.ts
+++ b/packages/cli/src/ui/commands/test/useSlashCompletion.schema.test.ts
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** @vitest-environment jsdom */
+
+import { describe, it, expect, vi } from 'vitest';
+
+const { schemaHandlerSpy, createHandlerMock } = vi.hoisted(() => {
+  const schemaHandlerSpy = vi.fn().mockResolvedValue({
+    suggestions: [
+      { value: 'alpha', description: 'alpha option' },
+      { value: 'beta', description: 'beta option' },
+    ],
+    hint: 'Select option',
+    position: 1,
+  });
+  const createHandlerMock = vi.fn(() => schemaHandlerSpy);
+  return { schemaHandlerSpy, createHandlerMock };
+});
+
+vi.mock('../schema/index.js', () => ({
+  createCompletionHandler: createHandlerMock,
+}));
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { useSlashCompletion } from '../../hooks/useSlashCompletion.js';
+import { useTextBuffer } from '../../components/shared/text-buffer.js';
+import { CommandContext, CommandKind, SlashCommand } from '../types.js';
+import { Config, FileDiscoveryService } from '@vybestack/llxprt-code-core';
+
+const mockCommandContext = {} as CommandContext;
+
+const mockConfig = {
+  getTargetDir: () => '/',
+  getWorkspaceContext: () => ({
+    getDirectories: () => [],
+  }),
+  getProjectRoot: () => '/',
+  getFileFilteringOptions: () => ({
+    respectGitIgnore: true,
+    respectLlxprtIgnore: true,
+  }),
+  getEnableRecursiveFileSearch: () => false,
+  getFileService: () => new FileDiscoveryService('/'),
+} as unknown as Config;
+
+function useTextBufferForTest(text: string, cursorOffset?: number) {
+  return useTextBuffer({
+    initialText: text,
+    initialCursorOffset: cursorOffset ?? text.length,
+    viewport: { width: 80, height: 20 },
+    isValidPath: () => false,
+    onChange: () => {},
+  });
+}
+
+describe('useSlashCompletion schema gating', () => {
+  const schemaDrivenSetCommand: SlashCommand = {
+    name: 'set',
+    description: 'set command',
+    kind: CommandKind.BUILT_IN,
+    schema: [
+      {
+        kind: 'literal',
+        value: 'alpha',
+        description: 'alpha option',
+        next: [
+          {
+            kind: 'value',
+            name: 'alpha-value',
+            description: 'alpha value',
+          },
+        ],
+      },
+      {
+        kind: 'literal',
+        value: 'beta',
+        description: 'beta option',
+        next: [
+          {
+            kind: 'value',
+            name: 'beta-value',
+            description: 'beta value',
+          },
+        ],
+      },
+    ],
+  };
+
+  it('requires a space or partial argument before schema completions run', async () => {
+    const slashCommands = [schemaDrivenSetCommand];
+    const { result } = renderHook(
+      ({ text }) => {
+        const textBuffer = useTextBufferForTest(text);
+        return useSlashCompletion(
+          textBuffer,
+          [],
+          '/',
+          slashCommands,
+          mockCommandContext,
+          false,
+          mockConfig,
+        );
+      },
+      { initialProps: { text: '/set' } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.suggestions).toEqual([]);
+      expect(result.current.showSuggestions).toBe(false);
+      expect(createHandlerMock).not.toHaveBeenCalled();
+    });
+
+    expect(createHandlerMock).not.toHaveBeenCalled();
+    expect(schemaHandlerSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/ui/hooks/useSlashCompletion.tsx
+++ b/packages/cli/src/ui/hooks/useSlashCompletion.tsx
@@ -308,7 +308,8 @@ export function useSlashCompletion(
         }
       }
 
-      const isArgumentCompletion = leafSupportsArguments;
+      const hasArgumentTokens = remainingParts.length > 0 || hasTrailingSpace;
+      const isArgumentCompletion = leafSupportsArguments && hasArgumentTokens;
 
       // Set completion range
       const activePartial = leafSupportsArguments


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed command completion to stop suggesting options after literal values are completed, preventing unnecessary suggestions when using commands like `unset`, `modelparam`, and `emojifilter`.
  * Improved argument completion behavior to only appear when actual argument tokens or trailing space are present.

* **Tests**
  * Added tests validating command completion termination and schema completion gating behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->