### PR TITLE
fix(cli): use custom descriptions for /set command options

### DIFF
--- a/packages/cli/src/ui/commands/setCommand.ts
+++ b/packages/cli/src/ui/commands/setCommand.ts
@@ -330,7 +330,7 @@ const directSettingSpecs: SettingLiteralSpec[] = [
 const createSettingLiteral = (spec: SettingLiteralSpec): LiteralArgument => ({
   kind: 'literal' as const,
   value: spec.value,
-  description: `${toTitleCase(spec.value)} option`,
+  description: spec.description ?? `${toTitleCase(spec.value)} option`,
   stopPropagation: true,
   next: [
     {


### PR DESCRIPTION
## Summary

Fixes #723

The `/set` command was displaying unhelpful auto-generated descriptions for settings like:

```
reasoning.enabled             Reasoning.Enabled option
reasoning.includeInContext    Reasoning.Include In Context option
reasoning.includeInResponse   Reasoning.Include In Response option
```

## Root Cause

The `createSettingLiteral` function in `packages/cli/src/ui/commands/setCommand.ts` was **ignoring** the `description` field from `SettingLiteralSpec` and always generating a fallback description by title-casing the setting key:

```typescript
// Before (line 333)
description: \`${toTitleCase(spec.value)} option\`,
```

This resulted in descriptions like "Reasoning.Include In Context option" even though proper descriptions were already defined in `directSettingSpecs`.

## Fix

Changed line 333 to use the custom description when available:

```typescript
// After
description: spec.description ?? \`${toTitleCase(spec.value)} option\`,
```

## Result

Now users will see meaningful descriptions like:

| Setting | New Description |
|---------|-----------------|
| `reasoning.enabled` | Show AI thinking process (Claude, Gemini 3, DeepSeek, etc) |
| `reasoning.includeInContext` | Send thinking to API on follow-up requests (uses more tokens) |
| `reasoning.includeInResponse` | Display thinking blocks in the UI |
| `reasoning.format` | API format: native (provider default) or field (reasoning_content) |
| `reasoning.stripFromContext` | Strip thinking blocks before sending to model (all/allButLast/none) |
| `reasoning.effort` | Thinking budget: low, medium, high (model-dependent) |
| `reasoning.maxTokens` | Max tokens for thinking/reasoning (some models require this) |

## Testing

- ✅ All existing `setCommand.test.ts` tests pass
- ✅ Lint passes
- ✅ Type check passes
- ✅ Build succeeds

## Notes

This is a minimal one-line change that respects the existing fallback behavior for settings without custom descriptions while enabling the descriptions that were already defined but unused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settings option descriptions to display custom text when available, providing clearer configuration guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->