### PR TITLE
feat: add Claude Opus 4.5 models to AnthropicProvider

### DIFF
--- a/packages/core/src/providers/anthropic/AnthropicProvider.test.ts
+++ b/packages/core/src/providers/anthropic/AnthropicProvider.test.ts
@@ -340,6 +340,48 @@ describe('AnthropicProvider', () => {
       });
     });
 
+    it('should include Claude Opus 4.5 models in OAuth model list', async () => {
+      // Create provider with OAuth token to get the OAuth-specific model list
+      const oauthProvider = new AnthropicProvider(
+        'sk-ant-oat-test-token',
+        undefined,
+        TEST_PROVIDER_CONFIG,
+      );
+
+      // Mock getAuthToken to return the OAuth token
+      vi.spyOn(oauthProvider, 'getAuthToken').mockResolvedValue(
+        'sk-ant-oat-test-token',
+      );
+
+      const models = await oauthProvider.getModels();
+      const modelIds = models.map((m) => m.id);
+
+      // Verify Claude Opus 4.5 dated model is present
+      expect(modelIds).toContain('claude-opus-4-5-20251101');
+
+      // Verify Claude Opus 4.5 rolling alias is present
+      expect(modelIds).toContain('claude-opus-4-5');
+
+      // Verify the models have correct properties
+      const opus45Dated = models.find(
+        (m) => m.id === 'claude-opus-4-5-20251101',
+      );
+      expect(opus45Dated).toBeDefined();
+      expect(opus45Dated?.name).toBe('Claude Opus 4.5');
+      expect(opus45Dated?.provider).toBe('anthropic');
+      expect(opus45Dated?.supportedToolFormats).toContain('anthropic');
+      expect(opus45Dated?.contextWindow).toBe(500000);
+      expect(opus45Dated?.maxOutputTokens).toBe(32000);
+
+      const opus45Alias = models.find((m) => m.id === 'claude-opus-4-5');
+      expect(opus45Alias).toBeDefined();
+      expect(opus45Alias?.name).toBe('Claude Opus 4.5');
+      expect(opus45Alias?.provider).toBe('anthropic');
+      expect(opus45Alias?.supportedToolFormats).toContain('anthropic');
+      expect(opus45Alias?.contextWindow).toBe(500000);
+      expect(opus45Alias?.maxOutputTokens).toBe(32000);
+    });
+
     it('should return models with correct structure', async () => {
       const models = await provider.getModels();
 

--- a/packages/core/src/providers/anthropic/AnthropicProvider.ts
+++ b/packages/core/src/providers/anthropic/AnthropicProvider.ts
@@ -276,6 +276,22 @@ export class AnthropicProvider extends BaseProvider {
       );
       return [
         {
+          id: 'claude-opus-4-5-20251101',
+          name: 'Claude Opus 4.5',
+          provider: 'anthropic',
+          supportedToolFormats: ['anthropic'],
+          contextWindow: 500000,
+          maxOutputTokens: 32000,
+        },
+        {
+          id: 'claude-opus-4-5',
+          name: 'Claude Opus 4.5',
+          provider: 'anthropic',
+          supportedToolFormats: ['anthropic'],
+          contextWindow: 500000,
+          maxOutputTokens: 32000,
+        },
+        {
           id: 'claude-opus-4-1-20250805',
           name: 'Claude Opus 4.1',
           provider: 'anthropic',
@@ -410,6 +426,14 @@ export class AnthropicProvider extends BaseProvider {
    */
   private getDefaultModels(): IModel[] {
     return [
+      {
+        id: 'claude-opus-4-5-20251101',
+        name: 'Claude Opus 4.5',
+        provider: 'anthropic',
+        supportedToolFormats: ['anthropic'],
+        contextWindow: 500000,
+        maxOutputTokens: 32000,
+      },
       {
         id: 'claude-opus-4-1-20250805',
         name: 'Claude Opus 4.1',


### PR DESCRIPTION
## Summary
- Add Claude Opus 4.5 models (`claude-opus-4-5-20251101` and `claude-opus-4-5`) to the Anthropic provider
- Update OAuth model list and default models list
- Add test coverage for the new models

Closes #663

## Test plan
- [x] Added new test verifying Claude Opus 4.5 models in OAuth model list
- [x] All existing AnthropicProvider tests pass (39 tests)
- [x] Full test suite passes
- [x] Lint and typecheck pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claude Opus 4.5 models with both stable dated and rolling alias versions, featuring a 500,000-token context window and 32,000-token maximum output capacity. Available through OAuth authentication and as default selections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->