### PR TITLE
Fix tool output limiter handling (#589)

### DIFF
--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -908,6 +908,7 @@ class Session {
         fc.name,
         callId,
         toolResult.llmContent,
+        this.config,
       );
       const message = this.extractToolResultText(toolResult);
 

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -725,6 +725,26 @@ describe('convertToFunctionResponse', () => {
     const result = convertToFunctionResponse(toolName, callId, llmContent);
     expect(result).toEqual([llmContent]);
   });
+
+  it('should trim string outputs using tool-output limits when config is provided', () => {
+    const llmContent = Array(5000).fill('long-line').join('\n');
+    const config = {
+      getEphemeralSettings: () => ({
+        'tool-output-max-tokens': 50,
+        'tool-output-truncate-mode': 'truncate',
+      }),
+    } as unknown as Config;
+
+    const result = convertToFunctionResponse(
+      toolName,
+      callId,
+      llmContent,
+      config,
+    );
+    expect(
+      result[0]?.functionResponse?.response?.['output'] as string,
+    ).toContain('[Output truncated due to token limit]');
+  });
 });
 
 class MockEditToolInvocation extends BaseToolInvocation<

--- a/packages/core/src/core/nonInteractiveToolExecutor.ts
+++ b/packages/core/src/core/nonInteractiveToolExecutor.ts
@@ -455,6 +455,7 @@ export async function executeToolCall(
       toolCallRequest.name,
       toolCallRequest.callId,
       finalLlmContent,
+      config,
     );
 
     // Return BOTH the tool call and response as an array

--- a/packages/core/src/utils/toolOutputLimiter.ts
+++ b/packages/core/src/utils/toolOutputLimiter.ts
@@ -6,7 +6,10 @@
 
 import { encoding_for_model } from '@dqbd/tiktoken';
 import { TextDecoder } from 'node:util';
-import { Config } from '../config/config.js';
+
+export interface ToolOutputSettingsProvider {
+  getEphemeralSettings(): Record<string, unknown>;
+}
 
 // Default limits
 export const DEFAULT_MAX_TOKENS = 50000;
@@ -86,7 +89,9 @@ export interface TruncatedOutput {
 /**
  * Get output limit configuration from ephemeral settings
  */
-export function getOutputLimits(config: Config): OutputLimitConfig {
+export function getOutputLimits(
+  config: ToolOutputSettingsProvider,
+): OutputLimitConfig {
   const ephemeralSettings = config.getEphemeralSettings();
 
   return {
@@ -108,7 +113,7 @@ export function getOutputLimits(config: Config): OutputLimitConfig {
  */
 export function limitOutputTokens(
   content: string,
-  config: Config,
+  config: ToolOutputSettingsProvider,
   toolName: string,
 ): TruncatedOutput {
   const limits = getOutputLimits(config);


### PR DESCRIPTION
## Summary
- ensure convertToFunctionResponse applies the tool output limiter so history stores trimmed tool responses
- update toolOutputLimiter to accept any settings provider and wire into CLI/non-interactive paths
- add regression coverage that fails if tool outputs aren\'t trimmed before storage

## Testing
- npm run format:check
- npm run lint
- npm run typecheck
- npm run test
- npm run build
- node scripts/start.js --profile-load synthetic --prompt "just say hi"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tool outputs now support configurable token limits with automatic truncation when limits are exceeded, including a truncation indicator.

* **Tests**
  * Added test coverage for tool output token limiting and truncation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->