### PR TITLE
fix(gemini): enable Gemini 3.x thinking blocks with correct ThinkingConfig #595

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@
 ## logging
 
 - We have a whole sophisticated logging system you designed do not use console.out or debug -- use our debug logging system
+- The log files are written to ~/.llxprt/debug/ - do not look for them in stderr or stdout
 
 ## Linting and Formatting
 
@@ -98,14 +99,6 @@ Task(
 
 NEVER include the Claude commit signature/co-authorship.
 
-**Do NOT add:**
-
-```
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-```
-
 ## Code Verification and Deployment Rules
 
 ### Never Declare Done Without Full Verification
@@ -124,14 +117,12 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 
 Run these checks in this exact order to match GitHub Actions CI:
 
-1. `npm run format:check` - Ensure all files are formatted
-2. `npm run lint:ci` - Zero warnings allowed (eslint with --max-warnings 0)
-3. `npx eslint integration-tests --max-warnings 0` - Integration tests lint
-4. `npx prettier --check integration-tests` - Integration tests format
-5. `npm run typecheck` - Type safety check
-6. `npm run build` - Build all packages
-7. `npm run bundle` - Create bundle
-8. `npm run test:ci` - Run all tests with CI configuration
+1. `npm run lint:ci` - Zero warnings allowed (eslint with --max-warnings 0)
+2. `npm run typecheck` - Type safety check
+3. `npm run format`
+4. `npm run build` - Build all packages
+5. `npm run bundle` - Create bundle
+6. `node scripts/start.js --profile-load synthetic --prompt "write me a haiku"`
 
 For shell scripts:
 

--- a/packages/cli/src/ui/commands/setCommand.ts
+++ b/packages/cli/src/ui/commands/setCommand.ts
@@ -193,6 +193,67 @@ const directSettingSpecs: SettingLiteralSpec[] = [
     value: 'retrywait',
     hint: 'positive integer in milliseconds (e.g., 1000)',
   },
+  // Reasoning/thinking settings
+  {
+    value: 'reasoning.enabled',
+    hint: 'true or false',
+    description: 'Show AI thinking process (Claude, Gemini 3, DeepSeek, etc)',
+    options: booleanOptions,
+  },
+  {
+    value: 'reasoning.includeInContext',
+    hint: 'true or false',
+    description:
+      'Send thinking to API on follow-up requests (uses more tokens)',
+    options: booleanOptions,
+  },
+  {
+    value: 'reasoning.includeInResponse',
+    hint: 'true or false',
+    description: 'Display thinking blocks in the UI',
+    options: booleanOptions,
+  },
+  {
+    value: 'reasoning.format',
+    hint: 'native or field',
+    description: 'API format: native=provider default, field=reasoning_content',
+    options: [
+      { value: 'native', description: 'Use provider default format' },
+      {
+        value: 'field',
+        description: 'Use reasoning_content field (OpenAI style)',
+      },
+    ],
+  },
+  {
+    value: 'reasoning.stripFromContext',
+    hint: 'all, allButLast, or none',
+    description: 'Control thinking in history sent to API',
+    options: [
+      {
+        value: 'all',
+        description: 'Remove all thinking from history (saves tokens)',
+      },
+      { value: 'allButLast', description: 'Keep only most recent thinking' },
+      { value: 'none', description: 'Keep all thinking in history' },
+    ],
+  },
+  {
+    value: 'reasoning.effort',
+    hint: 'minimal, low, medium, or high',
+    description: 'How much the AI should think before responding',
+    options: [
+      { value: 'minimal', description: 'Quick responses, less deliberation' },
+      { value: 'low', description: 'Light thinking for simple tasks' },
+      { value: 'medium', description: 'Balanced thinking for most tasks' },
+      { value: 'high', description: 'Deep thinking for complex problems' },
+    ],
+  },
+  {
+    value: 'reasoning.maxTokens',
+    hint: 'positive integer (e.g., 8000)',
+    description: 'Cap on thinking tokens (limits thinking length)',
+  },
 ];
 
 const createSettingLiteral = (spec: SettingLiteralSpec): LiteralArgument => ({

--- a/packages/core/src/providers/gemini/__tests__/gemini.thoughtSignature.test.ts
+++ b/packages/core/src/providers/gemini/__tests__/gemini.thoughtSignature.test.ts
@@ -1,0 +1,442 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { Part } from '@google/genai';
+import {
+  ensureActiveLoopHasThoughtSignatures,
+  stripThoughtsFromHistory,
+  SYNTHETIC_THOUGHT_SIGNATURE,
+} from '../thoughtSignatures.js';
+
+/**
+ * Tests for Gemini 3.x thought signature handling.
+ *
+ * Gemini 3.x models require that functionCall parts in the "active loop"
+ * have a thoughtSignature property. The active loop is defined as all
+ * content from the last user message with text to the end of the history.
+ *
+ * See: https://ai.google.dev/gemini-api/docs/thought-signatures
+ */
+describe('ensureActiveLoopHasThoughtSignatures', () => {
+  interface Content {
+    role: string;
+    parts: Part[];
+  }
+
+  it('should add thoughtSignature to the first functionCall in each model turn of the active loop', () => {
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'Old message' }] },
+      {
+        role: 'model',
+        parts: [{ functionCall: { name: 'old_tool', args: {} } }],
+      },
+      // Start of active loop (last user text message)
+      { role: 'user', parts: [{ text: 'New message' }] },
+      {
+        role: 'model',
+        parts: [
+          { functionCall: { name: 'tool1', args: {} } },
+          { functionCall: { name: 'tool2', args: {} } },
+        ],
+      },
+      {
+        role: 'user',
+        parts: [{ functionResponse: { name: 'tool1', response: {} } }],
+      },
+      {
+        role: 'model',
+        parts: [
+          {
+            functionCall: { name: 'tool_with_sig', args: {} },
+            thoughtSignature: 'existing-sig',
+          } as Part,
+          { functionCall: { name: 'another_tool', args: {} } },
+        ],
+      },
+    ];
+
+    const newContents = ensureActiveLoopHasThoughtSignatures(history);
+
+    // Outside active loop - unchanged
+    expect(
+      (newContents[1]?.parts?.[0] as Part & { thoughtSignature?: string })
+        ?.thoughtSignature,
+    ).toBeUndefined();
+
+    // Inside active loop, first model turn
+    // First function call gets a signature
+    expect(
+      (newContents[3]?.parts?.[0] as Part & { thoughtSignature?: string })
+        ?.thoughtSignature,
+    ).toBe(SYNTHETIC_THOUGHT_SIGNATURE);
+    // Second function call does NOT get a signature
+    expect(
+      (newContents[3]?.parts?.[1] as Part & { thoughtSignature?: string })
+        ?.thoughtSignature,
+    ).toBeUndefined();
+
+    // User functionResponse part - unchanged (this is not a model turn)
+    expect(
+      (newContents[4]?.parts?.[0] as Part & { thoughtSignature?: string })
+        ?.thoughtSignature,
+    ).toBeUndefined();
+
+    // Inside active loop, second model turn
+    // First function call already has a signature, so it's preserved
+    expect(
+      (newContents[5]?.parts?.[0] as Part & { thoughtSignature?: string })
+        ?.thoughtSignature,
+    ).toBe('existing-sig');
+    // Second function call does NOT get a signature
+    expect(
+      (newContents[5]?.parts?.[1] as Part & { thoughtSignature?: string })
+        ?.thoughtSignature,
+    ).toBeUndefined();
+  });
+
+  it('should not modify contents if there is no user text message', () => {
+    const history: Content[] = [
+      {
+        role: 'user',
+        parts: [{ functionResponse: { name: 'tool', response: {} } }],
+      },
+      {
+        role: 'model',
+        parts: [{ functionCall: { name: 'tool2', args: {} } }],
+      },
+    ];
+    const newContents = ensureActiveLoopHasThoughtSignatures(history);
+    expect(newContents).toEqual(history);
+    expect(
+      (newContents[1]?.parts?.[0] as Part & { thoughtSignature?: string })
+        ?.thoughtSignature,
+    ).toBeUndefined();
+  });
+
+  it('should handle an empty history', () => {
+    const history: Content[] = [];
+    const newContents = ensureActiveLoopHasThoughtSignatures(history);
+    expect(newContents).toEqual([]);
+  });
+
+  it('should handle history with only a user message', () => {
+    const history: Content[] = [{ role: 'user', parts: [{ text: 'Hello' }] }];
+    const newContents = ensureActiveLoopHasThoughtSignatures(history);
+    expect(newContents).toEqual(history);
+  });
+
+  it('should preserve existing thoughtSignature if already present', () => {
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'Hello' }] },
+      {
+        role: 'model',
+        parts: [
+          {
+            functionCall: { name: 'tool', args: {} },
+            thoughtSignature: 'real-signature-from-api',
+          } as Part,
+        ],
+      },
+    ];
+    const newContents = ensureActiveLoopHasThoughtSignatures(history);
+    expect(
+      (newContents[1]?.parts?.[0] as Part & { thoughtSignature?: string })
+        ?.thoughtSignature,
+    ).toBe('real-signature-from-api');
+  });
+
+  it('should handle model turns with text only (no functionCall)', () => {
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'Hello' }] },
+      { role: 'model', parts: [{ text: 'Hi there!' }] },
+      { role: 'user', parts: [{ text: 'Can you help?' }] },
+      {
+        role: 'model',
+        parts: [{ functionCall: { name: 'help_tool', args: {} } }],
+      },
+    ];
+    const newContents = ensureActiveLoopHasThoughtSignatures(history);
+
+    // Text-only model turn - no changes
+    expect(newContents[1]?.parts?.[0]).toEqual({ text: 'Hi there!' });
+
+    // Function call in active loop gets signature
+    expect(
+      (newContents[3]?.parts?.[0] as Part & { thoughtSignature?: string })
+        ?.thoughtSignature,
+    ).toBe(SYNTHETIC_THOUGHT_SIGNATURE);
+  });
+
+  it('should handle mixed parts (text + functionCall) in same turn', () => {
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'Hello' }] },
+      {
+        role: 'model',
+        parts: [
+          { text: 'Let me check...' },
+          { functionCall: { name: 'check_tool', args: {} } },
+          { functionCall: { name: 'another_check', args: {} } },
+        ],
+      },
+    ];
+    const newContents = ensureActiveLoopHasThoughtSignatures(history);
+
+    // Text part unchanged
+    expect(newContents[1]?.parts?.[0]).toEqual({ text: 'Let me check...' });
+
+    // First functionCall gets signature
+    expect(
+      (newContents[1]?.parts?.[1] as Part & { thoughtSignature?: string })
+        ?.thoughtSignature,
+    ).toBe(SYNTHETIC_THOUGHT_SIGNATURE);
+
+    // Second functionCall does NOT get signature
+    expect(
+      (newContents[1]?.parts?.[2] as Part & { thoughtSignature?: string })
+        ?.thoughtSignature,
+    ).toBeUndefined();
+  });
+
+  it('should handle multi-step tool calls across multiple turns', () => {
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'Analyze the code' }] },
+      {
+        role: 'model',
+        parts: [
+          { functionCall: { name: 'read_file', args: { path: 'a.ts' } } },
+        ],
+      },
+      {
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              name: 'read_file',
+              response: { content: 'file a' },
+            },
+          },
+        ],
+      },
+      {
+        role: 'model',
+        parts: [
+          { functionCall: { name: 'read_file', args: { path: 'b.ts' } } },
+        ],
+      },
+      {
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              name: 'read_file',
+              response: { content: 'file b' },
+            },
+          },
+        ],
+      },
+      {
+        role: 'model',
+        parts: [{ text: 'Analysis complete' }],
+      },
+    ];
+
+    const newContents = ensureActiveLoopHasThoughtSignatures(history);
+
+    // First tool call gets signature
+    expect(
+      (newContents[1]?.parts?.[0] as Part & { thoughtSignature?: string })
+        ?.thoughtSignature,
+    ).toBe(SYNTHETIC_THOUGHT_SIGNATURE);
+
+    // Second tool call gets signature
+    expect(
+      (newContents[3]?.parts?.[0] as Part & { thoughtSignature?: string })
+        ?.thoughtSignature,
+    ).toBe(SYNTHETIC_THOUGHT_SIGNATURE);
+
+    // Final text response - unchanged
+    expect(newContents[5]?.parts?.[0]).toEqual({ text: 'Analysis complete' });
+  });
+
+  it('should return the same reference if no modifications needed', () => {
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'Hello' }] },
+      { role: 'model', parts: [{ text: 'Hi!' }] },
+    ];
+    const newContents = ensureActiveLoopHasThoughtSignatures(history);
+    // No function calls, so no modifications needed
+    expect(newContents).toEqual(history);
+  });
+});
+
+/**
+ * Tests for stripThoughtsFromHistory function.
+ *
+ * Gemini returns thought content with `thought: true` on parts.
+ * These should be stripped from history before sending back to the API.
+ */
+describe('stripThoughtsFromHistory', () => {
+  interface Content {
+    role: string;
+    parts: Part[];
+  }
+
+  it('should strip thought parts from model turns with policy "all"', () => {
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'Hello' }] },
+      {
+        role: 'model',
+        parts: [
+          { text: 'Let me think...', thought: true } as Part,
+          { text: 'Here is my answer.' },
+        ],
+      },
+    ];
+
+    const result = stripThoughtsFromHistory(history, 'all');
+
+    expect(result).toHaveLength(2);
+    expect(result[1].parts).toHaveLength(1);
+    expect((result[1].parts[0] as { text: string }).text).toBe(
+      'Here is my answer.',
+    );
+  });
+
+  it('should remove thoughtSignature properties', () => {
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'Hello' }] },
+      {
+        role: 'model',
+        parts: [
+          {
+            functionCall: { name: 'tool', args: {} },
+            thoughtSignature: 'some-sig',
+          } as Part,
+        ],
+      },
+    ];
+
+    const result = stripThoughtsFromHistory(history, 'all');
+
+    expect(result).toHaveLength(2);
+    const firstPart = result[1].parts[0] as Part & {
+      thoughtSignature?: string;
+    };
+    expect(firstPart.thoughtSignature).toBeUndefined();
+    expect((firstPart as { functionCall: unknown }).functionCall).toBeDefined();
+  });
+
+  it('should return unchanged contents with policy "none"', () => {
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'Hello' }] },
+      {
+        role: 'model',
+        parts: [
+          { text: 'Thinking...', thought: true } as Part,
+          { text: 'Answer' },
+        ],
+      },
+    ];
+
+    const result = stripThoughtsFromHistory(history, 'none');
+
+    expect(result).toBe(history); // Same reference
+    expect(result[1].parts).toHaveLength(2);
+  });
+
+  it('should keep last model turn with policy "allButLast"', () => {
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'First question' }] },
+      {
+        role: 'model',
+        parts: [
+          { text: 'First thought', thought: true } as Part,
+          { text: 'First answer' },
+        ],
+      },
+      { role: 'user', parts: [{ text: 'Second question' }] },
+      {
+        role: 'model',
+        parts: [
+          { text: 'Second thought', thought: true } as Part,
+          { text: 'Second answer' },
+        ],
+      },
+    ];
+
+    const result = stripThoughtsFromHistory(history, 'allButLast');
+
+    // First model turn should have thought stripped
+    expect(result[1].parts).toHaveLength(1);
+    expect((result[1].parts[0] as { text: string }).text).toBe('First answer');
+
+    // Last model turn should be preserved
+    expect(result[3].parts).toHaveLength(2);
+    expect(
+      (result[3].parts[0] as { text: string; thought?: boolean }).thought,
+    ).toBe(true);
+  });
+
+  it('should handle empty history', () => {
+    const result = stripThoughtsFromHistory([], 'all');
+    expect(result).toEqual([]);
+  });
+
+  it('should preserve user turns unchanged', () => {
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'Hello' }] },
+      {
+        role: 'model',
+        parts: [{ text: 'Thought', thought: true } as Part],
+      },
+      { role: 'user', parts: [{ text: 'Another question' }] },
+    ];
+
+    const result = stripThoughtsFromHistory(history, 'all');
+
+    // User turns preserved
+    expect(result[0]).toBe(history[0]);
+    expect(result[1]).toBe(history[2]); // Second user turn becomes index 1
+    // Model turn with only thought parts is removed entirely
+    expect(result).toHaveLength(2);
+  });
+
+  it('should remove model turns that become empty after stripping thoughts', () => {
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'Hello' }] },
+      {
+        role: 'model',
+        parts: [{ text: 'Only thinking...', thought: true } as Part],
+      },
+      { role: 'user', parts: [{ text: 'Next question' }] },
+      {
+        role: 'model',
+        parts: [{ text: 'Real answer' }],
+      },
+    ];
+
+    const result = stripThoughtsFromHistory(history, 'all');
+
+    // First model turn is removed entirely (only had thought)
+    expect(result).toHaveLength(3);
+    expect(result[0].role).toBe('user');
+    expect(result[1].role).toBe('user');
+    expect(result[2].role).toBe('model');
+    expect((result[2].parts[0] as { text: string }).text).toBe('Real answer');
+  });
+
+  it('should return same reference if no modifications needed', () => {
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'Hello' }] },
+      { role: 'model', parts: [{ text: 'Hi!' }] },
+    ];
+
+    const result = stripThoughtsFromHistory(history, 'all');
+
+    expect(result).toEqual(history);
+  });
+});

--- a/packages/core/src/providers/gemini/thoughtSignatures.ts
+++ b/packages/core/src/providers/gemini/thoughtSignatures.ts
@@ -1,0 +1,241 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Part } from '@google/genai';
+
+/**
+ * Synthetic thought signature used when a functionCall part lacks one.
+ * This bypasses Gemini 3.x validation without containing actual reasoning.
+ *
+ * @see https://ai.google.dev/gemini-api/docs/thought-signatures
+ */
+export const SYNTHETIC_THOUGHT_SIGNATURE = 'skip_thought_signature_validator';
+
+/**
+ * Content structure matching Gemini API format
+ */
+interface Content {
+  role: string;
+  parts: Part[];
+}
+
+/**
+ * Part with optional thoughtSignature
+ */
+interface PartWithThoughtSignature extends Part {
+  thoughtSignature?: string;
+}
+
+/**
+ * Ensures that all functionCall parts in the "active loop" have a thoughtSignature.
+ *
+ * The active loop is defined as all content from the last user message with text
+ * (not a functionResponse) to the end of the history. Gemini 3.x requires that
+ * the first functionCall part in each model turn within this active loop has
+ * a thoughtSignature property.
+ *
+ * This function:
+ * 1. Finds the start of the active loop by locating the last user turn with text
+ * 2. For each model turn in the active loop, ensures the first functionCall has a signature
+ * 3. Preserves existing signatures if present
+ * 4. Adds a synthetic signature if missing
+ *
+ * @param requestContents - The conversation history to process
+ * @returns A new array with thoughtSignatures ensured (shallow copy if modified)
+ */
+export function ensureActiveLoopHasThoughtSignatures(
+  requestContents: Content[],
+): Content[] {
+  // Find the start of the active loop by finding the last user turn
+  // with a text message, i.e. that is not just a functionResponse.
+  let activeLoopStartIndex = -1;
+  for (let i = requestContents.length - 1; i >= 0; i--) {
+    const content = requestContents[i];
+    if (
+      content.role === 'user' &&
+      content.parts?.some((part) => 'text' in part && part.text)
+    ) {
+      activeLoopStartIndex = i;
+      break;
+    }
+  }
+
+  // No active loop found - return unchanged
+  if (activeLoopStartIndex === -1) {
+    return requestContents;
+  }
+
+  // Track if any modifications are needed
+  let needsModification = false;
+
+  // Check if we need to modify anything
+  for (let i = activeLoopStartIndex; i < requestContents.length; i++) {
+    const content = requestContents[i];
+    if (content.role === 'model' && content.parts) {
+      for (const part of content.parts) {
+        if ('functionCall' in part && part.functionCall) {
+          const partWithSig = part as PartWithThoughtSignature;
+          if (!partWithSig.thoughtSignature) {
+            needsModification = true;
+            break;
+          }
+          // Only the first functionCall matters, so break after checking it
+          break;
+        }
+      }
+    }
+    if (needsModification) break;
+  }
+
+  // No modifications needed - return unchanged
+  if (!needsModification) {
+    return requestContents;
+  }
+
+  // Create shallow copy and modify
+  const newContents = requestContents.slice();
+
+  for (let i = activeLoopStartIndex; i < newContents.length; i++) {
+    const content = newContents[i];
+    if (content.role === 'model' && content.parts) {
+      const newParts = content.parts.slice();
+      let modified = false;
+
+      for (let j = 0; j < newParts.length; j++) {
+        const part = newParts[j];
+        if ('functionCall' in part && part.functionCall) {
+          const partWithSig = part as PartWithThoughtSignature;
+          if (!partWithSig.thoughtSignature) {
+            // Create new part with signature
+            newParts[j] = {
+              ...part,
+              thoughtSignature: SYNTHETIC_THOUGHT_SIGNATURE,
+            } as PartWithThoughtSignature;
+            modified = true;
+          }
+          // Only the first functionCall in the turn gets a signature
+          break;
+        }
+      }
+
+      if (modified) {
+        newContents[i] = {
+          ...content,
+          parts: newParts,
+        };
+      }
+    }
+  }
+
+  return newContents;
+}
+
+/**
+ * Part with optional thought property (Gemini's thinking content)
+ */
+interface PartWithThought extends Part {
+  thought?: boolean;
+  text?: string;
+}
+
+/**
+ * Strips thought content from history before sending to the API.
+ * Gemini returns parts with `thought: true` for reasoning content,
+ * and these should not be sent back in subsequent requests.
+ *
+ * Also removes thoughtSignature properties to clean up the history.
+ *
+ * @param contents - The conversation history
+ * @param policy - How to strip thoughts: 'all' removes all, 'allButLast' keeps last model turn, 'none' keeps all
+ * @returns A new array with thought content stripped according to policy
+ */
+export function stripThoughtsFromHistory(
+  contents: Content[],
+  policy: 'all' | 'allButLast' | 'none' = 'all',
+): Content[] {
+  if (policy === 'none') {
+    return contents;
+  }
+
+  // Find the last model turn index if needed
+  let lastModelTurnIndex = -1;
+  if (policy === 'allButLast') {
+    for (let i = contents.length - 1; i >= 0; i--) {
+      if (contents[i].role === 'model') {
+        lastModelTurnIndex = i;
+        break;
+      }
+    }
+  }
+
+  let needsModification = false;
+
+  // Check if we need to modify anything
+  for (let i = 0; i < contents.length; i++) {
+    const content = contents[i];
+    if (content.role !== 'model' || !content.parts) continue;
+
+    // Skip last model turn if policy is 'allButLast'
+    if (policy === 'allButLast' && i === lastModelTurnIndex) continue;
+
+    for (const part of content.parts) {
+      const partWithThought = part as PartWithThought;
+      const partWithSig = part as PartWithThoughtSignature;
+      if (partWithThought.thought || partWithSig.thoughtSignature) {
+        needsModification = true;
+        break;
+      }
+    }
+    if (needsModification) break;
+  }
+
+  if (!needsModification) {
+    return contents;
+  }
+
+  // Create new array with thoughts stripped
+  const newContents: Content[] = [];
+
+  for (let i = 0; i < contents.length; i++) {
+    const content = contents[i];
+
+    if (content.role !== 'model' || !content.parts) {
+      newContents.push(content);
+      continue;
+    }
+
+    // Skip stripping for last model turn if policy is 'allButLast'
+    if (policy === 'allButLast' && i === lastModelTurnIndex) {
+      newContents.push(content);
+      continue;
+    }
+
+    // Filter out thought parts and remove thoughtSignature
+    const filteredParts = content.parts
+      .filter((part) => {
+        const partWithThought = part as PartWithThought;
+        return !partWithThought.thought;
+      })
+      .map((part) => {
+        const partWithSig = part as PartWithThoughtSignature;
+        if (partWithSig.thoughtSignature) {
+          const { thoughtSignature: _, ...restPart } = partWithSig;
+          return restPart as Part;
+        }
+        return part;
+      });
+
+    // Only add content if it has remaining parts
+    if (filteredParts.length > 0) {
+      newContents.push({
+        ...content,
+        parts: filteredParts,
+      });
+    }
+  }
+
+  return newContents;
+}


### PR DESCRIPTION
## Summary - Fixes #595

Gemini 3.x thinking blocks were not appearing in the UI when using `gemini-3-pro-preview` with `reasoning.enabled=true`. This PR fixes the root cause and adds comprehensive debugging and test coverage.

### Root Cause

The code was using an **invalid `thinkingLevel: 'HIGH'` property** in the `ThinkingConfig` object. The `@google/genai` SDK's `ThinkingConfig` interface only supports:

```typescript
interface ThinkingConfig {
  includeThoughts?: boolean;  // whether to include thoughts in response
  thinkingBudget?: number;    // 0=DISABLED, -1=AUTOMATIC, or specific token count
}
```

The invalid `thinkingLevel` property was silently ignored by the API, resulting in:
- `thoughtPartsCount: 0` - No thought parts returned
- `willYieldThinkingBlock: false` - No ThinkingBlocks created
- No `<think>...</think>` blocks in UI output

### The Fix

Changed the thinkingConfig from:
```typescript
// WRONG - thinkingLevel is not a valid property
thinkingConfig = { thinkingLevel: 'HIGH' as const }
```

To:
```typescript
// CORRECT - uses actual SDK properties
thinkingConfig = {
  includeThoughts: true,
  thinkingBudget: reasoningMaxTokens ?? -1  // -1 = AUTOMATIC
}
```

### Changes

- **`packages/core/src/providers/gemini/GeminiProvider.ts`**: Fix thinkingConfig to use correct `includeThoughts` and `thinkingBudget` properties
- **`packages/core/src/providers/gemini/thoughtSignatures.ts`**: New utility for Gemini 3.x thought signature handling (required for multi-turn conversations)
- **`packages/core/src/providers/gemini/__tests__/gemini.thoughtSignature.test.ts`**: Comprehensive test coverage for thought signature functions
- Added debug logging using `DebugLogger` (namespace: `llxprt:provider:gemini:thinking`) for thinking block detection

### Verification

**Before fix:**
```
thoughtPartsCount: 0
willYieldThinkingBlock: false
```

**After fix:**
```
thinkingConfig: { includeThoughts: true, thinkingBudget: -1 }
thoughtPartsCount: 1
willYieldThinkingBlock: true
```

UI output now shows:
```
<think>Understanding the Query: I've quickly grasped the core request...</think>
```

### Test Plan

- [x] All 6,104 tests pass
- [x] Lint passes with zero warnings
- [x] Format check passes
- [x] Manual testing with `gemini-3-pro-preview` + `reasoning.enabled=true` + `--keyfile ~/.foogle_key`
- [x] Debug logs confirm `thoughtPartsCount > 0` and `willYieldThinkingBlock: true`
- [x] UI displays `<think>...</think>` blocks matching Anthropic/OpenAI behavior

Closes #595

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reasoning configuration settings to customize AI thinking behavior, context inclusion, and response formatting
  * Enhanced Gemini 3.x provider with improved thinking and reasoning capabilities

* **Documentation**
  * Updated logging procedures and deployment verification guidance

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->