### PR TITLE
fix(tmux): trigger UI refresh on SIGCONT to restore prompt after reattach

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -1027,6 +1027,11 @@ export function KeypressProvider({
       process.stdout.write(ENABLE_BRACKETED_PASTE);
       process.stdout.write(ENABLE_FOCUS_TRACKING);
       enableSupportedProtocol();
+
+      // Trigger a refresh to ensure the UI re-renders with proper prompt state
+      // This is necessary because tmux reattach can cause the terminal to lose
+      // the current display state, including the prompt text and cursor position
+      setRefreshGeneration((prev) => prev + 1);
     };
 
     process.on('SIGCONT', handleSigcont);


### PR DESCRIPTION
## Summary

Fixes a regression where the prompt is lost when a tmux session reconnects. This was originally fixed in PR #613 for issue #263, but a recent change caused a regression.

## Problem

When tmux detaches and reattaches, the terminal state is reset. The SIGCONT handler was already:
- Resuming stdin
- Re-enabling raw mode
- Re-sending terminal control sequences (bracketed paste, focus tracking)
- Re-enabling kitty protocol if supported

However, the **React UI wasn't re-rendering**, causing the prompt text and cursor position to be lost.

## Solution

Added `setRefreshGeneration((prev) => prev + 1)` to the SIGCONT handler in `KeypressContext.tsx`. This increments the refresh generation counter which triggers the useEffect to re-run, causing the UI to properly refresh after tmux reattach.

## Changes

1. **KeypressContext.tsx**: Added `setRefreshGeneration()` call to the `handleSigcont` function
2. **KeypressContext.test.tsx**: 
   - Added new test "should trigger refresh to re-render UI on SIGCONT"
   - Fixed existing test that had double-escaped escape sequences

## Testing

- All Suspend/Resume tests pass (7 tests)
- Full test suite passes
- Lint, typecheck, format, build all pass

Fixes #263

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal session resume now correctly refreshes the UI to reflect the current prompt state.

* **Tests**
  * Added test coverage for UI refresh behavior on terminal resume events.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->