### PR TITLE
Fix InputPrompt vertical alignment by removing unnecessary margin

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -858,7 +858,6 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           )}
         </Text>
         <Box
-          marginTop={1}
           flexDirection="column"
           width={inputWidth + 6} // 6 = FRAME_OVERHEAD (4) + PADDING (2)
           ref={innerBoxRef}


### PR DESCRIPTION
## TLDR

Fixes a visual misalignment where the input prompt `> ` was positioned higher than the user input text.


## Dive Deeper

The InputPrompt component had a `marginTop={1}` on the `Box` wrapping the input content, which caused the input text to be offset vertically relative to the prompt character. Removing this margin aligns the prompt and the input text on the same line.

## Reviewer Test Plan

1. Run the CLI (`npm start` or `llxprt`).
2. Type some text into the input field.
3. Verify that the `> ` prompt and the typed text are horizontally aligned.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | 🍏  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

None



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reduced vertical spacing around input fields for a more compact layout appearance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->