### PR TITLE
fix(experimental-ui): avoid stdin contention

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -375,24 +375,27 @@ export async function main() {
   }
 
   const wasRaw = process.stdin.isRaw;
-  if (config.isInteractive() && !wasRaw && process.stdin.isTTY) {
+  if (
+    config.isInteractive() &&
+    !argv.experimentalUi &&
+    !wasRaw &&
+    process.stdin.isTTY
+  ) {
     // Set this as early as possible to avoid spurious characters from
     // input showing up in the output.
     process.stdin.setRawMode(true);
 
-    if (!argv.experimentalUi) {
-      // This cleanup isn't strictly needed but may help in certain situations.
-      process.on('SIGTERM', async () => {
-        process.stdin.setRawMode(wasRaw);
-        await runExitCleanup();
-        process.exit(0);
-      });
-      process.on('SIGINT', async () => {
-        process.stdin.setRawMode(wasRaw);
-        await runExitCleanup();
-        process.exit(130); // Standard exit code for SIGINT
-      });
-    }
+    // This cleanup isn't strictly needed but may help in certain situations.
+    process.on('SIGTERM', async () => {
+      process.stdin.setRawMode(wasRaw);
+      await runExitCleanup();
+      process.exit(0);
+    });
+    process.on('SIGINT', async () => {
+      process.stdin.setRawMode(wasRaw);
+      await runExitCleanup();
+      process.exit(130); // Standard exit code for SIGINT
+    });
 
     // Detect and enable Kitty keyboard protocol once at startup.
     detectAndEnableKittyProtocol();
@@ -837,6 +840,11 @@ export async function main() {
       } catch {
         // ignore
       }
+    }
+    // Ensure the parent process isn't consuming stdin while bun runs
+    // (inherited stdio means both processes share the same TTY fd).
+    if (process.stdin.isTTY) {
+      process.stdin.pause();
     }
 
     let uiRoot = dirname(uiEntryPath);


### PR DESCRIPTION
Fixes #776\n\nWhen launching the experimental UI via bun with inherited stdio, the parent process now avoids interactive stdin setup and pauses stdin so it doesn't compete with bun/OpenTUI for keystrokes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved input handling logic in interactive startup to better manage terminal states in experimental UI mode.

* **Bug Fixes**
  * Fixed stdin contention between parent and child processes in experimental UI mode by pausing parent input when the subprocess is active.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->