### PR TITLE
Fix keytar handling for MCP OAuth (#770)

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -53,6 +53,7 @@ esbuild
       '@lydell/node-pty-linux-x64',
       '@lydell/node-pty-win32-arm64',
       '@lydell/node-pty-win32-x64',
+      'keytar',
       'node:module',
       // UI package uses opentui which has Bun-specific imports that esbuild can't handle
       // Keep it external - it will be dynamically imported at runtime when --experimental-ui is used

--- a/packages/core/src/mcp/token-storage/keychain-token-storage.missing-keytar.test.ts
+++ b/packages/core/src/mcp/token-storage/keychain-token-storage.missing-keytar.test.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  KeychainTokenStorage,
+  resetKeytarLoader,
+  setKeytarLoader,
+} from './keychain-token-storage.js';
+
+describe('KeychainTokenStorage when keytar is missing', () => {
+  afterEach(() => {
+    resetKeytarLoader();
+  });
+
+  it('falls back without throwing when keytar cannot be loaded', async () => {
+    const error = new Error("Cannot find module 'keytar'");
+    (error as NodeJS.ErrnoException).code = 'ERR_MODULE_NOT_FOUND';
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    setKeytarLoader(() => Promise.reject(error));
+
+    const storage = new KeychainTokenStorage('service');
+
+    const isAvailable = await storage.checkKeychainAvailability();
+
+    expect(isAvailable).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'keytar not available; falling back to encrypted file storage for MCP tokens.',
+    );
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- mark keytar as external in the CLI bundle so native module isn’t inlined
- make keytar loading pluggable and warn clearly when missing; preserve encrypted file fallback
- add a regression test for missing-keytar behavior

## Testing
- npm run format
- npm run lint
- npm run typecheck
- npm run test
- npm run build
- node scripts/start.js --profile-load synthetic --prompt "write me a haiku"

Fixes #770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of token storage by implementing graceful fallback to encrypted file storage when keytar is unavailable, preventing application crashes while ensuring secure token management.

* **Tests**
  * Added test coverage for token storage behavior when keytar is unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->