### PR TITLE
fix(test): update setCommand test expectation for unset option hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,6 @@ Get started immediately with powerful LLM options:
 /auth anthropic enable
 /provider anthropic
 /model claude-sonnet-4-5
-
-# Kimi k2-thinking for deep reasoning
-/auth kimi enable
-/provider kimi
-/model k2-thinking
-/set thinkingBudget 10000  # Adjust based on task complexity
 ```
 
 ## Why Choose LLxprt Code?


### PR DESCRIPTION
Updated the expected hint in `setCommand.phase09.test.ts` from 'Select option' to 'Unset option' to match the actual behavior defined in the schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for Kimi thinking flow configuration, including new commands and parameters for enabling and configuring the thinking budget.

* **Tests**
  * Updated test expectations for option selection interface hints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->