### PR TITLE
Ink UI: drag-select copy with mouse tracking

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -99,6 +99,7 @@ import { useStaticHistoryRefresh } from './hooks/useStaticHistoryRefresh.js';
 import { useTodoContext } from './contexts/TodoContext.js';
 import { useWorkspaceMigration } from './hooks/useWorkspaceMigration.js';
 import { useFlickerDetector } from './hooks/useFlickerDetector.js';
+import { useMouseSelection } from './hooks/useMouseSelection.js';
 import { isWorkspaceTrusted } from '../config/trustedFolders.js';
 import { globalOAuthUI } from '../auth/global-oauth-ui.js';
 import { UIStateProvider, type UIState } from './contexts/UIStateContext.js';
@@ -1237,7 +1238,7 @@ export const AppContainer = (props: AppContainerProps) => {
           {
             type: MessageType.INFO,
             text: nextActive
-              ? 'Mouse events enabled (in-app wheel scrolling on; terminal selection/copy may be limited).'
+              ? 'Mouse events enabled (wheel scrolling + in-app selection/copy on).'
               : 'Mouse events disabled (terminal selection/copy on; in-app wheel scrolling off).',
           },
           Date.now(),
@@ -1372,6 +1373,8 @@ export const AppContainer = (props: AppContainerProps) => {
   const mainControlsRef = useRef<DOMElement>(null);
   const pendingHistoryItemRef = useRef<DOMElement>(null);
   const rootUiRef = useRef<DOMElement>(null);
+
+  useMouseSelection({ enabled: true, rootRef: rootUiRef });
 
   useLayoutEffect(() => {
     if (mainControlsRef.current) {

--- a/packages/cli/src/ui/commands/mouseCommand.ts
+++ b/packages/cli/src/ui/commands/mouseCommand.ts
@@ -24,7 +24,7 @@ function parseMouseCommandMode(args: string): MouseCommandMode | null {
 export const mouseCommand: SlashCommand = {
   name: 'mouse',
   description:
-    'Toggle mouse event tracking (enables in-app wheel scrolling; may interfere with terminal selection/copy)',
+    'Toggle mouse event tracking (enables in-app wheel scrolling and in-app selection/copy)',
   kind: CommandKind.BUILT_IN,
 
   action: async (_context, args): Promise<MessageActionReturn> => {
@@ -47,7 +47,7 @@ export const mouseCommand: SlashCommand = {
       type: 'message',
       messageType: 'info',
       content: nextActive
-        ? 'Mouse events enabled (in-app wheel scrolling on; terminal selection/copy may be limited).'
+        ? 'Mouse events enabled (wheel scrolling + in-app selection/copy on).'
         : 'Mouse events disabled (terminal selection/copy on; in-app wheel scrolling off).',
     };
   },

--- a/packages/cli/src/ui/components/messages/OAuthUrlMessage.tsx
+++ b/packages/cli/src/ui/components/messages/OAuthUrlMessage.tsx
@@ -54,8 +54,9 @@ export const OAuthUrlMessage: React.FC<OAuthUrlMessageProps> = ({
         </Box>
         <Box>
           <Text color={Colors.Comment} dimColor wrap="wrap">
-            Tip: if selection/copy isn’t working, run /mouse off (or press
-            Ctrl+\) to disable mouse tracking.
+            Tip: when mouse scrolling is enabled, drag to select and it will be
+            copied to your clipboard. For terminal selection, run /mouse off
+            (Ctrl+\).
           </Text>
         </Box>
       </Box>

--- a/packages/cli/src/ui/hooks/useMouseSelection.ts
+++ b/packages/cli/src/ui/hooks/useMouseSelection.ts
@@ -1,0 +1,309 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import type { RefObject } from 'react';
+import {
+  type DOMElement,
+  type DOMNode,
+  Range,
+  comparePoints,
+  getBoundingBox,
+  hitTest,
+  useApp,
+  useStdout,
+} from 'ink';
+import { useMouse } from './useMouse.js';
+import type { MouseEvent } from '../utils/mouse.js';
+import { useScrollProvider } from '../contexts/ScrollProvider.js';
+import { copyTextToClipboard } from '../utils/clipboard.js';
+
+type SelectionPoint = {
+  node: DOMNode;
+  offset: number;
+};
+
+type BoundingBox = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+function isInsideBox(
+  point: { x: number; y: number },
+  box: BoundingBox,
+): boolean {
+  return (
+    point.x >= box.x &&
+    point.x < box.x + box.width &&
+    point.y >= box.y &&
+    point.y < box.y + box.height
+  );
+}
+
+function getScrollOffsets(node: DOMElement): {
+  scrollTop: number;
+  scrollLeft: number;
+} {
+  const anyNode = node as unknown as {
+    internal_scrollState?: { scrollTop?: number; scrollLeft?: number };
+    style?: { scrollTop?: number; scrollLeft?: number };
+  };
+  return {
+    scrollTop:
+      anyNode.internal_scrollState?.scrollTop ?? anyNode.style?.scrollTop ?? 0,
+    scrollLeft:
+      anyNode.internal_scrollState?.scrollLeft ??
+      anyNode.style?.scrollLeft ??
+      0,
+  };
+}
+
+function findInnermostScrollableAtPoint(
+  root: DOMElement,
+  point: { x: number; y: number },
+): { node: DOMElement; box: BoundingBox } | null {
+  const candidates: Array<{
+    node: DOMElement;
+    box: BoundingBox;
+    area: number;
+  }> = [];
+
+  const visit = (node: DOMElement) => {
+    const anyNode = node as unknown as {
+      style?: { overflow?: string; overflowX?: string; overflowY?: string };
+    };
+    const overflow = anyNode.style?.overflow;
+    const overflowX = anyNode.style?.overflowX ?? overflow;
+    const overflowY = anyNode.style?.overflowY ?? overflow;
+    const isScrollable = overflowX === 'scroll' || overflowY === 'scroll';
+
+    if (isScrollable) {
+      const box = getBoundingBox(node);
+      if (isInsideBox(point, box)) {
+        candidates.push({ node, box, area: box.width * box.height });
+      }
+    }
+
+    for (const child of node.childNodes) {
+      if (child.nodeName === 'ink-box' || child.nodeName === 'ink-root') {
+        visit(child as DOMElement);
+      }
+    }
+  };
+
+  visit(root);
+
+  candidates.sort((a, b) => a.area - b.area);
+  return candidates[0] ?? null;
+}
+
+export function useMouseSelection({
+  enabled,
+  rootRef,
+  onCopiedText,
+}: {
+  enabled: boolean;
+  rootRef: RefObject<DOMElement | null>;
+  onCopiedText?: (text: string) => void;
+}) {
+  const { stdout } = useStdout();
+  const { selection } = useApp();
+  const scrollProvider = useScrollProvider();
+
+  const selectionRangeRef = useRef<Range | null>(null);
+  const anchorPointRef = useRef<SelectionPoint | null>(null);
+  const isDraggingRef = useRef(false);
+
+  const clearSelection = useCallback(() => {
+    selection?.removeAllRanges();
+    selectionRangeRef.current = null;
+    anchorPointRef.current = null;
+    isDraggingRef.current = false;
+  }, [selection]);
+
+  useEffect(() => {
+    if (!enabled) {
+      clearSelection();
+    }
+  }, [enabled, clearSelection]);
+
+  const notifySelectionChanged = useCallback(() => {
+    // `Selection.notifyChange()` is intentionally private, but Ink relies on it to trigger rerenders.
+    (
+      selection as unknown as { notifyChange?: () => void } | undefined
+    )?.notifyChange?.();
+  }, [selection]);
+
+  const findHitTestTarget = useCallback(
+    (
+      event: MouseEvent,
+    ): { node: DOMElement; point: { x: number; y: number } } | null => {
+      const root = rootRef.current;
+      if (!root) return null;
+
+      const x = event.col - 1;
+      const y = event.row - 1;
+      const point = { x, y };
+
+      const scrollables = scrollProvider.getScrollables();
+      const scrollableCandidates: Array<{
+        node: DOMElement;
+        box: BoundingBox;
+        area: number;
+      }> = [];
+
+      for (const entry of scrollables) {
+        if (!entry.ref.current || !entry.hasFocus()) continue;
+        const box = getBoundingBox(entry.ref.current);
+        if (isInsideBox(point, box)) {
+          scrollableCandidates.push({
+            node: entry.ref.current,
+            box,
+            area: box.width * box.height,
+          });
+        }
+      }
+
+      scrollableCandidates.sort((a, b) => a.area - b.area);
+      const scrollableRoot = scrollableCandidates[0]?.node;
+
+      if (!scrollableRoot) {
+        return { node: root, point };
+      }
+
+      // Ignore clicks on the scrollbar column so scrollbar dragging still works.
+      const scrollableBox = scrollableCandidates[0]?.box;
+      if (scrollableBox && x === scrollableBox.x + scrollableBox.width - 1) {
+        return null;
+      }
+
+      const innermostScrollable = findInnermostScrollableAtPoint(
+        scrollableRoot,
+        point,
+      );
+
+      if (innermostScrollable) {
+        const { scrollTop, scrollLeft } = getScrollOffsets(
+          innermostScrollable.node,
+        );
+        return {
+          node: innermostScrollable.node,
+          point: {
+            x: x - innermostScrollable.box.x + scrollLeft,
+            y: y - innermostScrollable.box.y + scrollTop,
+          },
+        };
+      }
+
+      return {
+        node: scrollableRoot,
+        point: {
+          x: x - (scrollableBox?.x ?? 0),
+          y: y - (scrollableBox?.y ?? 0),
+        },
+      };
+    },
+    [rootRef, scrollProvider],
+  );
+
+  const resolveSelectionPoint = useCallback(
+    (event: MouseEvent): SelectionPoint | null => {
+      if (!enabled) return null;
+      if (!selection) return null;
+
+      const target = findHitTestTarget(event);
+      if (!target) return null;
+
+      const hit = hitTest(target.node, target.point.x, target.point.y);
+      if (!hit) return null;
+
+      return { node: hit.node, offset: hit.offset };
+    },
+    [enabled, selection, findHitTestTarget],
+  );
+
+  const updateSelectionRange = useCallback(
+    (anchor: SelectionPoint, focus: SelectionPoint) => {
+      if (!selection) return;
+
+      const ordering = comparePoints(
+        anchor.node,
+        anchor.offset,
+        focus.node,
+        focus.offset,
+      );
+      const start = ordering <= 0 ? anchor : focus;
+      const end = ordering <= 0 ? focus : anchor;
+
+      const range = selectionRangeRef.current ?? new Range();
+      range.setStart(start.node, start.offset);
+      range.setEnd(end.node, end.offset);
+
+      if (!selectionRangeRef.current) {
+        selection.removeAllRanges();
+        selection.addRange(range);
+        selectionRangeRef.current = range;
+      } else {
+        notifySelectionChanged();
+      }
+    },
+    [selection, notifySelectionChanged],
+  );
+
+  const copySelectionToClipboard = useCallback(async () => {
+    if (!selection || selection.rangeCount === 0) return;
+    const text = selection.toString();
+    if (text.length === 0) return;
+
+    onCopiedText?.(text);
+    await copyTextToClipboard(text, stdout);
+  }, [onCopiedText, selection, stdout]);
+
+  const mouseHandler = useMemo(
+    () => (event: MouseEvent) => {
+      if (!enabled) return;
+      if (!selection) return;
+
+      if (event.name === 'left-press') {
+        const point = resolveSelectionPoint(event);
+        if (!point) return;
+        isDraggingRef.current = true;
+        anchorPointRef.current = point;
+        updateSelectionRange(point, point);
+        return;
+      }
+
+      if (event.name === 'move') {
+        if (!isDraggingRef.current) return;
+        const anchor = anchorPointRef.current;
+        if (!anchor) return;
+        const point = resolveSelectionPoint(event);
+        if (!point) return;
+        updateSelectionRange(anchor, point);
+        return;
+      }
+
+      if (event.name === 'left-release') {
+        if (!isDraggingRef.current) return;
+        isDraggingRef.current = false;
+        void copySelectionToClipboard();
+      }
+    },
+    [
+      enabled,
+      selection,
+      resolveSelectionPoint,
+      updateSelectionRange,
+      copySelectionToClipboard,
+    ],
+  );
+
+  useMouse(mouseHandler, { isActive: enabled });
+
+  return { clearSelection };
+}

--- a/packages/cli/src/ui/utils/clipboard.test.ts
+++ b/packages/cli/src/ui/utils/clipboard.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import {
+  buildOsc52,
+  copyTextToClipboard,
+  writeOsc52ToTerminal,
+} from './clipboard.js';
+
+const copyToClipboard = vi.hoisted(() => vi.fn(async () => undefined));
+vi.mock('./commandUtils.js', () => ({
+  copyToClipboard,
+}));
+
+describe('clipboard utils', () => {
+  const originalTmux = process.env.TMUX;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    if (originalTmux === undefined) {
+      delete process.env.TMUX;
+    } else {
+      process.env.TMUX = originalTmux;
+    }
+  });
+
+  afterEach(() => {
+    if (originalTmux === undefined) {
+      delete process.env.TMUX;
+    } else {
+      process.env.TMUX = originalTmux;
+    }
+  });
+
+  describe('buildOsc52', () => {
+    it('builds a plain OSC52 sequence', () => {
+      delete process.env.TMUX;
+      const base64 = Buffer.from('hello').toString('base64');
+      expect(buildOsc52('hello')).toBe(`\u001b]52;c;${base64}\u0007`);
+    });
+
+    it('wraps OSC52 for tmux', () => {
+      process.env.TMUX = '1';
+      const base64 = Buffer.from('hello').toString('base64');
+      const osc52 = `\u001b]52;c;${base64}\u0007`;
+      expect(buildOsc52('hello')).toBe(`\u001bPtmux;\u001b${osc52}\u001b\\`);
+    });
+  });
+
+  describe('writeOsc52ToTerminal', () => {
+    it('does not write for empty text', () => {
+      const stdout = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+      writeOsc52ToTerminal('', stdout);
+      expect(stdout.write).not.toHaveBeenCalled();
+    });
+
+    it('writes OSC52 to stdout', () => {
+      delete process.env.TMUX;
+      const stdout = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+      writeOsc52ToTerminal('hello', stdout);
+      expect(stdout.write).toHaveBeenCalledTimes(1);
+      expect(stdout.write).toHaveBeenCalledWith(buildOsc52('hello'));
+    });
+  });
+
+  describe('copyTextToClipboard', () => {
+    it('attempts OSC52 and platform clipboard', async () => {
+      delete process.env.TMUX;
+      const stdout = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+      await copyTextToClipboard('hello', stdout);
+      expect(stdout.write).toHaveBeenCalledTimes(1);
+      expect(copyToClipboard).toHaveBeenCalledWith('hello');
+    });
+
+    it('does not throw if platform clipboard copy fails', async () => {
+      copyToClipboard.mockRejectedValueOnce(new Error('clipboard failed'));
+      const stdout = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+      await expect(
+        copyTextToClipboard('hello', stdout),
+      ).resolves.toBeUndefined();
+      expect(stdout.write).toHaveBeenCalledTimes(1);
+      expect(copyToClipboard).toHaveBeenCalledWith('hello');
+    });
+  });
+});

--- a/packages/cli/src/ui/utils/clipboard.ts
+++ b/packages/cli/src/ui/utils/clipboard.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { copyToClipboard } from './commandUtils.js';
+
+export function buildOsc52(text: string): string {
+  const base64 = Buffer.from(text).toString('base64');
+  const osc52 = `\u001b]52;c;${base64}\u0007`;
+  if (process.env.TMUX) {
+    return `\u001bPtmux;\u001b${osc52}\u001b\\`;
+  }
+  return osc52;
+}
+
+export function writeOsc52ToTerminal(
+  text: string,
+  stdout: NodeJS.WriteStream = process.stdout,
+): void {
+  if (text.length === 0) return;
+  try {
+    stdout.write(buildOsc52(text));
+  } catch {
+    // ignore terminal write failures
+  }
+}
+
+export async function copyTextToClipboard(
+  text: string,
+  stdout: NodeJS.WriteStream = process.stdout,
+): Promise<void> {
+  if (text.length === 0) return;
+  writeOsc52ToTerminal(text, stdout);
+  try {
+    await copyToClipboard(text);
+  } catch {
+    // ignore copy failures; OSC52 will still have been attempted
+  }
+}


### PR DESCRIPTION
Fixes #861

- Adds always-on in-app selection/copy for legacy Ink UI while mouse tracking is enabled (wheel scrolling remains).
- Copies via OSC52 (tmux-safe) with platform clipboard fallback.

Checklist run: format, lint, typecheck, test, build, and `node scripts/start.js --profile-load synthetic --prompt "write me a haiku"`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mouse-based drag-to-select text functionality in the UI.
  * Added clipboard support for copying selected text.

* **Updates**
  * Clarified mouse event messaging to indicate wheel scrolling and in-app selection/copy are now available.
  * Updated user guidance for mouse-enabled interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->