### PR TITLE
fix: add missing getMessageBus and getPolicyEngine methods to subagent scheduler config #644

### DIFF
--- a/packages/core/src/core/subagent.ts
+++ b/packages/core/src/core/subagent.ts
@@ -1291,6 +1291,8 @@ export class SubAgentScope {
         typeof this.config.getApprovalMode === 'function'
           ? this.config.getApprovalMode()
           : ApprovalMode.DEFAULT,
+      getMessageBus: () => this.config.getMessageBus(),
+      getPolicyEngine: () => this.config.getPolicyEngine(),
     } as unknown as Config;
   }
 


### PR DESCRIPTION
## Summary
Fixes #644 - Subagents now launch successfully by adding missing `getMessageBus()` and `getPolicyEngine()` methods to the scheduler config.

## Problem
Subagents were failing to launch with the error `this.config.getMessageBus is not a function`. This occurred because the `createSchedulerConfig()` method in `packages/core/src/core/subagent.ts` was creating a partial `Config` object that was missing the `getMessageBus()` and `getPolicyEngine()` methods required by `CoreToolScheduler`.

## Solution
Added the missing methods to the partial `Config` object returned by `createSchedulerConfig()`:
- `getMessageBus: () => this.config.getMessageBus()`
- `getPolicyEngine: () => this.config.getPolicyEngine()`

These methods delegate to the actual `foregroundConfig` passed to the SubAgentScope during creation.

## Changes
- Modified `packages/core/src/core/subagent.ts:1294-1295` to include the two missing methods

## Testing
- All tests pass (npm run test:ci)
- Lint and format checks pass
- Build and bundle successful

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced scheduler configuration with improved access to core runtime components, enabling more flexible scheduling operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->