### PR TITLE
Add Ctrl+F shortcut to toggle Todo dialog

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -74,6 +74,7 @@ Slash commands provide meta-level control over the CLI itself.
     - **`schema`**:
       - **Description:** Show the full JSON schema for the tool's configured parameters.
   - **Keyboard Shortcut:** Press **Ctrl+T** at any time to toggle between showing and hiding tool descriptions.
+  - **Keyboard Shortcut:** Press **Ctrl+F** to toggle the Todo dialog visibility.
 
 - **`/memory`**
   - **Description:** Manage the AI's instructional context (hierarchical memory loaded from `LLXPRT.md` files).

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -13,6 +13,7 @@ This document lists the available keyboard shortcuts in LLxprt Code.
 | `Ctrl+O` | Toggle the display of the debug console.                                                                              |
 | `Ctrl+S` | Allows long responses to print fully, disabling truncation. Use your terminal's scrollback to view the entire output. |
 | `Ctrl+T` | Toggle the display of tool descriptions.                                                                              |
+| `Ctrl+F` | Toggle the Todo dialog visibility.                                                                                 |
 | `Ctrl+Y` | Toggle auto-approval (YOLO mode) for all tool calls.                                                                  |
 
 ## Input Prompt

--- a/packages/cli/src/config/keyBindings.ts
+++ b/packages/cli/src/config/keyBindings.ts
@@ -47,6 +47,7 @@ export enum Command {
   // App level bindings
   SHOW_ERROR_DETAILS = 'showErrorDetails',
   TOGGLE_TOOL_DESCRIPTIONS = 'toggleToolDescriptions',
+  TOGGLE_TODO_DIALOG = 'toggleTodoDialog',
   TOGGLE_IDE_CONTEXT_DETAIL = 'toggleIDEContextDetail',
   QUIT = 'quit',
   EXIT = 'exit',
@@ -155,6 +156,7 @@ export const defaultKeyBindings: KeyBindingConfig = {
   // App level bindings
   [Command.SHOW_ERROR_DETAILS]: [{ key: 'o', ctrl: true }],
   [Command.TOGGLE_TOOL_DESCRIPTIONS]: [{ key: 't', ctrl: true }],
+  [Command.TOGGLE_TODO_DIALOG]: [{ key: 'f', ctrl: true }],
   [Command.TOGGLE_IDE_CONTEXT_DETAIL]: [{ key: 'g', ctrl: true }],
   [Command.QUIT]: [{ key: 'c', ctrl: true }],
   [Command.EXIT]: [{ key: 'd', ctrl: true }],

--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -1840,4 +1840,45 @@ describe('App UI', () => {
       expect(lastFrame()).toContain('test_tool'); // Tool status should still be visible after cancellation
     });
   });
+
+  describe('Todo Panel Toggle', () => {
+    it('should toggle the TodoPanel when Ctrl+F is pressed', async () => {
+      const { stdin, unmount, rerender } = renderWithProviders(
+        <App
+          config={mockConfig as unknown as ServerConfig}
+          settings={mockSettings}
+          version={mockVersion}
+        />,
+      );
+      currentUnmount = unmount;
+
+      // Initially visible
+      await Promise.resolve();
+      expect(mockTodoPanel).toHaveBeenCalledTimes(1);
+
+      // Press Ctrl+F to hide
+      stdin.write('\u0006'); // Ctrl+F
+      rerender(
+        <App
+          config={mockConfig as unknown as ServerConfig}
+          settings={mockSettings}
+          version={mockVersion}
+        />,
+      );
+      await Promise.resolve();
+      expect(mockTodoPanel).not.toHaveBeenCalled();
+
+      // Press Ctrl+F again to show
+      stdin.write('\u0006'); // Ctrl+F
+      rerender(
+        <App
+          config={mockConfig as unknown as ServerConfig}
+          settings={mockSettings}
+          version={mockVersion}
+        />,
+      );
+      await Promise.resolve();
+      expect(mockTodoPanel).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -440,6 +440,9 @@ const App = (props: AppInternalProps) => {
   const [showErrorDetails, setShowErrorDetails] = useState<boolean>(false);
   const [showToolDescriptions, setShowToolDescriptions] =
     useState<boolean>(false);
+  const [showTodoPanel, setShowTodoPanel] = useState<boolean>(
+    () => settings.merged.showTodoPanel ?? true,
+  );
 
   const [ctrlCPressedOnce, setCtrlCPressedOnce] = useState(false);
   const [quittingMessages, setQuittingMessages] = useState<
@@ -471,6 +474,11 @@ const App = (props: AppInternalProps) => {
     setIdeContextState(ideContext.getIdeContext());
     return unsubscribe;
   }, []);
+
+  // Update todo panel visibility when settings change.
+  useEffect(() => {
+    setShowTodoPanel(settings.merged.showTodoPanel ?? true);
+  }, [settings.merged.showTodoPanel]);
 
   // Update currentModel when settings change - get it from the SAME place as diagnostics
   useEffect(() => {
@@ -1134,6 +1142,8 @@ const App = (props: AppInternalProps) => {
         if (Object.keys(mcpServers || {}).length > 0) {
           handleSlashCommand(newValue ? '/mcp desc' : '/mcp nodesc');
         }
+      } else if (keyMatchers[Command.TOGGLE_TODO_DIALOG](key)) {
+        setShowTodoPanel((prev) => !prev);
       } else if (
         keyMatchers[Command.TOGGLE_IDE_CONTEXT_DETAIL](key) &&
         config.getIdeMode() &&
@@ -1316,7 +1326,7 @@ const App = (props: AppInternalProps) => {
     geminiClient,
   ]);
 
-  const showTodoPanelSetting = settings.merged.showTodoPanel ?? true;
+  const showTodoPanelSetting = showTodoPanel;
   const hideContextSummary = settings.merged.hideContextSummary ?? false;
 
   if (quittingMessages) {

--- a/packages/cli/src/ui/keyMatchers.test.ts
+++ b/packages/cli/src/ui/keyMatchers.test.ts
@@ -54,6 +54,7 @@ describe('keyMatchers', () => {
     [Command.SHOW_ERROR_DETAILS]: (key: Key) => key.ctrl && key.name === 'o',
     [Command.TOGGLE_TOOL_DESCRIPTIONS]: (key: Key) =>
       key.ctrl && key.name === 't',
+    [Command.TOGGLE_TODO_DIALOG]: (key: Key) => key.ctrl && key.name === 'f',
     [Command.TOGGLE_IDE_CONTEXT_DETAIL]: (key: Key) =>
       key.ctrl && key.name === 'g',
     [Command.QUIT]: (key: Key) => key.ctrl && key.name === 'c',
@@ -216,6 +217,11 @@ describe('keyMatchers', () => {
       command: Command.TOGGLE_TOOL_DESCRIPTIONS,
       positive: [createKey('t', { ctrl: true })],
       negative: [createKey('t'), createKey('s', { ctrl: true })],
+    },
+    {
+      command: Command.TOGGLE_TODO_DIALOG,
+      positive: [createKey('f', { ctrl: true })],
+      negative: [createKey('f'), createKey('t', { ctrl: true })],
     },
     {
       command: Command.TOGGLE_IDE_CONTEXT_DETAIL,


### PR DESCRIPTION
Introduces a new keyboard shortcut (Ctrl+F) to toggle the visibility of the Todo dialog in the CLI app. Updates documentation, key binding configuration, UI logic, and tests to support this feature.

Resolves #609

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut (Ctrl+F) to quickly toggle the Todo panel visibility on and off, enabling seamless task management without disrupting your workflow

* **Documentation**
  * Updated keyboard shortcuts documentation to include the new Ctrl+F toggle
  * Updated command documentation with the new keyboard shortcut reference

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->