### PR TITLE
fix(version): bump to 0.7.0 and update sandboxImageUri #715

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vybestack/llxprt-code",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vybestack/llxprt-code",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"
@@ -18075,7 +18075,7 @@
     },
     "packages/cli": {
       "name": "@vybestack/llxprt-code",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.1",
         "@dqbd/tiktoken": "^1.0.21",
@@ -18368,7 +18368,7 @@
     },
     "packages/core": {
       "name": "@vybestack/llxprt-code-core",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "dependencies": {
         "@ai-sdk/openai": "^2.0.74",
         "@anthropic-ai/sdk": "^0.55.1",
@@ -18526,7 +18526,7 @@
     },
     "packages/test-utils": {
       "name": "@vybestack/llxprt-code-test-utils",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.3.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vybestack/llxprt-code",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "engines": {
     "node": ">=20"
   },
@@ -14,7 +14,7 @@
     "url": "git+https://github.com/vybestack/llxprt-code.git"
   },
   "config": {
-    "sandboxImageUri": "ghcr.io/vybestack/llxprt-code/sandbox:0.5.0"
+    "sandboxImageUri": "ghcr.io/vybestack/llxprt-code/sandbox:0.7.0"
   },
   "scripts": {
     "start": "cross-env NODE_ENV=development node scripts/start.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vybestack/llxprt-code",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "LLxprt Code",
   "repository": {
     "type": "git",
@@ -33,7 +33,7 @@
     "dist"
   ],
   "config": {
-    "sandboxImageUri": "ghcr.io/vybestack/llxprt-code/sandbox:0.5.0"
+    "sandboxImageUri": "ghcr.io/vybestack/llxprt-code/sandbox:0.7.0"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.55.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vybestack/llxprt-code-core",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "LLxprt Code Core",
   "repository": {
     "type": "git",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vybestack/llxprt-code-test-utils",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "private": true,
   "main": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
- Bump all package versions from 0.6.1 to 0.7.0
- Update sandboxImageUri from 0.5.0 to 0.7.0 in both root and cli package.json files
- This ensures E2E sandbox tests pull the correct container image version

## Root Cause
The sandboxImageUri configuration was not updated when the project version was previously bumped, causing E2E tests to reference an outdated sandbox image.

## Changes
- `package.json`: version 0.6.1 → 0.7.0, sandboxImageUri 0.5.0 → 0.7.0
- `packages/cli/package.json`: version 0.6.1 → 0.7.0, sandboxImageUri 0.5.0 → 0.7.0
- `packages/core/package.json`: version 0.6.1 → 0.7.0
- `packages/test-utils/package.json`: version 0.6.1 → 0.7.0
- `package-lock.json`: regenerated with updated versions

## Test Plan
- [x] All unit tests pass (`npm run test:ci`)
- [x] Lint passes with zero warnings (`npm run lint:ci`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build && npm run bundle`)
- [x] Formatting check passes (`npm run format`)

Closes #715

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.7.0 with infrastructure updates across all packages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->