### PR TITLE
Fix CLI history refresh after trimming (#596)

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -146,6 +146,7 @@ import {
   toTokenMetricsSnapshot,
   type TokenMetricsSnapshot,
 } from './utils/tokenMetricsTracker.js';
+import { useStaticHistoryRefresh } from './hooks/useStaticHistoryRefresh.js';
 
 // Todo UI imports
 import { TodoPanel } from './components/TodoPanel.js';
@@ -414,6 +415,7 @@ const App = (props: AppInternalProps) => {
     stdout.write(ansiEscapes.clearTerminal);
     setStaticKey((prev) => prev + 1);
   }, [setStaticKey, stdout]);
+  useStaticHistoryRefresh(history, refreshStatic);
 
   const [llxprtMdFileCount, setLlxprtMdFileCount] = useState<number>(0);
   const [debugMessage, setDebugMessage] = useState<string>('');

--- a/packages/cli/src/ui/hooks/useStaticHistoryRefresh.test.ts
+++ b/packages/cli/src/ui/hooks/useStaticHistoryRefresh.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { HistoryItem } from '../types.js';
+import { useStaticHistoryRefresh } from './useStaticHistoryRefresh.js';
+
+const makeHistory = (...ids: number[]): HistoryItem[] =>
+  ids.map((id, index) => ({
+    id,
+    type: index % 2 === 0 ? 'user' : 'gemini',
+    text: `item-${id}`,
+  }));
+
+describe('useStaticHistoryRefresh', () => {
+  it('does not refresh when history only grows', async () => {
+    const refreshStatic = vi.fn();
+    const { rerender } = renderHook(
+      ({ history }) => useStaticHistoryRefresh(history, refreshStatic),
+      { initialProps: { history: [] as HistoryItem[] } },
+    );
+
+    rerender({ history: makeHistory(1) });
+    rerender({ history: makeHistory(1, 2, 3) });
+
+    await waitFor(() => {
+      expect(refreshStatic).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  it('refreshes when history length decreases', async () => {
+    const refreshStatic = vi.fn();
+    const { rerender } = renderHook(
+      ({ history }) => useStaticHistoryRefresh(history, refreshStatic),
+      { initialProps: { history: makeHistory(1, 2, 3, 4) } },
+    );
+
+    rerender({ history: makeHistory(3, 4) });
+
+    await waitFor(() => {
+      expect(refreshStatic).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('refreshes when the oldest id changes while length stays constant', async () => {
+    const refreshStatic = vi.fn();
+    const { rerender } = renderHook(
+      ({ history }) => useStaticHistoryRefresh(history, refreshStatic),
+      { initialProps: { history: makeHistory(10, 11, 12, 13) } },
+    );
+
+    // Simulate trimming the first item while appending a new one.
+    rerender({ history: makeHistory(11, 12, 13, 14) });
+
+    await waitFor(() => {
+      expect(refreshStatic).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/cli/src/ui/hooks/useStaticHistoryRefresh.ts
+++ b/packages/cli/src/ui/hooks/useStaticHistoryRefresh.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useEffect, useRef } from 'react';
+import type { HistoryItem } from '../types.js';
+
+/**
+ * Ensures the Ink <Static> history output stays in sync with the in-memory
+ * history when earlier items are trimmed (due to max items/bytes). Ink's
+ * Static component only appends new rows, so if items are removed we must
+ * force a full refresh so future rows render again.
+ */
+export function useStaticHistoryRefresh(
+  history: HistoryItem[],
+  refreshStatic: () => void,
+): void {
+  const previousStateRef = useRef<{
+    firstId: number | null;
+    length: number;
+  }>({
+    firstId: null,
+    length: 0,
+  });
+
+  useEffect(() => {
+    const currentFirstId = history.length > 0 ? history[0].id : null;
+    const previousState = previousStateRef.current;
+
+    const historyShrank =
+      history.length < previousState.length ||
+      (previousState.firstId !== null && currentFirstId === null) ||
+      (previousState.firstId !== null &&
+        currentFirstId !== null &&
+        currentFirstId > previousState.firstId);
+
+    if (historyShrank) {
+      refreshStatic();
+    }
+
+    previousStateRef.current = {
+      firstId: currentFirstId,
+      length: history.length,
+    };
+  }, [history, refreshStatic]);
+}


### PR DESCRIPTION
## Summary
- add a dedicated hook that watches chat history for trims and forces the Ink <Static> region to redraw
- call the hook from App so history changes after large reports continue rendering new items
- cover the regression with hook-level tests that simulate length drops and id shifts

## Testing
- npm run format:check
- npm run lint
- npm run typecheck
- npm run test
- npm run build
- node scripts/start.js --profile-load synthetic --prompt 'just say hi' *(fails with "Vitest failed to access its internal state"; reproduces on main as well)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced history management to properly refresh the CLI UI when history items are removed or changed, ensuring consistent display.

* **Tests**
  * Added comprehensive test coverage for the new history refresh logic, validating behavior for history growth, reduction, and item modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->