### PR TITLE
fix(#726): Preserve spacing when thinking blocks appear between text chunks

### DIFF
--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -69,6 +69,39 @@ export type StreamEvent =
   | { type: StreamEventType.RETRY };
 
 /**
+ * Aggregates text from content blocks while preserving spacing around non-text blocks.
+ * When thinking blocks (or other non-text blocks) appear between text chunks, this ensures
+ * proper spacing is maintained in the aggregated output.
+ *
+ * @param blocks - Array of content blocks to process
+ * @param currentText - The current accumulated text
+ * @param lastBlockWasNonText - Whether the previous block was a non-text block
+ * @returns Object containing the aggregated text and the updated non-text flag
+ */
+export function aggregateTextWithSpacing(
+  blocks: ContentBlock[],
+  currentText: string,
+  lastBlockWasNonText: boolean,
+): { text: string; lastBlockWasNonText: boolean } {
+  let aggregatedText = currentText;
+  let wasNonText = lastBlockWasNonText;
+
+  for (const block of blocks) {
+    if (block.type === 'text') {
+      if (wasNonText && aggregatedText.length > 0) {
+        aggregatedText += ' ';
+      }
+      aggregatedText += block.text;
+      wasNonText = false;
+    } else {
+      wasNonText = true;
+    }
+  }
+
+  return { text: aggregatedText, lastBlockWasNonText: wasNonText };
+}
+
+/**
  * Custom createUserContent function that properly handles function response arrays.
  * This fixes the issue where multiple function responses are incorrectly nested.
  *
@@ -1214,17 +1247,13 @@ export class GeminiChat {
           let lastBlockWasNonText = false;
           for await (const iContent of streamResponse) {
             lastResponse = iContent;
-            for (const block of iContent.blocks ?? []) {
-              if (block.type === 'text') {
-                if (lastBlockWasNonText && aggregatedText.length > 0) {
-                  aggregatedText += ' ';
-                }
-                aggregatedText += block.text;
-                lastBlockWasNonText = false;
-              } else {
-                lastBlockWasNonText = true;
-              }
-            }
+            const result = aggregateTextWithSpacing(
+              iContent.blocks ?? [],
+              aggregatedText,
+              lastBlockWasNonText,
+            );
+            aggregatedText = result.text;
+            lastBlockWasNonText = result.lastBlockWasNonText;
           }
 
           if (!lastResponse) {
@@ -2042,17 +2071,13 @@ export class GeminiChat {
     let lastBlockWasNonText = false;
     for await (const chunk of stream) {
       if (chunk.blocks) {
-        for (const block of chunk.blocks) {
-          if (block.type === 'text') {
-            if (lastBlockWasNonText && summary.length > 0) {
-              summary += ' ';
-            }
-            summary += block.text;
-            lastBlockWasNonText = false;
-          } else {
-            lastBlockWasNonText = true;
-          }
-        }
+        const result = aggregateTextWithSpacing(
+          chunk.blocks,
+          summary,
+          lastBlockWasNonText,
+        );
+        summary = result.text;
+        lastBlockWasNonText = result.lastBlockWasNonText;
       }
     }
 


### PR DESCRIPTION
## Summary

Fixes #726 - Sonnet Thinking Causes Missing Spaces in Interactive Mode

When Claude Sonnet uses thinking blocks in interactive mode, spaces between sentences were being lost, causing words to run together like `"available.I'll"` instead of `"available. I'll"`.

### Root Cause

The text aggregation logic in `geminiChat.ts` was skipping non-text blocks (like thinking blocks) without preserving spacing between text chunks. When the stream emits:

1. Text: `"available."`
2. Thinking: `(internal thought)`
3. Text: `"I'll help you"`

The aggregation would simply concatenate the text blocks without any spacing, resulting in `"available.I'll help you"`.

### Changes

**packages/core/src/core/geminiChat.ts**
- Added `lastBlockWasNonText` tracking to the retry path text aggregation (line ~1214)
- Added same fix to the compression summary generation path (line ~2042)
- When transitioning from a non-text block to a text block, adds a space if there's already accumulated text

**packages/core/src/core/geminiChat.thinking-spacing.test.ts** (new file)
- 10 comprehensive tests covering:
  - Spacing preservation when thinking blocks appear between text chunks
  - Multiple consecutive thinking blocks (no duplicate spaces)
  - Thinking blocks at start (no leading space)
  - Thinking blocks at end (preserves trailing space)
  - Empty text blocks
  - Mixed non-text block types (code blocks, etc.)
  - Edge cases (only text, only thinking, empty stream)

### Test Plan

- [x] New tests pass (10/10)
- [x] Existing geminiChat tests pass (no regressions)
- [x] TypeScript compilation succeeds
- [x] Linting passes with zero warnings
- [x] Build succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text spacing in chat responses when content streams include non-text or mixed blocks, improving formatting and readability.

* **Tests**
  * Added comprehensive tests covering many content scenarios to prevent spacing regressions.

* **New Features**
  * Exposed improved text-aggregation behavior to ensure consistent spacing across streamed and non-streamed responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->