### PR TITLE
fix(#749): Extract Kimi K2 tool calls from reasoning_content and prevent token leaks

### DIFF
--- a/packages/core/src/providers/openai/OpenAIProvider.reasoning.test.ts
+++ b/packages/core/src/providers/openai/OpenAIProvider.reasoning.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { OpenAIProvider } from './OpenAIProvider.js';
 import type {
   ThinkingBlock,
+  ToolCallBlock,
   IContent,
 } from '../../services/history/IContent.js';
 import type { NormalizedGenerateChatOptions } from '../BaseProvider.js';
@@ -32,19 +33,21 @@ describe('OpenAIProvider reasoning parsing @plan:PLAN-20251202-THINKING.P10', ()
         provider as unknown as {
           parseStreamingReasoningDelta: (
             delta: OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta,
-          ) => ThinkingBlock | null;
+          ) => { thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] };
         }
       ).parseStreamingReasoningDelta(delta);
 
       expect(result).not.toBeNull();
-      expect(result).toMatchObject({
+      expect(result.thinking).not.toBeNull();
+      expect(result.thinking).toMatchObject({
         type: 'thinking',
         thought: 'Let me think about this problem...',
         sourceField: 'reasoning_content',
       });
+      expect(result.toolCalls).toHaveLength(0);
     });
 
-    it('should return null when reasoning_content is absent', () => {
+    it('should return null thinking when reasoning_content is absent', () => {
       const delta: OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta = {
         content: 'Regular content',
       };
@@ -53,14 +56,15 @@ describe('OpenAIProvider reasoning parsing @plan:PLAN-20251202-THINKING.P10', ()
         provider as unknown as {
           parseStreamingReasoningDelta: (
             delta: OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta,
-          ) => ThinkingBlock | null;
+          ) => { thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] };
         }
       ).parseStreamingReasoningDelta(delta);
 
-      expect(result).toBeNull();
+      expect(result.thinking).toBeNull();
+      expect(result.toolCalls).toHaveLength(0);
     });
 
-    it('should return null when reasoning_content is empty string', () => {
+    it('should return null thinking when reasoning_content is empty string', () => {
       const delta: OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta = {
         reasoning_content: '',
       };
@@ -69,11 +73,12 @@ describe('OpenAIProvider reasoning parsing @plan:PLAN-20251202-THINKING.P10', ()
         provider as unknown as {
           parseStreamingReasoningDelta: (
             delta: OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta,
-          ) => ThinkingBlock | null;
+          ) => { thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] };
         }
       ).parseStreamingReasoningDelta(delta);
 
-      expect(result).toBeNull();
+      expect(result.thinking).toBeNull();
+      expect(result.toolCalls).toHaveLength(0);
     });
 
     it('should handle delta with both reasoning_content and content', () => {
@@ -86,16 +91,18 @@ describe('OpenAIProvider reasoning parsing @plan:PLAN-20251202-THINKING.P10', ()
         provider as unknown as {
           parseStreamingReasoningDelta: (
             delta: OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta,
-          ) => ThinkingBlock | null;
+          ) => { thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] };
         }
       ).parseStreamingReasoningDelta(delta);
 
       expect(result).not.toBeNull();
-      expect(result).toMatchObject({
+      expect(result.thinking).not.toBeNull();
+      expect(result.thinking).toMatchObject({
         type: 'thinking',
         thought: 'Thinking...',
         sourceField: 'reasoning_content',
       });
+      expect(result.toolCalls).toHaveLength(0);
     });
 
     it('should set sourceField to reasoning_content', () => {
@@ -107,13 +114,14 @@ describe('OpenAIProvider reasoning parsing @plan:PLAN-20251202-THINKING.P10', ()
         provider as unknown as {
           parseStreamingReasoningDelta: (
             delta: OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta,
-          ) => ThinkingBlock | null;
+          ) => { thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] };
         }
       ).parseStreamingReasoningDelta(delta);
 
       expect(result).not.toBeNull();
+      expect(result.thinking).not.toBeNull();
       // Type assertion after verification
-      expect(result!.sourceField).toBe('reasoning_content');
+      expect(result.thinking!.sourceField).toBe('reasoning_content');
     });
   });
 
@@ -129,19 +137,21 @@ describe('OpenAIProvider reasoning parsing @plan:PLAN-20251202-THINKING.P10', ()
         provider as unknown as {
           parseNonStreamingReasoning: (
             message: OpenAI.Chat.Completions.ChatCompletionMessage,
-          ) => ThinkingBlock | null;
+          ) => { thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] };
         }
       ).parseNonStreamingReasoning(message);
 
       expect(result).not.toBeNull();
-      expect(result).toMatchObject({
+      expect(result.thinking).not.toBeNull();
+      expect(result.thinking).toMatchObject({
         type: 'thinking',
         thought: 'Let me analyze this thoroughly...',
         sourceField: 'reasoning_content',
       });
+      expect(result.toolCalls).toHaveLength(0);
     });
 
-    it('should return null when reasoning_content is absent', () => {
+    it('should return null thinking when reasoning_content is absent', () => {
       const message: OpenAI.Chat.Completions.ChatCompletionMessage = {
         role: 'assistant',
         content: 'Answer',
@@ -151,14 +161,15 @@ describe('OpenAIProvider reasoning parsing @plan:PLAN-20251202-THINKING.P10', ()
         provider as unknown as {
           parseNonStreamingReasoning: (
             message: OpenAI.Chat.Completions.ChatCompletionMessage,
-          ) => ThinkingBlock | null;
+          ) => { thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] };
         }
       ).parseNonStreamingReasoning(message);
 
-      expect(result).toBeNull();
+      expect(result.thinking).toBeNull();
+      expect(result.toolCalls).toHaveLength(0);
     });
 
-    it('should return null when reasoning_content is empty string', () => {
+    it('should return null thinking when reasoning_content is empty string', () => {
       const message: OpenAI.Chat.Completions.ChatCompletionMessage = {
         role: 'assistant',
         content: 'Answer',
@@ -169,11 +180,12 @@ describe('OpenAIProvider reasoning parsing @plan:PLAN-20251202-THINKING.P10', ()
         provider as unknown as {
           parseNonStreamingReasoning: (
             message: OpenAI.Chat.Completions.ChatCompletionMessage,
-          ) => ThinkingBlock | null;
+          ) => { thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] };
         }
       ).parseNonStreamingReasoning(message);
 
-      expect(result).toBeNull();
+      expect(result.thinking).toBeNull();
+      expect(result.toolCalls).toHaveLength(0);
     });
 
     it('should handle message with tool_calls and reasoning_content', () => {
@@ -197,16 +209,18 @@ describe('OpenAIProvider reasoning parsing @plan:PLAN-20251202-THINKING.P10', ()
         provider as unknown as {
           parseNonStreamingReasoning: (
             message: OpenAI.Chat.Completions.ChatCompletionMessage,
-          ) => ThinkingBlock | null;
+          ) => { thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] };
         }
       ).parseNonStreamingReasoning(message);
 
       expect(result).not.toBeNull();
-      expect(result).toMatchObject({
+      expect(result.thinking).not.toBeNull();
+      expect(result.thinking).toMatchObject({
         type: 'thinking',
         thought: 'Need to use a tool...',
         sourceField: 'reasoning_content',
       });
+      expect(result.toolCalls).toHaveLength(0);
     });
 
     it('should set sourceField to reasoning_content', () => {
@@ -220,13 +234,14 @@ describe('OpenAIProvider reasoning parsing @plan:PLAN-20251202-THINKING.P10', ()
         provider as unknown as {
           parseNonStreamingReasoning: (
             message: OpenAI.Chat.Completions.ChatCompletionMessage,
-          ) => ThinkingBlock | null;
+          ) => { thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] };
         }
       ).parseNonStreamingReasoning(message);
 
       expect(result).not.toBeNull();
+      expect(result.thinking).not.toBeNull();
       // Type assertion after verification
-      expect(result!.sourceField).toBe('reasoning_content');
+      expect(result.thinking!.sourceField).toBe('reasoning_content');
     });
   });
 
@@ -236,13 +251,14 @@ describe('OpenAIProvider reasoning parsing @plan:PLAN-20251202-THINKING.P10', ()
         provider as unknown as {
           parseStreamingReasoningDelta: (
             delta: OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta | null,
-          ) => ThinkingBlock | null;
+          ) => { thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] };
         }
       ).parseStreamingReasoningDelta(
         null as unknown as OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta,
       );
 
-      expect(result).toBeNull();
+      expect(result.thinking).toBeNull();
+      expect(result.toolCalls).toHaveLength(0);
     });
 
     it('should handle undefined delta gracefully (streaming)', () => {
@@ -252,13 +268,14 @@ describe('OpenAIProvider reasoning parsing @plan:PLAN-20251202-THINKING.P10', ()
             delta:
               | OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta
               | undefined,
-          ) => ThinkingBlock | null;
+          ) => { thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] };
         }
       ).parseStreamingReasoningDelta(
         undefined as unknown as OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta,
       );
 
-      expect(result).toBeNull();
+      expect(result.thinking).toBeNull();
+      expect(result.toolCalls).toHaveLength(0);
     });
 
     it('should handle null message gracefully (non-streaming)', () => {
@@ -266,13 +283,14 @@ describe('OpenAIProvider reasoning parsing @plan:PLAN-20251202-THINKING.P10', ()
         provider as unknown as {
           parseNonStreamingReasoning: (
             message: OpenAI.Chat.Completions.ChatCompletionMessage | null,
-          ) => ThinkingBlock | null;
+          ) => { thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] };
         }
       ).parseNonStreamingReasoning(
         null as unknown as OpenAI.Chat.Completions.ChatCompletionMessage,
       );
 
-      expect(result).toBeNull();
+      expect(result.thinking).toBeNull();
+      expect(result.toolCalls).toHaveLength(0);
     });
 
     it('should handle undefined message gracefully (non-streaming)', () => {
@@ -280,13 +298,14 @@ describe('OpenAIProvider reasoning parsing @plan:PLAN-20251202-THINKING.P10', ()
         provider as unknown as {
           parseNonStreamingReasoning: (
             message: OpenAI.Chat.Completions.ChatCompletionMessage | undefined,
-          ) => ThinkingBlock | null;
+          ) => { thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] };
         }
       ).parseNonStreamingReasoning(
         undefined as unknown as OpenAI.Chat.Completions.ChatCompletionMessage,
       );
 
-      expect(result).toBeNull();
+      expect(result.thinking).toBeNull();
+      expect(result.toolCalls).toHaveLength(0);
     });
 
     it('should handle empty delta object (streaming)', () => {
@@ -297,11 +316,12 @@ describe('OpenAIProvider reasoning parsing @plan:PLAN-20251202-THINKING.P10', ()
         provider as unknown as {
           parseStreamingReasoningDelta: (
             delta: OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta,
-          ) => ThinkingBlock | null;
+          ) => { thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] };
         }
       ).parseStreamingReasoningDelta(delta);
 
-      expect(result).toBeNull();
+      expect(result.thinking).toBeNull();
+      expect(result.toolCalls).toHaveLength(0);
     });
 
     it('should handle minimal message object (non-streaming)', () => {
@@ -313,11 +333,12 @@ describe('OpenAIProvider reasoning parsing @plan:PLAN-20251202-THINKING.P10', ()
         provider as unknown as {
           parseNonStreamingReasoning: (
             message: OpenAI.Chat.Completions.ChatCompletionMessage,
-          ) => ThinkingBlock | null;
+          ) => { thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] };
         }
       ).parseNonStreamingReasoning(message);
 
-      expect(result).toBeNull();
+      expect(result.thinking).toBeNull();
+      expect(result.toolCalls).toHaveLength(0);
     });
 
     it('should preserve whitespace-only reasoning_content (streaming) for proper formatting', () => {
@@ -331,13 +352,15 @@ describe('OpenAIProvider reasoning parsing @plan:PLAN-20251202-THINKING.P10', ()
         provider as unknown as {
           parseStreamingReasoningDelta: (
             delta: OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta,
-          ) => ThinkingBlock | null;
+          ) => { thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] };
         }
       ).parseStreamingReasoningDelta(delta);
 
       // Whitespace should be preserved for proper formatting during accumulation
       expect(result).not.toBeNull();
-      expect(result?.thought).toBe('   \n\t  ');
+      expect(result.thinking).not.toBeNull();
+      expect(result.thinking?.thought).toBe('   \n\t  ');
+      expect(result.toolCalls).toHaveLength(0);
     });
 
     it('should handle whitespace-only reasoning_content (non-streaming)', () => {
@@ -351,12 +374,13 @@ describe('OpenAIProvider reasoning parsing @plan:PLAN-20251202-THINKING.P10', ()
         provider as unknown as {
           parseNonStreamingReasoning: (
             message: OpenAI.Chat.Completions.ChatCompletionMessage,
-          ) => ThinkingBlock | null;
+          ) => { thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] };
         }
       ).parseNonStreamingReasoning(message);
 
       // Whitespace-only should be treated as empty and return null
-      expect(result).toBeNull();
+      expect(result.thinking).toBeNull();
+      expect(result.toolCalls).toHaveLength(0);
     });
   });
 });
@@ -953,6 +977,383 @@ describe('OpenAIProvider buildMessagesWithReasoning @plan:PLAN-20251202-THINKING
       expect(result).toHaveLength(2);
       expect(result[0]).not.toHaveProperty('reasoning_content');
       expect(result[1]).not.toHaveProperty('reasoning_content');
+    });
+  });
+});
+
+/**
+ * Tests for Kimi K2 tool calls embedded in reasoning_content
+ *
+ * @issue #749
+ * @plan PLAN-20251209-KIMI-REASONING-TOOLS
+ * @requirement REQ-KIMI-REASONING-001
+ */
+describe('OpenAIProvider Kimi tool calls in reasoning_content @issue:749', () => {
+  let provider: OpenAIProvider;
+
+  beforeEach(() => {
+    provider = new OpenAIProvider('test-api-key', 'https://api.openai.com/v1');
+  });
+
+  describe('parseStreamingReasoningDelta with embedded Kimi tool calls @requirement:REQ-KIMI-REASONING-001.1', () => {
+    it('should extract tool calls from reasoning_content and return clean thinking', () => {
+      const delta: OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta = {
+        reasoning_content: `Let me search for this.
+<|tool_calls_section_begin|>
+<|tool_call_begin|>functions.grep:call_123<|tool_call_argument_begin|>{"pattern": "test"}<|tool_call_end|>
+<|tool_calls_section_end|>
+That should find it.`,
+      };
+
+      const result = (
+        provider as unknown as {
+          parseStreamingReasoningDelta: (
+            delta: OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta,
+          ) => { thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] };
+        }
+      ).parseStreamingReasoningDelta(delta);
+
+      expect(result).not.toBeNull();
+      expect(result.thinking).not.toBeNull();
+      expect(result.thinking?.thought).toBe(
+        'Let me search for this.\n\nThat should find it.',
+      );
+      expect(result.thinking?.sourceField).toBe('reasoning_content');
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls[0]).toMatchObject({
+        type: 'tool_call',
+        name: 'grep',
+        parameters: { pattern: 'test' },
+      });
+    });
+
+    it('should handle reasoning_content with only tool calls (no thinking text)', () => {
+      const delta: OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta = {
+        reasoning_content: `<|tool_calls_section_begin|>
+<|tool_call_begin|>functions.read:call_456<|tool_call_argument_begin|>{"file_path": "/test.ts"}<|tool_call_end|>
+<|tool_calls_section_end|>`,
+      };
+
+      const result = (
+        provider as unknown as {
+          parseStreamingReasoningDelta: (
+            delta: OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta,
+          ) => { thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] };
+        }
+      ).parseStreamingReasoningDelta(delta);
+
+      expect(result).not.toBeNull();
+      expect(result.thinking).toBeNull(); // No thinking text, just tool calls
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls[0]).toMatchObject({
+        type: 'tool_call',
+        name: 'read',
+        parameters: { file_path: '/test.ts' },
+      });
+    });
+
+    it('should handle multiple tool calls in reasoning_content with thinking before and after', () => {
+      const delta: OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta = {
+        reasoning_content: `First, I need to search.
+<|tool_calls_section_begin|>
+<|tool_call_begin|>functions.grep:call_1<|tool_call_argument_begin|>{"pattern": "error"}<|tool_call_end|>
+<|tool_call_begin|>functions.grep:call_2<|tool_call_argument_begin|>{"pattern": "warning"}<|tool_call_end|>
+<|tool_calls_section_end|>
+Now let me read the files.
+<|tool_calls_section_begin|>
+<|tool_call_begin|>functions.read:call_3<|tool_call_argument_begin|>{"file_path": "/log.txt"}<|tool_call_end|>
+<|tool_calls_section_end|>
+Done analyzing.`,
+      };
+
+      const result = (
+        provider as unknown as {
+          parseStreamingReasoningDelta: (
+            delta: OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta,
+          ) => { thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] };
+        }
+      ).parseStreamingReasoningDelta(delta);
+
+      expect(result).not.toBeNull();
+      expect(result.thinking).not.toBeNull();
+      expect(result.thinking?.thought).toBe(
+        'First, I need to search.\n\nNow let me read the files.\n\nDone analyzing.',
+      );
+      expect(result.toolCalls).toHaveLength(3);
+      expect(result.toolCalls[0].name).toBe('grep');
+      expect(result.toolCalls[1].name).toBe('grep');
+      expect(result.toolCalls[2].name).toBe('read');
+    });
+
+    it('should return empty arrays when reasoning_content has no tool calls', () => {
+      const delta: OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta = {
+        reasoning_content: 'Just thinking, no tools needed.',
+      };
+
+      const result = (
+        provider as unknown as {
+          parseStreamingReasoningDelta: (
+            delta: OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta,
+          ) => { thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] };
+        }
+      ).parseStreamingReasoningDelta(delta);
+
+      expect(result).not.toBeNull();
+      expect(result.thinking).not.toBeNull();
+      expect(result.thinking?.thought).toBe('Just thinking, no tools needed.');
+      expect(result.toolCalls).toHaveLength(0);
+    });
+
+    it('should return null thinking and empty toolCalls when reasoning_content is absent', () => {
+      const delta: OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta = {
+        content: 'Regular content',
+      };
+
+      const result = (
+        provider as unknown as {
+          parseStreamingReasoningDelta: (
+            delta: OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta,
+          ) => { thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] };
+        }
+      ).parseStreamingReasoningDelta(delta);
+
+      expect(result).not.toBeNull();
+      expect(result.thinking).toBeNull();
+      expect(result.toolCalls).toHaveLength(0);
+    });
+
+    it('should preserve whitespace in thinking text after tool call extraction', () => {
+      const delta: OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta = {
+        reasoning_content: `  Leading whitespace\n<|tool_calls_section_begin|>
+<|tool_call_begin|>functions.test:call_1<|tool_call_argument_begin|>{}<|tool_call_end|>
+<|tool_calls_section_end|>
+  Trailing whitespace  `,
+      };
+
+      const result = (
+        provider as unknown as {
+          parseStreamingReasoningDelta: (
+            delta: OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta,
+          ) => { thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] };
+        }
+      ).parseStreamingReasoningDelta(delta);
+
+      expect(result.thinking).not.toBeNull();
+      expect(result.thinking?.thought).toBe(
+        '  Leading whitespace\n\n  Trailing whitespace  ',
+      );
+      expect(result.toolCalls).toHaveLength(1);
+    });
+
+    it('should handle malformed Kimi tokens gracefully', () => {
+      const delta: OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta = {
+        reasoning_content: `Normal thinking.
+<|tool_calls_section_begin|>
+<|tool_call_begin|>incomplete_tool_call
+<|tool_calls_section_end|>
+More thinking.`,
+      };
+
+      const result = (
+        provider as unknown as {
+          parseStreamingReasoningDelta: (
+            delta: OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta,
+          ) => { thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] };
+        }
+      ).parseStreamingReasoningDelta(delta);
+
+      // Should still extract thinking and strip the malformed section
+      expect(result.thinking).not.toBeNull();
+      expect(result.thinking?.thought).toContain('Normal thinking');
+      expect(result.thinking?.thought).toContain('More thinking');
+      // No valid tool calls extracted
+      expect(result.toolCalls).toHaveLength(0);
+    });
+  });
+
+  describe('parseNonStreamingReasoning with embedded Kimi tool calls @requirement:REQ-KIMI-REASONING-001.2', () => {
+    it('should extract tool calls from reasoning_content and return clean thinking', () => {
+      const message: OpenAI.Chat.Completions.ChatCompletionMessage = {
+        role: 'assistant',
+        content: 'Final answer',
+        reasoning_content: `Let me analyze this.
+<|tool_calls_section_begin|>
+<|tool_call_begin|>functions.bash:call_789<|tool_call_argument_begin|>{"command": "ls"}<|tool_call_end|>
+<|tool_calls_section_end|>
+Analysis complete.`,
+      };
+
+      const result = (
+        provider as unknown as {
+          parseNonStreamingReasoning: (
+            message: OpenAI.Chat.Completions.ChatCompletionMessage,
+          ) => { thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] };
+        }
+      ).parseNonStreamingReasoning(message);
+
+      expect(result).not.toBeNull();
+      expect(result.thinking).not.toBeNull();
+      expect(result.thinking?.thought).toBe(
+        'Let me analyze this.\n\nAnalysis complete.',
+      );
+      expect(result.thinking?.sourceField).toBe('reasoning_content');
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls[0]).toMatchObject({
+        type: 'tool_call',
+        name: 'bash',
+        parameters: { command: 'ls' },
+      });
+    });
+
+    it('should handle reasoning_content with only tool calls (no thinking text)', () => {
+      const message: OpenAI.Chat.Completions.ChatCompletionMessage = {
+        role: 'assistant',
+        content: null,
+        reasoning_content: `<|tool_calls_section_begin|>
+<|tool_call_begin|>functions.write:call_999<|tool_call_argument_begin|>{"file_path": "/new.txt", "content": "test"}<|tool_call_end|>
+<|tool_calls_section_end|>`,
+      };
+
+      const result = (
+        provider as unknown as {
+          parseNonStreamingReasoning: (
+            message: OpenAI.Chat.Completions.ChatCompletionMessage,
+          ) => { thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] };
+        }
+      ).parseNonStreamingReasoning(message);
+
+      expect(result).not.toBeNull();
+      expect(result.thinking).toBeNull(); // Only whitespace left after extraction
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls[0]).toMatchObject({
+        type: 'tool_call',
+        name: 'write',
+      });
+    });
+
+    it('should handle multiple tool calls with complex parameters', () => {
+      const message: OpenAI.Chat.Completions.ChatCompletionMessage = {
+        role: 'assistant',
+        content: 'Done',
+        reasoning_content: `Processing multiple operations.
+<|tool_calls_section_begin|>
+<|tool_call_begin|>functions.edit:call_a1<|tool_call_argument_begin|>{"file_path": "/test.ts", "old_string": "foo", "new_string": "bar"}<|tool_call_end|>
+<|tool_call_begin|>functions.glob:call_a2<|tool_call_argument_begin|>{"pattern": "**/*.ts"}<|tool_call_end|>
+<|tool_calls_section_end|>
+Operations queued.`,
+      };
+
+      const result = (
+        provider as unknown as {
+          parseNonStreamingReasoning: (
+            message: OpenAI.Chat.Completions.ChatCompletionMessage,
+          ) => { thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] };
+        }
+      ).parseNonStreamingReasoning(message);
+
+      expect(result.thinking).not.toBeNull();
+      expect(result.thinking?.thought).toBe(
+        'Processing multiple operations.\n\nOperations queued.',
+      );
+      expect(result.toolCalls).toHaveLength(2);
+      expect(result.toolCalls[0]).toMatchObject({
+        type: 'tool_call',
+        name: 'edit',
+        parameters: {
+          file_path: '/test.ts',
+          old_string: 'foo',
+          new_string: 'bar',
+        },
+      });
+      expect(result.toolCalls[1]).toMatchObject({
+        type: 'tool_call',
+        name: 'glob',
+        parameters: { pattern: '**/*.ts' },
+      });
+    });
+
+    it('should return empty arrays when reasoning_content has no tool calls', () => {
+      const message: OpenAI.Chat.Completions.ChatCompletionMessage = {
+        role: 'assistant',
+        content: 'Answer',
+        reasoning_content: 'Just pure reasoning here.',
+      };
+
+      const result = (
+        provider as unknown as {
+          parseNonStreamingReasoning: (
+            message: OpenAI.Chat.Completions.ChatCompletionMessage,
+          ) => { thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] };
+        }
+      ).parseNonStreamingReasoning(message);
+
+      expect(result.thinking).not.toBeNull();
+      expect(result.thinking?.thought).toBe('Just pure reasoning here.');
+      expect(result.toolCalls).toHaveLength(0);
+    });
+
+    it('should return null thinking and empty toolCalls when reasoning_content is absent', () => {
+      const message: OpenAI.Chat.Completions.ChatCompletionMessage = {
+        role: 'assistant',
+        content: 'Answer',
+      };
+
+      const result = (
+        provider as unknown as {
+          parseNonStreamingReasoning: (
+            message: OpenAI.Chat.Completions.ChatCompletionMessage,
+          ) => { thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] };
+        }
+      ).parseNonStreamingReasoning(message);
+
+      expect(result).not.toBeNull();
+      expect(result.thinking).toBeNull();
+      expect(result.toolCalls).toHaveLength(0);
+    });
+
+    it('should handle Kimi K2 style call IDs with prefixes', () => {
+      const message: OpenAI.Chat.Completions.ChatCompletionMessage = {
+        role: 'assistant',
+        content: 'Done',
+        reasoning_content: `<|tool_calls_section_begin|>
+<|tool_call_begin|>call_functionsgrep7:call_prefix_123<|tool_call_argument_begin|>{"pattern": "test"}<|tool_call_end|>
+<|tool_calls_section_end|>`,
+      };
+
+      const result = (
+        provider as unknown as {
+          parseNonStreamingReasoning: (
+            message: OpenAI.Chat.Completions.ChatCompletionMessage,
+          ) => { thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] };
+        }
+      ).parseNonStreamingReasoning(message);
+
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls[0].name).toBe('grep');
+    });
+
+    it('should trim whitespace-only thinking in non-streaming mode', () => {
+      const message: OpenAI.Chat.Completions.ChatCompletionMessage = {
+        role: 'assistant',
+        content: 'Answer',
+        reasoning_content: `
+<|tool_calls_section_begin|>
+<|tool_call_begin|>functions.test:call_1<|tool_call_argument_begin|>{}<|tool_call_end|>
+<|tool_calls_section_end|>
+   `,
+      };
+
+      const result = (
+        provider as unknown as {
+          parseNonStreamingReasoning: (
+            message: OpenAI.Chat.Completions.ChatCompletionMessage,
+          ) => { thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] };
+        }
+      ).parseNonStreamingReasoning(message);
+
+      // After extracting tool calls, only whitespace remains, should be null
+      expect(result.thinking).toBeNull();
+      expect(result.toolCalls).toHaveLength(1);
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #749 - Kimi K2 model embeds tool calls using special tokens in both `reasoning_content` and `delta.content`, causing raw tokens to leak into user output and tool calls to fail execution.

## Problem

When Kimi K2 sends responses with embedded tool calls using its special token format:
```
<|tool_calls_section_begin|>
<|tool_call_begin|>functions.tool_name:call_id<|tool_call_argument_begin|>{"arg": "value"}<|tool_call_end|>
<|tool_calls_section_end|>
```

These tokens were:
1. Not being extracted from `reasoning_content` - tool calls weren't executing
2. Leaking into user-visible output as raw tokens
3. Appearing inside `<think>` tags without sanitization

## Solution

### 1. Extract tool calls from reasoning_content
- Modified `parseStreamingReasoningDelta()` and `parseNonStreamingReasoning()` to:
  - Extract embedded Kimi tool calls using `extractKimiToolCallsFromText()`
  - Return new type `{ thinking: ThinkingBlock | null; toolCalls: ToolCallBlock[] }`
  - Updated all call sites to destructure and handle extracted tool calls

### 2. Fix hasOpenKimiSection buffer logic
- Changed from checking tag presence to counting occurrences:
  ```typescript
  // Before: hasKimiBegin && !hasKimiEnd (fails with multiple sections)
  // After: kimiBeginCount > kimiEndCount (correct accounting)
  ```
- This prevents premature buffer flush when multiple Kimi sections are present and only some are complete

### 3. Strip stray Kimi tokens
- Added cleanup in `extractKimiToolCallsFromText()` after section processing:
  ```typescript
  text = text.replace(/<\|tool_call(?:_(?:begin|end|argument_begin))?\|>/g, '');
  text = text.replace(/<\|tool_calls_section_(?:begin|end)\|>/g, '');
  ```
- Handles partial sections, malformed tokens, and any remaining stray tokens

### 4. Sanitize thinking content
- Clean Kimi tokens from `<think>` tag content before accumulation
- Prevents tokens embedded inside thinking blocks from leaking to output

## Testing

- Added comprehensive tests in `OpenAIProvider.reasoning.test.ts`:
  - Streaming reasoning_content with embedded Kimi tool calls
  - Non-streaming reasoning_content with embedded Kimi tool calls
  - Multiple tool calls in one chunk
  - Mixed content (thinking + tool calls + more thinking)
  - Malformed token handling

- Verified with `chutesk2streaming` profile (Kimi K2 Thinking model):
  - NO raw Kimi tokens in output
  - Tool calls execute properly
  - Clean user-facing text

## Files Changed

- `packages/core/src/providers/openai/OpenAIProvider.ts` - Main implementation
- `packages/core/src/providers/openai/OpenAIProvider.reasoning.test.ts` - Tests

## Verification

```bash
npm run lint:ci   # PASS
npm run typecheck # PASS
npm run build     # PASS
npm run bundle    # PASS
```

Live test with Kimi K2:
```bash
LLXPRT_DEBUG=llxprt:* node scripts/start.js --profile-load chutesk2streaming --prompt "analyze the codebase"
# SUCCESS - tool calls execute, no raw tokens in output
```

Fixes #749

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reasoning content handling to properly extract and process tool calls embedded within reasoning blocks.
  * Added sanitization to clean formatting artifacts from reasoning content.
  * Enhanced support for extracting tool calls from reasoning content in streaming and non-streaming modes.

* **Tests**
  * Updated test suite to validate reasoning and tool call extraction behavior across various scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->