### PR TITLE
fix: re-enable raw mode and terminal sequences after tmux reattach (issue #263)

### DIFF
--- a/packages/cli/src/ui/hooks/useBracketedPaste.ts
+++ b/packages/cli/src/ui/hooks/useBracketedPaste.ts
@@ -5,9 +5,10 @@
  */
 
 import { useEffect } from 'react';
-
-const ENABLE_BRACKETED_PASTE = '\x1b[?2004h';
-const DISABLE_BRACKETED_PASTE = '\x1b[?2004l';
+import {
+  ENABLE_BRACKETED_PASTE,
+  DISABLE_BRACKETED_PASTE,
+} from '../utils/terminalSequences.js';
 
 /**
  * Enables and disables bracketed paste mode in the terminal.

--- a/packages/cli/src/ui/utils/terminalSequences.ts
+++ b/packages/cli/src/ui/utils/terminalSequences.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Terminal control sequences for managing terminal modes and cursor state.
+ * These sequences are used to enable/disable various terminal features and
+ * need to be re-sent after terminal resume (e.g., tmux reattach).
+ */
+
+/** Enable bracketed paste mode - terminal wraps pasted text with special sequences */
+export const ENABLE_BRACKETED_PASTE = '\x1b[?2004h';
+
+/** Disable bracketed paste mode */
+export const DISABLE_BRACKETED_PASTE = '\x1b[?2004l';
+
+/** Enable focus tracking - terminal sends sequences when window gains/loses focus */
+export const ENABLE_FOCUS_TRACKING = '\x1b[?1004h';
+
+/** Disable focus tracking */
+export const DISABLE_FOCUS_TRACKING = '\x1b[?1004l';
+
+/** Show cursor */
+export const SHOW_CURSOR = '\x1b[?25h';
+
+/** Hide cursor */
+export const HIDE_CURSOR = '\x1b[?25l';

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -23,7 +23,9 @@ const baseExcludePatterns = [
   '**/*.integration.{test,spec}.?(c|m)[jt]s?(x)',
   // Temporarily exclude ALL React DOM tests that have React 19 compatibility issues
   // This is a comprehensive exclusion until React 19 compatibility is properly resolved
+  // EXCEPT KeypressContext.test.tsx which we're actively working on for issue #263
   '**/*.test.tsx',
+  '!**/KeypressContext.test.tsx',
   '**/gemini.test.tsx',
   // Exclude UI component tests that may directly import React DOM
   '**/ui/components/**/*.test.ts',
@@ -53,7 +55,12 @@ export default defineConfig({
     },
   },
   test: {
-    include: ['**/*.{test,spec}.?(c|m)[jt]s?(x)', 'config.test.ts'],
+    include: [
+      '**/*.{test,spec}.?(c|m)[jt]s?(x)',
+      'config.test.ts',
+      // Temporarily include KeypressContext test for issue #263
+      'src/ui/contexts/KeypressContext.test.tsx',
+    ],
     exclude: baseExcludePatterns,
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary
Fixes #263 - Keyboard input stops working after tmux detach/reattach

Implements SIGCONT handler to restore terminal state after tmux detach/reattach or fg after Ctrl+Z suspend.

## Changes
- ✅ Add SIGCONT listener to re-enable raw mode and re-send terminal control sequences
- ✅ Add Ctrl+Z handler to cleanly suspend with SIGTSTP
- ✅ Extract terminal sequences to shared constants in `terminalSequences.ts`
- ✅ Add comprehensive tests for suspend/resume functionality
- ✅ Track raw mode management to avoid interfering with already-raw terminals

## Technical Details
The SIGCONT handler:
- Resumes stdin
- Re-enables raw mode (if we managed it initially)
- Re-sends bracketed paste escape sequence (`\x1b[?2004h`)
- Re-sends focus tracking escape sequence (`\x1b[?1004h`)

The Ctrl+Z handler:
- Disables raw mode
- Shows cursor (`\x1b[?25h`)
- Disables bracketed paste and focus tracking
- Sends SIGTSTP (not SIGSTOP) to suspend properly

## Test Plan
- [x] Unit tests pass (6 new tests for suspend/resume)
- [x] Lint passes
- [x] Build succeeds
- [x] Manual testing: CLI works after tmux reattach
- [ ] Manual testing in tmux by reviewer

## CodeRabbit Review
✅ CodeRabbit review completed successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved terminal suspension and reattachment handling, ensuring terminal features and cursor visibility are properly restored after suspending or reattaching the terminal.

* **Tests**
  * Added comprehensive test coverage for terminal suspend/resume scenarios.

* **Refactor**
  * Consolidated terminal control sequences into a shared utility module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->