### PR TITLE
Propagate abort signals through task launch (#619)

### DIFF
--- a/packages/core/src/runtime/AgentRuntimeLoader.ts
+++ b/packages/core/src/runtime/AgentRuntimeLoader.ts
@@ -51,6 +51,7 @@ export interface AgentRuntimeLoaderOverrides {
 export interface AgentRuntimeLoaderOptions {
   profile: AgentRuntimeProfileSnapshot;
   overrides?: AgentRuntimeLoaderOverrides;
+  signal?: AbortSignal;
 }
 
 export interface AgentRuntimeLoaderResult {
@@ -177,9 +178,15 @@ function createFilteredToolRegistryView(
 export async function loadAgentRuntime(
   options: AgentRuntimeLoaderOptions,
 ): Promise<AgentRuntimeLoaderResult> {
-  const { profile, overrides = {} } = options;
+  const { profile, overrides = {}, signal } = options;
   if (!profile) {
     throw new Error('AgentRuntimeLoader requires a profile option.');
+  }
+
+  if (signal?.aborted) {
+    const error = new Error('Runtime load aborted');
+    error.name = 'AbortError';
+    throw error;
   }
 
   const history = overrides.historyService ?? new HistoryService();


### PR DESCRIPTION
## Summary
- wire AbortSignal from task tool into orchestrator launch and treat aborts as cancellation during startup
- add abort checks in orchestrator/runtime assembly and pass parent signal into SubAgentScope so cancellation reaches active runs
- cover launch cancellation with new unit tests for TaskTool and SubagentOrchestrator

## Testing
- npm run format:check
- npm run lint
- npm run typecheck
- npm run test
- npm run build
- node scripts/start.js --profile-load synthetic --prompt "just say hi"

Fixes #619

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added abort signal support for cancelling subagent operations in progress, with proper resource cleanup and error handling across all execution stages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->