### PR TITLE
Fix Luther PR creation - #784

### DIFF
--- a/.github/workflows/luther.yml
+++ b/.github/workflows/luther.yml
@@ -613,8 +613,8 @@ jobs:
         id: pr
         if: steps.commit_push.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GH_SECRET }}
-          GITHUB_TOKEN: '' # Override job-level GITHUB_TOKEN to force gh to use GH_TOKEN
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
           ISSUE_BRANCH: ${{ steps.select_issue.outputs.branch }}
           ISSUE_TITLE: ${{ steps.issue_data.outputs.title }}
           ISSUE_NUMBER: ${{ steps.select_issue.outputs.issue_number }}


### PR DESCRIPTION
## Summary

Fixes #784 - Luther was failing to create PRs due to authentication issues.

## Problem

The Luther workflow was attempting to create PRs using `secrets.GH_SECRET` in the "Open or update pull request" step (line 616). This was causing authentication failures as seen in workflow run 20186769334, step 18.

## Solution

Changed the PR creation step to use the built-in `github.token` instead of `secrets.GH_SECRET`. The workflow now uses:
- **PR creation step**: Uses `github.token` for successful PR creation
- **CodeRabbit review request step**: Still uses `secrets.GH_SECRET` so the comment appears to come from the user (not a bot), ensuring CodeRabbit will respond

## Changes Made

- Modified `.github/workflows/luther.yml` line 616-617 to use `github.token` instead of `secrets.GH_SECRET`
- Kept the CodeRabbit review request step using `secrets.GH_SECRET` as intended

## Testing

- Validated workflow file with `actionlint` - no errors
- Validated ci.yml still passes - no errors

This fix enables Luther to create PRs successfully while still triggering bot reviews properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow authentication to use GitHub's native token mechanism, improving security and reliability of automated processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->