### PR TITLE
fix: context limit not updating after profile load or settings change

### DIFF
--- a/packages/core/src/runtime/createAgentRuntimeContext.test.ts
+++ b/packages/core/src/runtime/createAgentRuntimeContext.test.ts
@@ -1,0 +1,429 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createAgentRuntimeContext } from './createAgentRuntimeContext.js';
+import type {
+  AgentRuntimeContextFactoryOptions,
+  ReadonlySettingsSnapshot,
+  AgentRuntimeProviderAdapter,
+  AgentRuntimeTelemetryAdapter,
+  ToolRegistryView,
+} from './AgentRuntimeContext.js';
+import type { AgentRuntimeState } from './AgentRuntimeState.js';
+import type { ProviderRuntimeContext } from './providerRuntimeContext.js';
+import type { IProvider } from '../providers/IProvider.js';
+
+describe('createAgentRuntimeContext', () => {
+  let mockProvider: IProvider;
+  let mockProviderAdapter: AgentRuntimeProviderAdapter;
+  let mockTelemetryAdapter: AgentRuntimeTelemetryAdapter;
+  let mockToolsView: ToolRegistryView;
+  let mockProviderRuntime: ProviderRuntimeContext;
+  let mockState: AgentRuntimeState;
+  let settings: ReadonlySettingsSnapshot;
+
+  beforeEach(() => {
+    // Mock provider
+    mockProvider = {
+      name: 'test-provider',
+      makeRequest: vi.fn(),
+    } as unknown as IProvider;
+
+    // Mock provider adapter
+    mockProviderAdapter = {
+      getActiveProvider: vi.fn().mockReturnValue(mockProvider),
+      setActiveProvider: vi.fn(),
+    };
+
+    // Mock telemetry adapter
+    mockTelemetryAdapter = {
+      logApiRequest: vi.fn(),
+      logApiResponse: vi.fn(),
+      logApiError: vi.fn(),
+    };
+
+    // Mock tools view
+    mockToolsView = {
+      listToolNames: vi.fn().mockReturnValue([]),
+      getToolMetadata: vi.fn(),
+    };
+
+    // Mock provider runtime
+    mockProviderRuntime = {
+      provider: 'test-provider',
+      model: 'gemini-2.0-flash',
+      authType: 'api-key',
+      sessionId: 'test-session',
+      runtimeId: 'test-runtime',
+    };
+
+    // Mock state
+    mockState = {
+      provider: 'test-provider',
+      model: 'gemini-2.0-flash',
+      authType: 'api-key',
+      sessionId: 'test-session',
+      runtimeId: 'test-runtime',
+    };
+
+    // Initial settings
+    settings = {
+      contextLimit: 50000,
+      compressionThreshold: 0.7,
+      preserveThreshold: 0.3,
+    };
+  });
+
+  describe('validation', () => {
+    it('should throw if provider is missing', () => {
+      const options: AgentRuntimeContextFactoryOptions = {
+        state: mockState,
+        settings,
+        provider: undefined as unknown as AgentRuntimeProviderAdapter,
+        telemetry: mockTelemetryAdapter,
+        tools: mockToolsView,
+        providerRuntime: mockProviderRuntime,
+      };
+
+      expect(() => createAgentRuntimeContext(options)).toThrow(
+        'AgentRuntimeContext requires a provider adapter',
+      );
+    });
+
+    it('should throw if telemetry is missing', () => {
+      const options: AgentRuntimeContextFactoryOptions = {
+        state: mockState,
+        settings,
+        provider: mockProviderAdapter,
+        telemetry: undefined as unknown as AgentRuntimeTelemetryAdapter,
+        tools: mockToolsView,
+        providerRuntime: mockProviderRuntime,
+      };
+
+      expect(() => createAgentRuntimeContext(options)).toThrow(
+        'AgentRuntimeContext requires a telemetry adapter',
+      );
+    });
+
+    it('should throw if tools is missing', () => {
+      const options: AgentRuntimeContextFactoryOptions = {
+        state: mockState,
+        settings,
+        provider: mockProviderAdapter,
+        telemetry: mockTelemetryAdapter,
+        tools: undefined as unknown as ToolRegistryView,
+        providerRuntime: mockProviderRuntime,
+      };
+
+      expect(() => createAgentRuntimeContext(options)).toThrow(
+        'AgentRuntimeContext requires a tools view',
+      );
+    });
+
+    it('should throw if providerRuntime is missing', () => {
+      const options: AgentRuntimeContextFactoryOptions = {
+        state: mockState,
+        settings,
+        provider: mockProviderAdapter,
+        telemetry: mockTelemetryAdapter,
+        tools: mockToolsView,
+        providerRuntime: undefined as unknown as ProviderRuntimeContext,
+      };
+
+      expect(() => createAgentRuntimeContext(options)).toThrow(
+        'AgentRuntimeContext requires a provider runtime context',
+      );
+    });
+  });
+
+  describe('ephemerals.contextLimit()', () => {
+    it('should return initial context limit from settings', () => {
+      const options: AgentRuntimeContextFactoryOptions = {
+        state: mockState,
+        settings,
+        provider: mockProviderAdapter,
+        telemetry: mockTelemetryAdapter,
+        tools: mockToolsView,
+        providerRuntime: mockProviderRuntime,
+      };
+
+      const context = createAgentRuntimeContext(options);
+      expect(context.ephemerals.contextLimit()).toBe(50000);
+    });
+
+    it('should use model default when contextLimit is not set', () => {
+      const settingsWithoutLimit: ReadonlySettingsSnapshot = {
+        compressionThreshold: 0.7,
+      };
+
+      const options: AgentRuntimeContextFactoryOptions = {
+        state: mockState,
+        settings: settingsWithoutLimit,
+        provider: mockProviderAdapter,
+        telemetry: mockTelemetryAdapter,
+        tools: mockToolsView,
+        providerRuntime: mockProviderRuntime,
+      };
+
+      const context = createAgentRuntimeContext(options);
+      // gemini-2.0-flash has a default of 1_048_576
+      expect(context.ephemerals.contextLimit()).toBe(1_048_576);
+    });
+
+    it('should return live context limit when settings change (fix for issue #602)', () => {
+      // Create mutable settings object to simulate settings changes
+      const mutableSettings: ReadonlySettingsSnapshot = {
+        contextLimit: 50000,
+        compressionThreshold: 0.7,
+      };
+
+      const options: AgentRuntimeContextFactoryOptions = {
+        state: mockState,
+        settings: mutableSettings,
+        provider: mockProviderAdapter,
+        telemetry: mockTelemetryAdapter,
+        tools: mockToolsView,
+        providerRuntime: mockProviderRuntime,
+      };
+
+      const context = createAgentRuntimeContext(options);
+
+      // Verify initial context limit
+      expect(context.ephemerals.contextLimit()).toBe(50000);
+
+      // Simulate profile load or context-limit change by mutating the settings object
+      mutableSettings.contextLimit = 100000;
+
+      // THIS IS THE KEY TEST: contextLimit should return the NEW value
+      expect(context.ephemerals.contextLimit()).toBe(100000);
+    });
+
+    it('should handle invalid context limit values and fall back to model default', () => {
+      const mutableSettings: ReadonlySettingsSnapshot = {
+        contextLimit: 50000,
+      };
+
+      const options: AgentRuntimeContextFactoryOptions = {
+        state: mockState,
+        settings: mutableSettings,
+        provider: mockProviderAdapter,
+        telemetry: mockTelemetryAdapter,
+        tools: mockToolsView,
+        providerRuntime: mockProviderRuntime,
+      };
+
+      const context = createAgentRuntimeContext(options);
+      expect(context.ephemerals.contextLimit()).toBe(50000);
+
+      // Test invalid values
+      mutableSettings.contextLimit = 0;
+      expect(context.ephemerals.contextLimit()).toBe(1_048_576);
+
+      mutableSettings.contextLimit = -1000;
+      expect(context.ephemerals.contextLimit()).toBe(1_048_576);
+
+      mutableSettings.contextLimit = NaN;
+      expect(context.ephemerals.contextLimit()).toBe(1_048_576);
+
+      mutableSettings.contextLimit = Infinity;
+      expect(context.ephemerals.contextLimit()).toBe(1_048_576);
+
+      // Test back to valid value
+      mutableSettings.contextLimit = 75000;
+      expect(context.ephemerals.contextLimit()).toBe(75000);
+    });
+
+    it('should handle different model context limits', () => {
+      const gpt4State: AgentRuntimeState = {
+        ...mockState,
+        model: 'gpt-4o',
+      };
+
+      const gpt4ProviderRuntime: ProviderRuntimeContext = {
+        ...mockProviderRuntime,
+        model: 'gpt-4o',
+      };
+
+      const mutableSettings: ReadonlySettingsSnapshot = {};
+
+      const options: AgentRuntimeContextFactoryOptions = {
+        state: gpt4State,
+        settings: mutableSettings,
+        provider: mockProviderAdapter,
+        telemetry: mockTelemetryAdapter,
+        tools: mockToolsView,
+        providerRuntime: gpt4ProviderRuntime,
+      };
+
+      const context = createAgentRuntimeContext(options);
+      // gpt-4o has default of 128_000
+      expect(context.ephemerals.contextLimit()).toBe(128_000);
+
+      // Override should work
+      mutableSettings.contextLimit = 50000;
+      expect(context.ephemerals.contextLimit()).toBe(50000);
+    });
+  });
+
+  describe('ephemerals other properties', () => {
+    it('should return compression threshold with fallback', () => {
+      const options: AgentRuntimeContextFactoryOptions = {
+        state: mockState,
+        settings: { compressionThreshold: 0.9 },
+        provider: mockProviderAdapter,
+        telemetry: mockTelemetryAdapter,
+        tools: mockToolsView,
+        providerRuntime: mockProviderRuntime,
+      };
+
+      const context = createAgentRuntimeContext(options);
+      expect(context.ephemerals.compressionThreshold()).toBe(0.9);
+    });
+
+    it('should use default compression threshold when not set', () => {
+      const options: AgentRuntimeContextFactoryOptions = {
+        state: mockState,
+        settings: {},
+        provider: mockProviderAdapter,
+        telemetry: mockTelemetryAdapter,
+        tools: mockToolsView,
+        providerRuntime: mockProviderRuntime,
+      };
+
+      const context = createAgentRuntimeContext(options);
+      expect(context.ephemerals.compressionThreshold()).toBe(0.8);
+    });
+
+    it('should return preserve threshold with fallback', () => {
+      const options: AgentRuntimeContextFactoryOptions = {
+        state: mockState,
+        settings: { preserveThreshold: 0.15 },
+        provider: mockProviderAdapter,
+        telemetry: mockTelemetryAdapter,
+        tools: mockToolsView,
+        providerRuntime: mockProviderRuntime,
+      };
+
+      const context = createAgentRuntimeContext(options);
+      expect(context.ephemerals.preserveThreshold()).toBe(0.15);
+    });
+
+    it('should use default preserve threshold when not set', () => {
+      const options: AgentRuntimeContextFactoryOptions = {
+        state: mockState,
+        settings: {},
+        provider: mockProviderAdapter,
+        telemetry: mockTelemetryAdapter,
+        tools: mockToolsView,
+        providerRuntime: mockProviderRuntime,
+      };
+
+      const context = createAgentRuntimeContext(options);
+      expect(context.ephemerals.preserveThreshold()).toBe(0.2);
+    });
+
+    it('should return tool format override when set', () => {
+      const options: AgentRuntimeContextFactoryOptions = {
+        state: mockState,
+        settings: { toolFormatOverride: 'custom-format' },
+        provider: mockProviderAdapter,
+        telemetry: mockTelemetryAdapter,
+        tools: mockToolsView,
+        providerRuntime: mockProviderRuntime,
+      };
+
+      const context = createAgentRuntimeContext(options);
+      expect(context.ephemerals.toolFormatOverride()).toBe('custom-format');
+    });
+
+    it('should return undefined for tool format override when not set', () => {
+      const options: AgentRuntimeContextFactoryOptions = {
+        state: mockState,
+        settings: {},
+        provider: mockProviderAdapter,
+        telemetry: mockTelemetryAdapter,
+        tools: mockToolsView,
+        providerRuntime: mockProviderRuntime,
+      };
+
+      const context = createAgentRuntimeContext(options);
+      expect(context.ephemerals.toolFormatOverride()).toBeUndefined();
+    });
+  });
+
+  describe('context immutability', () => {
+    it('should freeze the returned context', () => {
+      const options: AgentRuntimeContextFactoryOptions = {
+        state: mockState,
+        settings,
+        provider: mockProviderAdapter,
+        telemetry: mockTelemetryAdapter,
+        tools: mockToolsView,
+        providerRuntime: mockProviderRuntime,
+      };
+
+      const context = createAgentRuntimeContext(options);
+      expect(Object.isFrozen(context)).toBe(true);
+    });
+
+    it('should freeze provider runtime metadata', () => {
+      const runtimeWithMetadata: ProviderRuntimeContext = {
+        ...mockProviderRuntime,
+        metadata: { custom: 'value' },
+      };
+
+      const options: AgentRuntimeContextFactoryOptions = {
+        state: mockState,
+        settings,
+        provider: mockProviderAdapter,
+        telemetry: mockTelemetryAdapter,
+        tools: mockToolsView,
+        providerRuntime: runtimeWithMetadata,
+      };
+
+      const context = createAgentRuntimeContext(options);
+      expect(Object.isFrozen(context.providerRuntime)).toBe(true);
+      expect(Object.isFrozen(context.providerRuntime.metadata)).toBe(true);
+    });
+  });
+
+  describe('history service', () => {
+    it('should use provided history service', () => {
+      const mockHistory = {
+        addMessage: vi.fn(),
+        getHistory: vi.fn(),
+      } as unknown as import('../services/history/HistoryService.js').HistoryService;
+
+      const options: AgentRuntimeContextFactoryOptions = {
+        state: mockState,
+        settings,
+        provider: mockProviderAdapter,
+        telemetry: mockTelemetryAdapter,
+        tools: mockToolsView,
+        providerRuntime: mockProviderRuntime,
+        history: mockHistory,
+      };
+
+      const context = createAgentRuntimeContext(options);
+      expect(context.history).toBe(mockHistory);
+    });
+
+    it('should create new history service when not provided', () => {
+      const options: AgentRuntimeContextFactoryOptions = {
+        state: mockState,
+        settings,
+        provider: mockProviderAdapter,
+        telemetry: mockTelemetryAdapter,
+        tools: mockToolsView,
+        providerRuntime: mockProviderRuntime,
+      };
+
+      const context = createAgentRuntimeContext(options);
+      expect(context.history).toBeDefined();
+    });
+  });
+});

--- a/packages/core/src/runtime/createAgentRuntimeContext.ts
+++ b/packages/core/src/runtime/createAgentRuntimeContext.ts
@@ -52,23 +52,19 @@ export function createAgentRuntimeContext(
 
   const history = options.history ?? new HistoryService();
 
-  const contextLimitOverride =
-    typeof options.settings.contextLimit === 'number' &&
-    Number.isFinite(options.settings.contextLimit) &&
-    options.settings.contextLimit > 0
-      ? options.settings.contextLimit
-      : undefined;
-
-  const resolvedContextLimit = tokenLimit(
-    options.state.model,
-    contextLimitOverride,
-  );
-
   const ephemerals = {
     compressionThreshold: (): number =>
       options.settings.compressionThreshold ??
       EPHEMERAL_DEFAULTS.compressionThreshold,
-    contextLimit: (): number => resolvedContextLimit,
+    contextLimit: (): number => {
+      const liveOverride =
+        typeof options.settings.contextLimit === 'number' &&
+        Number.isFinite(options.settings.contextLimit) &&
+        options.settings.contextLimit > 0
+          ? options.settings.contextLimit
+          : undefined;
+      return tokenLimit(options.state.model, liveOverride);
+    },
     preserveThreshold: (): number =>
       options.settings.preserveThreshold ??
       EPHEMERAL_DEFAULTS.preserveThreshold,


### PR DESCRIPTION
## Summary

Fixes #602 - Token guard context limit doesn't update after profile load, model switch, or `/set context-limit` commands.

### Root Cause
The `contextLimit()` function in `createAgentRuntimeContext.ts` was capturing the computed context limit at runtime context creation time and returning this frozen value. Since the `AgentRuntimeContext` is created once and then frozen with `Object.freeze()`, any subsequent settings changes had no effect on the token guard.

### Fix
Changed `ephemerals.contextLimit()` to compute the value dynamically from `options.settings` on each call instead of returning a pre-computed frozen value. The settings object is passed by reference, so mutations (from profile load, `/set`, or model switch) are now properly visible.

### Changes
- **`packages/core/src/runtime/createAgentRuntimeContext.ts`**: Modified `contextLimit()` to read live from settings
- **`packages/core/src/runtime/createAgentRuntimeContext.test.ts`**: Added 19 comprehensive tests covering:
  - Initial value computation
  - Live updates after settings mutation
  - Invalid value handling (null, negative, zero)
  - Model default fallbacks
  - Context immutability

## Test plan
- [x] All unit tests pass (5,769 tests)
- [x] Lint/typecheck/build pass
- [x] Scratch test with haiku prompt works
- [ ] Manual test: Run `/profile load <profile-with-different-context-limit>` and verify token guard uses new limit
- [ ] Manual test: Run `/set context-limit 50000` and verify change takes effect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for runtime context validation, configuration handling, and immutability guarantees.

* **Refactor**
  * Updated context limit computation to be evaluated dynamically at access time rather than during initialization, enabling responsive runtime configuration updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->