### PR TITLE
fix(#584): Auto-retry when models return tool calls without text

### DIFF
--- a/packages/core/src/providers/openai/OpenAIProvider.emptyResponseRetry.test.ts
+++ b/packages/core/src/providers/openai/OpenAIProvider.emptyResponseRetry.test.ts
@@ -255,7 +255,7 @@ describe('OpenAIProvider empty response retry (issue #584)', () => {
     const continuationPrompt = continuationMessages.find(
       (m) =>
         m.role === 'user' &&
-        m.content?.includes('Based on the tool results above'),
+        m.content?.includes('tool calls above have been registered'),
     );
     expect(continuationPrompt).toBeDefined();
   });


### PR DESCRIPTION
## Summary

Fixes #584 - Resolves issue where certain models (specifically gpt-oss-120b on OpenRouter) complete tool calls successfully but return empty responses with finish_reason=stop, requiring users to manually type "continue" to get output.

This PR implements automatic continuation requests when this specific scenario is detected.

## Changes

### Core Implementation
- Added detection logic for empty responses after tool calls in both legacy and pipeline code paths
- Tracks `finish_reason` during streaming to identify when models stop without generating text
- Automatically constructs and sends a continuation request when:
  - `finish_reason === 'stop'`
  - Tool calls were executed successfully
  - No text content was generated (including thinking/reasoning content)

### Continuation Mechanism
When the condition is detected, the provider:
1. Builds a new message array with the full conversation history
2. Adds the assistant's tool call message
3. Includes placeholder tool response messages (since we don't execute tools in the provider)
4. Appends a user prompt requesting analysis/summary based on tool results
5. Makes a second streaming request
6. Yields the text content from the continuation response

### Safety Features
- Only retries once to prevent infinite loops
- Only triggers on `finish_reason=stop` (not on 'length' or other finish reasons)
- Logs retry attempts for debugging and monitoring
- Works in both legacy and pipeline tool processing modes

## Testing

### Unit Tests
- Created comprehensive test suite (`OpenAIProvider.emptyResponseRetry.test.ts`)
- Tests verify automatic retry when tools complete but no text is returned
- Tests verify no retry when text is already present
- Tests verify no retry on `finish_reason=length` (truncated responses)
- All tests pass

### Manual Testing
- Tested with synthetic profile - works correctly
- Ready for real-world testing with gpt-oss-120b on OpenRouter

## Technical Details

**Files Modified:**
- `packages/core/src/providers/openai/OpenAIProvider.ts`
  - Legacy path: Added `lastFinishReason` tracking and retry logic (lines ~2050, ~2716-2810)
  - Pipeline path: Added `lastFinishReason` tracking and retry logic (lines ~3726, ~4391-4495)

**Files Added:**
- `packages/core/src/providers/openai/OpenAIProvider.emptyResponseRetry.test.ts`
  - Test suite with 3 test cases covering different scenarios

## Related Issues

Closes #584

## Test Plan

- [x] Unit tests pass
- [x] Lint passes
- [x] Type check passes
- [x] Build succeeds
- [x] Tested with synthetic profile
- [ ] Ready for testing with gpt-oss-120b on OpenRouter by issue reporter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposes tool format detection to callers to improve handling of tool-based responses.

* **Bug Fixes**
  * Improved handling when tool calls produce no immediate text: the provider automatically requests a continuation so assistant replies aren't truncated or missing.
  * Better state tracking and logging around continuation events for more robust streaming behavior.

* **Tests**
  * Added tests validating continuation/retry behavior for empty streaming responses to ensure reliable retries and message emission.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->