### PR TITLE
fix: Add retry/backoff to GeminiProvider and OpenAIResponsesProvider for #813

### DIFF
--- a/packages/core/src/providers/gemini/GeminiProvider.retry.test.ts
+++ b/packages/core/src/providers/gemini/GeminiProvider.retry.test.ts
@@ -1,0 +1,636 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Tests for GeminiProvider retry/backoff behavior
+ * @plan PLAN-20251215-issue813
+ * @requirement REQ-RETRY-001: GeminiProvider must use retryWithBackoff for all SDK calls
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { GeminiProvider } from './GeminiProvider.js';
+import { type IContent } from '../../services/history/IContent.js';
+import { createProviderCallOptions } from '../../test-utils/providerCallOptions.js';
+import { ApiError } from '@google/genai';
+
+// Track calls to retryWithBackoff
+const retryWithBackoffMock = vi.hoisted(() =>
+  vi.fn(async (fn: () => Promise<unknown>) => fn()),
+);
+
+// Mock the retry utility
+vi.mock('../../utils/retry.js', () => ({
+  retryWithBackoff: retryWithBackoffMock,
+  getErrorStatus: vi.fn((error: unknown) => {
+    if (error && typeof error === 'object' && 'status' in error) {
+      return (error as { status: number }).status;
+    }
+    return undefined;
+  }),
+  isNetworkTransientError: vi.fn(() => false),
+}));
+
+const generateContentStreamMock = vi.hoisted(() => vi.fn());
+const generateContentMock = vi.hoisted(() => vi.fn());
+
+const googleGenAIConstructor = vi.hoisted(() =>
+  vi.fn().mockImplementation(() => ({
+    models: {
+      generateContentStream: generateContentStreamMock,
+      generateContent: generateContentMock,
+    },
+  })),
+);
+
+vi.mock('@google/genai', () => ({
+  GoogleGenAI: googleGenAIConstructor,
+  Type: { OBJECT: 'object' },
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+      this.name = 'ApiError';
+    }
+  },
+}));
+
+vi.mock('../../core/prompts.js', () => ({
+  getCoreSystemPromptAsync: vi.fn().mockResolvedValue('system prompt'),
+}));
+
+vi.mock('../../code_assist/codeAssist.js', () => ({
+  createCodeAssistContentGenerator: vi.fn(),
+}));
+
+const mockSettingsService = vi.hoisted(() => ({
+  set: vi.fn(),
+  get: vi.fn(),
+  getProviderSettings: vi.fn().mockReturnValue({}),
+  updateSettings: vi.fn(),
+  getAllGlobalSettings: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('../../settings/settingsServiceInstance.js', () => ({
+  getSettingsService: vi.fn(() => mockSettingsService),
+}));
+
+describe('GeminiProvider retry behavior', () => {
+  let provider: GeminiProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    retryWithBackoffMock.mockReset();
+    retryWithBackoffMock.mockImplementation(async (fn) => fn());
+    generateContentStreamMock.mockReset();
+    generateContentMock.mockReset();
+    delete process.env.GEMINI_API_KEY;
+  });
+
+  afterEach(() => {
+    delete process.env.GEMINI_API_KEY;
+  });
+
+  describe('generateChatCompletionWithOptions', () => {
+    it('should wrap streaming API calls with retryWithBackoff', async () => {
+      const fakeStream = {
+        async *[Symbol.asyncIterator]() {
+          yield {
+            candidates: [
+              {
+                content: {
+                  parts: [{ text: 'retry test response' }],
+                },
+              },
+            ],
+          };
+        },
+      };
+
+      // Make retryWithBackoff execute the streaming call
+      retryWithBackoffMock.mockImplementation(async (fn) => {
+        generateContentStreamMock.mockResolvedValueOnce(fakeStream);
+        return fn();
+      });
+
+      process.env.GEMINI_API_KEY = 'test-key';
+      provider = new GeminiProvider('test-key');
+
+      const generator = provider.generateChatCompletion(
+        createProviderCallOptions({
+          providerName: provider.name,
+          contents: [
+            {
+              speaker: 'human',
+              blocks: [{ type: 'text', text: 'hello retry' }],
+            },
+          ] as IContent[],
+        }),
+      );
+
+      // Consume the generator
+      const results: IContent[] = [];
+      for await (const chunk of generator) {
+        results.push(chunk);
+      }
+
+      // Verify retryWithBackoff was called
+      expect(retryWithBackoffMock).toHaveBeenCalled();
+
+      // Verify the retry options include proper error handling
+      const retryCall = retryWithBackoffMock.mock.calls[0];
+      expect(retryCall).toBeDefined();
+      const options = retryCall?.[1] as { shouldRetryOnError?: unknown };
+      expect(options?.shouldRetryOnError).toBeDefined();
+    });
+
+    it('should wrap non-streaming API calls with retryWithBackoff', async () => {
+      const response = {
+        candidates: [
+          {
+            content: {
+              parts: [{ text: 'non-streaming response' }],
+            },
+          },
+        ],
+      };
+
+      retryWithBackoffMock.mockImplementation(async (fn) => {
+        generateContentMock.mockResolvedValueOnce(response);
+        return fn();
+      });
+
+      process.env.GEMINI_API_KEY = 'test-key';
+      provider = new GeminiProvider('test-key');
+
+      // Force non-streaming mode
+      (
+        provider as unknown as {
+          providerConfig: {
+            getEphemeralSettings?: () => Record<string, unknown>;
+          };
+        }
+      ).providerConfig = {
+        getEphemeralSettings: () => ({
+          streaming: 'disabled',
+        }),
+      };
+
+      const generator = provider.generateChatCompletion(
+        createProviderCallOptions({
+          providerName: provider.name,
+          contents: [
+            {
+              speaker: 'human',
+              blocks: [{ type: 'text', text: 'hello non-streaming' }],
+            },
+          ] as IContent[],
+        }),
+      );
+
+      // Consume the generator
+      const results: IContent[] = [];
+      for await (const chunk of generator) {
+        results.push(chunk);
+      }
+
+      // Verify retryWithBackoff was called for non-streaming
+      expect(retryWithBackoffMock).toHaveBeenCalled();
+    });
+
+    it('should retry on 429 rate limit errors', async () => {
+      let callCount = 0;
+      const fakeStream = {
+        async *[Symbol.asyncIterator]() {
+          yield {
+            candidates: [
+              {
+                content: {
+                  parts: [{ text: 'success after retry' }],
+                },
+              },
+            ],
+          };
+        },
+      };
+
+      // Simulate retry behavior: fail first, succeed second
+      retryWithBackoffMock.mockImplementation(async (fn, options) => {
+        const shouldRetry = options?.shouldRetryOnError || (() => false);
+        while (callCount < 2) {
+          try {
+            callCount++;
+            if (callCount === 1) {
+              const error = new ApiError(429, 'Rate limit exceeded');
+              throw error;
+            }
+            generateContentStreamMock.mockResolvedValueOnce(fakeStream);
+            return fn();
+          } catch (error) {
+            if (!shouldRetry(error as Error)) {
+              throw error;
+            }
+            // Continue to retry
+          }
+        }
+        generateContentStreamMock.mockResolvedValueOnce(fakeStream);
+        return fn();
+      });
+
+      process.env.GEMINI_API_KEY = 'test-key';
+      provider = new GeminiProvider('test-key');
+
+      const generator = provider.generateChatCompletion(
+        createProviderCallOptions({
+          providerName: provider.name,
+          contents: [
+            {
+              speaker: 'human',
+              blocks: [{ type: 'text', text: 'test 429 retry' }],
+            },
+          ] as IContent[],
+        }),
+      );
+
+      const results: IContent[] = [];
+      for await (const chunk of generator) {
+        results.push(chunk);
+      }
+
+      // Should have succeeded after retry
+      expect(results.length).toBeGreaterThan(0);
+    });
+
+    it('should not retry on 400 bad request errors', async () => {
+      retryWithBackoffMock.mockImplementation(async (fn, options) => {
+        const shouldRetry = options?.shouldRetryOnError;
+        const error = new ApiError(400, 'Bad request');
+
+        // The shouldRetryOnError predicate should return false for 400
+        expect(shouldRetry).toBeDefined();
+        expect(shouldRetry!(error)).toBe(false);
+
+        throw error;
+      });
+
+      process.env.GEMINI_API_KEY = 'test-key';
+      provider = new GeminiProvider('test-key');
+
+      const generator = provider.generateChatCompletion(
+        createProviderCallOptions({
+          providerName: provider.name,
+          contents: [
+            {
+              speaker: 'human',
+              blocks: [{ type: 'text', text: 'test 400 no retry' }],
+            },
+          ] as IContent[],
+        }),
+      );
+
+      await expect(async () => {
+        for await (const _chunk of generator) {
+          // Should throw before yielding
+        }
+      }).rejects.toThrow();
+    });
+
+    it('should provide shouldRetryOnError callback to retryWithBackoff', async () => {
+      const fakeStream = {
+        async *[Symbol.asyncIterator]() {
+          yield {
+            candidates: [
+              {
+                content: {
+                  parts: [{ text: 'retry options test' }],
+                },
+              },
+            ],
+          };
+        },
+      };
+
+      retryWithBackoffMock.mockImplementation(async (fn, options) => {
+        // Verify shouldRetryOnError callback is provided
+        expect(options?.shouldRetryOnError).toBeDefined();
+        generateContentStreamMock.mockResolvedValueOnce(fakeStream);
+        return fn();
+      });
+
+      process.env.GEMINI_API_KEY = 'test-key';
+      provider = new GeminiProvider('test-key');
+
+      const generator = provider.generateChatCompletion(
+        createProviderCallOptions({
+          providerName: provider.name,
+          contents: [
+            {
+              speaker: 'human',
+              blocks: [{ type: 'text', text: 'retry options test' }],
+            },
+          ] as IContent[],
+        }),
+      );
+
+      for await (const _chunk of generator) {
+        // Consume
+      }
+
+      expect(retryWithBackoffMock).toHaveBeenCalled();
+    });
+  });
+
+  describe('invokeServerTool', () => {
+    it('should wrap web_search calls with retryWithBackoff', async () => {
+      const searchResult = {
+        candidates: [
+          {
+            content: {
+              parts: [{ text: 'search results' }],
+            },
+          },
+        ],
+      };
+
+      retryWithBackoffMock.mockImplementation(async (fn) => {
+        generateContentMock.mockResolvedValueOnce(searchResult);
+        return fn();
+      });
+
+      process.env.GEMINI_API_KEY = 'test-key';
+      provider = new GeminiProvider('test-key');
+
+      await provider.invokeServerTool('web_search', { query: 'test query' });
+
+      // Verify retryWithBackoff was called for web_search
+      expect(retryWithBackoffMock).toHaveBeenCalled();
+    });
+
+    it('should wrap web_fetch calls with retryWithBackoff', async () => {
+      const fetchResult = {
+        candidates: [
+          {
+            content: {
+              parts: [{ text: 'fetch results' }],
+            },
+          },
+        ],
+      };
+
+      retryWithBackoffMock.mockImplementation(async (fn) => {
+        generateContentMock.mockResolvedValueOnce(fetchResult);
+        return fn();
+      });
+
+      process.env.GEMINI_API_KEY = 'test-key';
+      provider = new GeminiProvider('test-key');
+
+      await provider.invokeServerTool('web_fetch', {
+        prompt: 'fetch https://example.com',
+      });
+
+      // Verify retryWithBackoff was called for web_fetch
+      expect(retryWithBackoffMock).toHaveBeenCalled();
+    });
+
+    it('should retry server tool calls on 429 errors', async () => {
+      let attempts = 0;
+      const searchResult = {
+        candidates: [
+          {
+            content: {
+              parts: [{ text: 'success after retry' }],
+            },
+          },
+        ],
+      };
+
+      retryWithBackoffMock.mockImplementation(async (fn, options) => {
+        const shouldRetry = options?.shouldRetryOnError || (() => false);
+        while (attempts < 3) {
+          try {
+            attempts++;
+            if (attempts <= 2) {
+              const error = new ApiError(429, 'Rate limit');
+              if (!shouldRetry(error)) {
+                throw error;
+              }
+              continue;
+            }
+            generateContentMock.mockResolvedValueOnce(searchResult);
+            return fn();
+          } catch (error) {
+            if (!shouldRetry(error as Error)) {
+              throw error;
+            }
+          }
+        }
+        generateContentMock.mockResolvedValueOnce(searchResult);
+        return fn();
+      });
+
+      process.env.GEMINI_API_KEY = 'test-key';
+      provider = new GeminiProvider('test-key');
+
+      const result = await provider.invokeServerTool('web_search', {
+        query: 'retry test',
+      });
+
+      expect(result).toBeDefined();
+    });
+
+    it('should retry server tool calls on 5xx errors', async () => {
+      let attempts = 0;
+      const searchResult = {
+        candidates: [
+          {
+            content: {
+              parts: [{ text: 'success after 500' }],
+            },
+          },
+        ],
+      };
+
+      retryWithBackoffMock.mockImplementation(async (fn, options) => {
+        const shouldRetry = options?.shouldRetryOnError || (() => false);
+        while (attempts < 2) {
+          try {
+            attempts++;
+            if (attempts === 1) {
+              const error = new ApiError(503, 'Service unavailable');
+              if (!shouldRetry(error)) {
+                throw error;
+              }
+              continue;
+            }
+            generateContentMock.mockResolvedValueOnce(searchResult);
+            return fn();
+          } catch (error) {
+            if (!shouldRetry(error as Error)) {
+              throw error;
+            }
+          }
+        }
+        generateContentMock.mockResolvedValueOnce(searchResult);
+        return fn();
+      });
+
+      process.env.GEMINI_API_KEY = 'test-key';
+      provider = new GeminiProvider('test-key');
+
+      const result = await provider.invokeServerTool('web_search', {
+        query: '5xx retry test',
+      });
+
+      expect(result).toBeDefined();
+    });
+  });
+
+  describe('shouldRetryOnError predicate', () => {
+    it('should return true for 429 errors', async () => {
+      let capturedPredicate: ((error: Error) => boolean) | undefined;
+
+      retryWithBackoffMock.mockImplementation(async (_fn, options) => {
+        capturedPredicate = options?.shouldRetryOnError;
+        // Don't actually call fn, just capture the predicate
+        return {
+          candidates: [{ content: { parts: [{ text: 'test' }] } }],
+        };
+      });
+
+      process.env.GEMINI_API_KEY = 'test-key';
+      provider = new GeminiProvider('test-key');
+
+      // Force non-streaming to get simpler flow
+      (
+        provider as unknown as {
+          providerConfig: {
+            getEphemeralSettings?: () => Record<string, unknown>;
+          };
+        }
+      ).providerConfig = {
+        getEphemeralSettings: () => ({
+          streaming: 'disabled',
+        }),
+      };
+
+      const generator = provider.generateChatCompletion(
+        createProviderCallOptions({
+          providerName: provider.name,
+          contents: [
+            {
+              speaker: 'human',
+              blocks: [{ type: 'text', text: 'predicate test' }],
+            },
+          ] as IContent[],
+        }),
+      );
+
+      for await (const _chunk of generator) {
+        // Consume to trigger the call
+      }
+
+      expect(capturedPredicate).toBeDefined();
+      const error429 = new ApiError(429, 'Rate limit');
+      expect(capturedPredicate!(error429)).toBe(true);
+    });
+
+    it('should return true for 5xx errors', async () => {
+      let capturedPredicate: ((error: Error) => boolean) | undefined;
+
+      retryWithBackoffMock.mockImplementation(async (_fn, options) => {
+        capturedPredicate = options?.shouldRetryOnError;
+        return {
+          candidates: [{ content: { parts: [{ text: 'test' }] } }],
+        };
+      });
+
+      process.env.GEMINI_API_KEY = 'test-key';
+      provider = new GeminiProvider('test-key');
+
+      (
+        provider as unknown as {
+          providerConfig: {
+            getEphemeralSettings?: () => Record<string, unknown>;
+          };
+        }
+      ).providerConfig = {
+        getEphemeralSettings: () => ({
+          streaming: 'disabled',
+        }),
+      };
+
+      const generator = provider.generateChatCompletion(
+        createProviderCallOptions({
+          providerName: provider.name,
+          contents: [
+            {
+              speaker: 'human',
+              blocks: [{ type: 'text', text: 'predicate test 5xx' }],
+            },
+          ] as IContent[],
+        }),
+      );
+
+      for await (const _chunk of generator) {
+        // Consume
+      }
+
+      expect(capturedPredicate).toBeDefined();
+      const error500 = new ApiError(500, 'Internal server error');
+      const error502 = new ApiError(502, 'Bad gateway');
+      const error503 = new ApiError(503, 'Service unavailable');
+
+      expect(capturedPredicate!(error500)).toBe(true);
+      expect(capturedPredicate!(error502)).toBe(true);
+      expect(capturedPredicate!(error503)).toBe(true);
+    });
+
+    it('should return false for 400 errors', async () => {
+      let capturedPredicate: ((error: Error) => boolean) | undefined;
+
+      retryWithBackoffMock.mockImplementation(async (_fn, options) => {
+        capturedPredicate = options?.shouldRetryOnError;
+        return {
+          candidates: [{ content: { parts: [{ text: 'test' }] } }],
+        };
+      });
+
+      process.env.GEMINI_API_KEY = 'test-key';
+      provider = new GeminiProvider('test-key');
+
+      (
+        provider as unknown as {
+          providerConfig: {
+            getEphemeralSettings?: () => Record<string, unknown>;
+          };
+        }
+      ).providerConfig = {
+        getEphemeralSettings: () => ({
+          streaming: 'disabled',
+        }),
+      };
+
+      const generator = provider.generateChatCompletion(
+        createProviderCallOptions({
+          providerName: provider.name,
+          contents: [
+            {
+              speaker: 'human',
+              blocks: [{ type: 'text', text: 'predicate test 400' }],
+            },
+          ] as IContent[],
+        }),
+      );
+
+      for await (const _chunk of generator) {
+        // Consume
+      }
+
+      expect(capturedPredicate).toBeDefined();
+      const error400 = new ApiError(400, 'Bad request');
+      expect(capturedPredicate!(error400)).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/providers/openai-responses/OpenAIResponsesProvider.retry.test.ts
+++ b/packages/core/src/providers/openai-responses/OpenAIResponsesProvider.retry.test.ts
@@ -1,0 +1,464 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Tests for OpenAIResponsesProvider retry/backoff behavior
+ * @plan PLAN-20251215-issue813
+ * @requirement REQ-RETRY-001: OpenAIResponsesProvider must use retryWithBackoff for all fetch calls
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { OpenAIResponsesProvider } from './OpenAIResponsesProvider.js';
+import { type IContent } from '../../services/history/IContent.js';
+import { createProviderCallOptions } from '../../test-utils/providerCallOptions.js';
+
+// Track calls to retryWithBackoff
+const retryWithBackoffMock = vi.hoisted(() =>
+  vi.fn(async (fn: () => Promise<unknown>) => fn()),
+);
+
+// Mock the retry utility
+vi.mock('../../utils/retry.js', () => ({
+  retryWithBackoff: retryWithBackoffMock,
+  getErrorStatus: vi.fn((error: unknown) => {
+    if (error && typeof error === 'object' && 'status' in error) {
+      return (error as { status: number }).status;
+    }
+    return undefined;
+  }),
+  isNetworkTransientError: vi.fn(() => false),
+}));
+
+const mockSettingsService = vi.hoisted(() => ({
+  set: vi.fn(),
+  get: vi.fn(),
+  setProviderSetting: vi.fn(),
+  getProviderSettings: vi.fn().mockReturnValue({}),
+  getSettings: vi.fn(),
+  updateSettings: vi.fn(),
+  getAllGlobalSettings: vi.fn().mockReturnValue({}),
+}));
+
+const parseResponsesStreamMock = vi.hoisted(() =>
+  vi.fn(async function* () {
+    yield {
+      speaker: 'ai',
+      blocks: [{ type: 'text', text: 'test response' }],
+    };
+  }),
+);
+
+const parseErrorResponseMock = vi.hoisted(() =>
+  vi.fn((status: number, body: string, provider: string) => {
+    const error = new Error(`${provider} API error ${status}: ${body}`);
+    (error as Error & { status: number }).status = status;
+    return error;
+  }),
+);
+
+const fetchMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../settings/settingsServiceInstance.js', () => ({
+  getSettingsService: () => mockSettingsService,
+}));
+
+vi.mock('../../core/prompts.js', () => ({
+  getCoreSystemPromptAsync: vi.fn().mockResolvedValue('system prompt'),
+}));
+
+vi.mock('../openai/parseResponsesStream.js', () => ({
+  parseResponsesStream: parseResponsesStreamMock,
+  parseErrorResponse: parseErrorResponseMock,
+}));
+
+describe('OpenAIResponsesProvider retry behavior', () => {
+  let provider: OpenAIResponsesProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    retryWithBackoffMock.mockReset();
+    retryWithBackoffMock.mockImplementation(async (fn) => fn());
+    mockSettingsService.getSettings.mockResolvedValue({});
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  describe('generateChatCompletionWithOptions', () => {
+    it('should wrap fetch calls with retryWithBackoff', async () => {
+      retryWithBackoffMock.mockImplementation(async (fn) => {
+        fetchMock.mockResolvedValueOnce({
+          ok: true,
+          body: {
+            async *[Symbol.asyncIterator]() {
+              yield new TextEncoder().encode('data: {"type":"done"}\n\n');
+            },
+          },
+        });
+        return fn();
+      });
+
+      provider = new OpenAIResponsesProvider('test-key');
+
+      const generator = provider.generateChatCompletion(
+        createProviderCallOptions({
+          providerName: provider.name,
+          contents: [
+            {
+              speaker: 'human',
+              blocks: [{ type: 'text', text: 'hello retry' }],
+            },
+          ] as IContent[],
+        }),
+      );
+
+      // Consume the generator
+      for await (const _chunk of generator) {
+        // Consume
+      }
+
+      // Verify retryWithBackoff was called
+      expect(retryWithBackoffMock).toHaveBeenCalled();
+    });
+
+    it('should provide shouldRetryOnError callback to retryWithBackoff', async () => {
+      retryWithBackoffMock.mockImplementation(async (fn, options) => {
+        // Verify shouldRetryOnError callback is provided
+        expect(options?.shouldRetryOnError).toBeDefined();
+        fetchMock.mockResolvedValueOnce({
+          ok: true,
+          body: undefined,
+        });
+        return fn();
+      });
+
+      provider = new OpenAIResponsesProvider('test-key');
+
+      const generator = provider.generateChatCompletion(
+        createProviderCallOptions({
+          providerName: provider.name,
+          contents: [
+            {
+              speaker: 'human',
+              blocks: [{ type: 'text', text: 'retry options test' }],
+            },
+          ] as IContent[],
+        }),
+      );
+
+      for await (const _chunk of generator) {
+        // Consume
+      }
+
+      expect(retryWithBackoffMock).toHaveBeenCalled();
+    });
+
+    it('should retry on 429 rate limit errors', async () => {
+      let callCount = 0;
+
+      retryWithBackoffMock.mockImplementation(async (fn, options) => {
+        const shouldRetry = options?.shouldRetryOnError || (() => false);
+
+        while (callCount < 2) {
+          try {
+            callCount++;
+            if (callCount === 1) {
+              // First call returns 429
+              fetchMock.mockResolvedValueOnce({
+                ok: false,
+                status: 429,
+                text: async () => 'Rate limit exceeded',
+              });
+              const result = await fn();
+              // If we get here without throwing, check if response is not ok
+              if (
+                result &&
+                typeof result === 'object' &&
+                'ok' in result &&
+                !result.ok
+              ) {
+                const error = new Error('Rate limit exceeded');
+                (error as Error & { status: number }).status = 429;
+                if (shouldRetry(error)) {
+                  continue;
+                }
+                throw error;
+              }
+              return result;
+            }
+            // Second call succeeds
+            fetchMock.mockResolvedValueOnce({
+              ok: true,
+              body: undefined,
+            });
+            return fn();
+          } catch (error) {
+            if (!shouldRetry(error as Error)) {
+              throw error;
+            }
+          }
+        }
+        fetchMock.mockResolvedValueOnce({
+          ok: true,
+          body: undefined,
+        });
+        return fn();
+      });
+
+      provider = new OpenAIResponsesProvider('test-key');
+
+      const generator = provider.generateChatCompletion(
+        createProviderCallOptions({
+          providerName: provider.name,
+          contents: [
+            {
+              speaker: 'human',
+              blocks: [{ type: 'text', text: 'test 429 retry' }],
+            },
+          ] as IContent[],
+        }),
+      );
+
+      const results: IContent[] = [];
+      for await (const chunk of generator) {
+        results.push(chunk);
+      }
+
+      // Should have succeeded (not thrown)
+      expect(retryWithBackoffMock).toHaveBeenCalled();
+    });
+
+    it('should not retry on 400 bad request errors', async () => {
+      retryWithBackoffMock.mockImplementation(async (_fn, options) => {
+        const shouldRetry = options?.shouldRetryOnError;
+        const error = new Error('Bad request');
+        (error as Error & { status: number }).status = 400;
+
+        // The shouldRetryOnError predicate should return false for 400
+        expect(shouldRetry).toBeDefined();
+        expect(shouldRetry!(error)).toBe(false);
+
+        throw error;
+      });
+
+      provider = new OpenAIResponsesProvider('test-key');
+
+      const generator = provider.generateChatCompletion(
+        createProviderCallOptions({
+          providerName: provider.name,
+          contents: [
+            {
+              speaker: 'human',
+              blocks: [{ type: 'text', text: 'test 400 no retry' }],
+            },
+          ] as IContent[],
+        }),
+      );
+
+      await expect(async () => {
+        for await (const _chunk of generator) {
+          // Should throw before yielding
+        }
+      }).rejects.toThrow();
+    });
+
+    it('should retry on 5xx server errors', async () => {
+      let callCount = 0;
+
+      retryWithBackoffMock.mockImplementation(async (fn, options) => {
+        const shouldRetry = options?.shouldRetryOnError || (() => false);
+
+        while (callCount < 2) {
+          try {
+            callCount++;
+            if (callCount === 1) {
+              const error = new Error('Service unavailable');
+              (error as Error & { status: number }).status = 503;
+              if (shouldRetry(error)) {
+                continue;
+              }
+              throw error;
+            }
+            fetchMock.mockResolvedValueOnce({
+              ok: true,
+              body: undefined,
+            });
+            return fn();
+          } catch (error) {
+            if (!shouldRetry(error as Error)) {
+              throw error;
+            }
+          }
+        }
+        fetchMock.mockResolvedValueOnce({
+          ok: true,
+          body: undefined,
+        });
+        return fn();
+      });
+
+      provider = new OpenAIResponsesProvider('test-key');
+
+      const generator = provider.generateChatCompletion(
+        createProviderCallOptions({
+          providerName: provider.name,
+          contents: [
+            {
+              speaker: 'human',
+              blocks: [{ type: 'text', text: 'test 503 retry' }],
+            },
+          ] as IContent[],
+        }),
+      );
+
+      for await (const _chunk of generator) {
+        // Consume
+      }
+
+      expect(retryWithBackoffMock).toHaveBeenCalled();
+    });
+  });
+
+  describe('getModels', () => {
+    it('should wrap models fetch with retryWithBackoff', async () => {
+      retryWithBackoffMock.mockImplementation(async (fn) => {
+        fetchMock.mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            data: [{ id: 'o3-mini' }, { id: 'o1' }],
+          }),
+        });
+        return fn();
+      });
+
+      provider = new OpenAIResponsesProvider('test-key');
+
+      const models = await provider.getModels();
+
+      // Verify retryWithBackoff was called for getModels
+      expect(retryWithBackoffMock).toHaveBeenCalled();
+      expect(models.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('shouldRetryOnError predicate', () => {
+    it('should return true for 429 errors', async () => {
+      let capturedPredicate: ((error: Error) => boolean) | undefined;
+
+      retryWithBackoffMock.mockImplementation(async (_fn, options) => {
+        capturedPredicate = options?.shouldRetryOnError;
+        fetchMock.mockResolvedValueOnce({
+          ok: true,
+          body: undefined,
+        });
+        return { ok: true, body: undefined };
+      });
+
+      provider = new OpenAIResponsesProvider('test-key');
+
+      const generator = provider.generateChatCompletion(
+        createProviderCallOptions({
+          providerName: provider.name,
+          contents: [
+            {
+              speaker: 'human',
+              blocks: [{ type: 'text', text: 'predicate test' }],
+            },
+          ] as IContent[],
+        }),
+      );
+
+      for await (const _chunk of generator) {
+        // Consume
+      }
+
+      expect(capturedPredicate).toBeDefined();
+      const error429 = new Error('Rate limit');
+      (error429 as Error & { status: number }).status = 429;
+      expect(capturedPredicate!(error429)).toBe(true);
+    });
+
+    it('should return true for 5xx errors', async () => {
+      let capturedPredicate: ((error: Error) => boolean) | undefined;
+
+      retryWithBackoffMock.mockImplementation(async (_fn, options) => {
+        capturedPredicate = options?.shouldRetryOnError;
+        fetchMock.mockResolvedValueOnce({
+          ok: true,
+          body: undefined,
+        });
+        return { ok: true, body: undefined };
+      });
+
+      provider = new OpenAIResponsesProvider('test-key');
+
+      const generator = provider.generateChatCompletion(
+        createProviderCallOptions({
+          providerName: provider.name,
+          contents: [
+            {
+              speaker: 'human',
+              blocks: [{ type: 'text', text: 'predicate test 5xx' }],
+            },
+          ] as IContent[],
+        }),
+      );
+
+      for await (const _chunk of generator) {
+        // Consume
+      }
+
+      expect(capturedPredicate).toBeDefined();
+      const error500 = new Error('Internal server error');
+      (error500 as Error & { status: number }).status = 500;
+      const error502 = new Error('Bad gateway');
+      (error502 as Error & { status: number }).status = 502;
+      const error503 = new Error('Service unavailable');
+      (error503 as Error & { status: number }).status = 503;
+
+      expect(capturedPredicate!(error500)).toBe(true);
+      expect(capturedPredicate!(error502)).toBe(true);
+      expect(capturedPredicate!(error503)).toBe(true);
+    });
+
+    it('should return false for 400 errors', async () => {
+      let capturedPredicate: ((error: Error) => boolean) | undefined;
+
+      retryWithBackoffMock.mockImplementation(async (_fn, options) => {
+        capturedPredicate = options?.shouldRetryOnError;
+        fetchMock.mockResolvedValueOnce({
+          ok: true,
+          body: undefined,
+        });
+        return { ok: true, body: undefined };
+      });
+
+      provider = new OpenAIResponsesProvider('test-key');
+
+      const generator = provider.generateChatCompletion(
+        createProviderCallOptions({
+          providerName: provider.name,
+          contents: [
+            {
+              speaker: 'human',
+              blocks: [{ type: 'text', text: 'predicate test 400' }],
+            },
+          ] as IContent[],
+        }),
+      );
+
+      for await (const _chunk of generator) {
+        // Consume
+      }
+
+      expect(capturedPredicate).toBeDefined();
+      const error400 = new Error('Bad request');
+      (error400 as Error & { status: number }).status = 400;
+      expect(capturedPredicate!(error400)).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/providers/openai-responses/OpenAIResponsesProvider.ts
+++ b/packages/core/src/providers/openai-responses/OpenAIResponsesProvider.ts
@@ -51,6 +51,11 @@ import { resolveRuntimeAuthToken } from '../utils/authToken.js';
 import { filterOpenAIRequestParams } from '../openai/openaiRequestParams.js';
 import { CodexOAuthTokenSchema } from '../../auth/types.js';
 import type { OAuthManager } from '../../auth/precedence.js';
+import {
+  retryWithBackoff,
+  getErrorStatus,
+  isNetworkTransientError,
+} from '../../utils/retry.js';
 
 export class OpenAIResponsesProvider extends BaseProvider {
   private logger: DebugLogger;
@@ -108,6 +113,32 @@ export class OpenAIResponsesProvider extends BaseProvider {
    */
   private isCodexMode(baseURL: string | undefined): boolean {
     return baseURL?.includes('chatgpt.com/backend-api/codex') ?? false;
+  }
+
+  /**
+   * @plan PLAN-20251215-issue813
+   * @requirement REQ-RETRY-001: OpenAIResponsesProvider must use retryWithBackoff for all fetch calls
+   *
+   * Determines if an error should trigger a retry.
+   * - 429 (rate limit) errors are retried
+   * - 5xx server errors are retried
+   * - 400 (bad request) errors are NOT retried
+   * - Network transient errors are retried
+   */
+  private shouldRetryOnError(error: Error | unknown): boolean {
+    // Check for status using helper (handles error shapes from fetch)
+    const status = getErrorStatus(error);
+    if (status !== undefined) {
+      if (status === 400) return false;
+      return status === 429 || (status >= 500 && status < 600);
+    }
+
+    // Check for network transient errors
+    if (isNetworkTransientError(error)) {
+      return true;
+    }
+
+    return false;
   }
 
   /**
@@ -172,13 +203,20 @@ export class OpenAIResponsesProvider extends BaseProvider {
     }
 
     try {
+      // @plan PLAN-20251215-issue813: Wrap with retryWithBackoff for 429/5xx handling
       // Fetch models from the API
-      const response = await fetch(`${baseURL}/models`, {
-        method: 'GET',
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
+      const response = await retryWithBackoff(
+        () =>
+          fetch(`${baseURL}/models`, {
+            method: 'GET',
+            headers: {
+              Authorization: `Bearer ${apiKey}`,
+            },
+          }),
+        {
+          shouldRetryOnError: this.shouldRetryOnError.bind(this),
         },
-      });
+      );
 
       if (response.ok) {
         const data = (await response.json()) as { data: Array<{ id: string }> };
@@ -611,11 +649,18 @@ export class OpenAIResponsesProvider extends BaseProvider {
       );
     }
 
-    const response = await fetch(responsesURL, {
-      method: 'POST',
-      headers,
-      body: bodyBlob,
-    });
+    // @plan PLAN-20251215-issue813: Wrap with retryWithBackoff for 429/5xx handling
+    const response = await retryWithBackoff(
+      () =>
+        fetch(responsesURL, {
+          method: 'POST',
+          headers,
+          body: bodyBlob,
+        }),
+      {
+        shouldRetryOnError: this.shouldRetryOnError.bind(this),
+      },
+    );
 
     if (!response.ok) {
       const errorBody = await response.text();


### PR DESCRIPTION
## Summary

Fixes #813 - GeminiProvider now has proper retry/backoff handling for all SDK calls.

Additionally addresses CodeRabbit's finding that OpenAIResponsesProvider had the same issue with direct fetch() calls not being wrapped with retry logic.

### Changes

**GeminiProvider:**
- Added `shouldRetryOnError` method to determine retry eligibility (429, 5xx, network transient errors)
- Wrapped all `generateContent`/`generateContentStream` calls in `invokeServerTool` (6 call sites for web_search and web_fetch across API key, Vertex AI, and OAuth modes)
- Wrapped all `generateContent`/`generateContentStream` calls in `generateChatCompletionWithOptions` (4 call sites for streaming/non-streaming, OAuth/API key modes)
- Added comprehensive test suite with 12 tests covering retry behavior

**OpenAIResponsesProvider:**
- Added `shouldRetryOnError` method matching the same pattern
- Wrapped `fetch()` call in `getModels()` for model listing
- Wrapped `fetch()` call in `generateChatCompletionWithOptions()` for the main API endpoint
- Added comprehensive test suite with 9 tests covering retry behavior

### Retry Behavior

Both providers now properly retry on:
- **429 (Too Many Requests):** Rate limit errors - retried with exponential backoff
- **5xx Server Errors:** 500, 502, 503, etc. - retried with exponential backoff  
- **Network Transient Errors:** ECONNRESET, ETIMEDOUT, socket errors - retried automatically
- **400 Bad Request:** NOT retried (non-recoverable error)

The implementation follows the existing patterns in `AnthropicProvider` and `OpenAIProvider` which already had proper retry handling.

### Test Plan

- [x] All 12 new GeminiProvider retry tests pass
- [x] All 9 new OpenAIResponsesProvider retry tests pass
- [x] All 53 existing GeminiProvider tests pass
- [x] All 30 existing OpenAIResponsesProvider tests pass
- [x] Lint passes with zero warnings
- [x] Typecheck passes for core package
- [x] Build succeeds
- [x] Format applied

### Files Changed

- `packages/core/src/providers/gemini/GeminiProvider.ts` - Added retry wrapping to all SDK calls
- `packages/core/src/providers/gemini/GeminiProvider.retry.test.ts` - New test file for retry behavior
- `packages/core/src/providers/openai-responses/OpenAIResponsesProvider.ts` - Added retry wrapping to fetch calls
- `packages/core/src/providers/openai-responses/OpenAIResponsesProvider.retry.test.ts` - New test file for retry behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic retry with backoff for transient API failures across supported providers, improving resilience to rate limits and temporary server errors.

* **Tests**
  * Added comprehensive retry behavior validation tests for API provider interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->