### PR TITLE
fix(tests): Prevent LLM from bypassing replace test with write_file tool - fixes #751

### DIFF
--- a/integration-tests/replace.test.ts
+++ b/integration-tests/replace.test.ts
@@ -94,7 +94,13 @@ describe('replace', () => {
 
   it('should fail safely when old_string is not found', async () => {
     const rig = new TestRig();
-    await rig.setup('should fail safely when old_string is not found');
+    await rig.setup('should fail safely when old_string is not found', {
+      settings: {
+        // Prevent LLM from using write_file to bypass the replace failure
+        // This ensures the test is deterministic by restricting available tools
+        excludeTools: ['write_file'],
+      },
+    });
     const fileName = 'no_match.txt';
     const fileContent = 'hello world';
     rig.createFile(fileName, fileContent);


### PR DESCRIPTION
## Summary

This PR fixes #751, a flaky integration test in `replace.test.ts` where the LLM sometimes bypassed the expected failure by creatively rewriting the file.

## Problem

The test "should fail safely when old_string is not found" creates a file with `"hello world"` and asks the LLM to replace `"goodbye"` with `"farewell"`. The test expects the replace to fail since "goodbye" is not in the file.

However, the LLM sometimes "helps" by:
- Using `write_file` tool to rewrite the entire file to include "goodbye"
- Then successfully performing the replace operation

This causes the test to fail intermittently.

## Solution

Added `excludeTools: ['write_file']` to the test configuration, which:
- Prevents the LLM from using `write_file` to bypass the replace failure
- Restricts available tools to only `read_file` and `replace` (what the test actually needs)
- Makes the test deterministic

The `excludeTools` setting was already supported by `TestRig` through the `settings` parameter in `setup()`, so no infrastructure changes were needed.

## Changes

- Modified `integration-tests/replace.test.ts` to add `excludeTools` setting to the flaky test

## Test Plan

- [x] `npm run format` - passed
- [x] `npm run lint:ci` - passed  
- [x] `npm run typecheck` - passed
- [x] `npm run build` - passed
- [x] `npm run bundle` - passed

The test should now be deterministic since the LLM can no longer bypass the expected failure by using alternative tools.

## Related Issues

fixes #751

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test determinism to improve reliability and consistency of test execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->