### PR TITLE
Fix codex context limit

### DIFF
--- a/packages/cli/src/providers/aliases/codex.config
+++ b/packages/cli/src/providers/aliases/codex.config
@@ -5,6 +5,6 @@
   "defaultModel": "gpt-5.2",
   "description": "OpenAI Codex (ChatGPT backend with OAuth)",
   "ephemeralSettings": {
-    "context-limit": 400000
+    "context-limit": 262144
   }
 }


### PR DESCRIPTION
Fixes #857

Sets codex alias context-limit to 262144 (256k) to match observed behavior.