### PR TITLE
feat: add reasoning.effort xhigh support

### DIFF
--- a/packages/cli/src/config/cliEphemeralSettings.test.ts
+++ b/packages/cli/src/config/cliEphemeralSettings.test.ts
@@ -61,6 +61,14 @@ describe('applyCliSetArguments', () => {
     expect(target.getValue('authOnly')).toBe(false);
   });
 
+  it('accepts reasoning.effort=xhigh', () => {
+    const target = new TestTarget();
+
+    applyCliSetArguments(target, ['reasoning.effort=xhigh']);
+
+    expect(target.getValue('reasoning.effort')).toBe('xhigh');
+  });
+
   it('collects model parameter entries and returns them separately', () => {
     const target = new TestTarget();
 

--- a/packages/cli/src/settings/ephemeralSettings.ts
+++ b/packages/cli/src/settings/ephemeralSettings.ts
@@ -71,7 +71,7 @@ export const ephemeralSettingHelp: Record<string, string> = {
   'reasoning.stripFromContext':
     'Remove thinking blocks from context before sending back to model (all/allButLast/none, default: none)',
   'reasoning.effort':
-    'How much the model should think before responding (minimal/low/medium/high, default: undefined)',
+    'How much the model should think before responding (minimal/low/medium/high/xhigh, default: undefined)',
   'reasoning.maxTokens':
     'Maximum token budget the model can use for reasoning (positive integer, default: undefined)',
   'enable-tool-prompts':
@@ -399,7 +399,7 @@ export function parseEphemeralSettingValue(
   }
 
   if (key === 'reasoning.effort') {
-    const validModes = ['minimal', 'low', 'medium', 'high'];
+    const validModes = ['minimal', 'low', 'medium', 'high', 'xhigh'];
     if (
       typeof parsedValue !== 'string' ||
       !validModes.includes(parsedValue.toLowerCase())

--- a/packages/cli/src/ui/commands/setCommand.ts
+++ b/packages/cli/src/ui/commands/setCommand.ts
@@ -284,13 +284,14 @@ const directSettingSpecs: SettingLiteralSpec[] = [
   },
   {
     value: 'reasoning.effort',
-    hint: 'minimal, low, medium, or high',
+    hint: 'minimal, low, medium, high, or xhigh',
     description: 'How much the AI should think before responding',
     options: [
       { value: 'minimal', description: 'Quick responses, less deliberation' },
       { value: 'low', description: 'Light thinking for simple tasks' },
       { value: 'medium', description: 'Balanced thinking for most tasks' },
       { value: 'high', description: 'Deep thinking for complex problems' },
+      { value: 'xhigh', description: 'Maximum thinking for hardest problems' },
     ],
   },
   {

--- a/packages/core/src/providers/gemini/GeminiProvider.ts
+++ b/packages/core/src/providers/gemini/GeminiProvider.ts
@@ -1220,12 +1220,14 @@ export class GeminiProvider extends BaseProvider {
         | 'low'
         | 'medium'
         | 'high'
+        | 'xhigh'
         | undefined) ??
       (reasoningObj?.effort as
         | 'minimal'
         | 'low'
         | 'medium'
         | 'high'
+        | 'xhigh'
         | undefined);
     void reasoningEffort; // Mark as intentionally unused (reserved for future effort-to-thinkingLevel mapping)
     const reasoningMaxTokens =

--- a/packages/core/src/providers/openai-responses/__tests__/OpenAIResponsesProvider.reasoningEffort.test.ts
+++ b/packages/core/src/providers/openai-responses/__tests__/OpenAIResponsesProvider.reasoningEffort.test.ts
@@ -1,0 +1,106 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SettingsService } from '../../../settings/SettingsService.js';
+import {
+  clearActiveProviderRuntimeContext,
+  createProviderRuntimeContext,
+  setActiveProviderRuntimeContext,
+} from '../../../runtime/providerRuntimeContext.js';
+import { OpenAIResponsesProvider } from '../OpenAIResponsesProvider.js';
+import { createProviderCallOptions } from '../../../test-utils/providerCallOptions.js';
+
+const originalFetch = global.fetch;
+const mockFetch = vi.fn();
+
+describe('OpenAIResponsesProvider reasoning.effort', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockClear();
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    setActiveProviderRuntimeContext(
+      createProviderRuntimeContext({
+        settingsService: new SettingsService(),
+        runtimeId: 'openai-responses-reasoning-effort-test',
+      }),
+    );
+  });
+
+  afterEach(() => {
+    clearActiveProviderRuntimeContext();
+    global.fetch = originalFetch;
+  });
+
+  it('forwards reasoning.effort=xhigh and strips non-API reasoning keys', async () => {
+    const provider = new OpenAIResponsesProvider(
+      'test-api-key',
+      'https://api.openai.com/v1',
+    );
+
+    const settings = new SettingsService();
+    settings.setProviderSetting(provider.name, 'model', 'gpt-5.2');
+
+    settings.set('reasoning.effort', 'xhigh');
+    settings.set('reasoning.enabled', true);
+    settings.set('reasoning.includeInContext', true);
+    settings.set('reasoning.includeInResponse', true);
+    settings.set('reasoning.format', 'field');
+    settings.set('reasoning.stripFromContext', 'none');
+
+    const runtime = createProviderRuntimeContext({
+      runtimeId: 'openai-responses-reasoning-runtime',
+      settingsService: settings,
+    });
+
+    let capturedBody: string | undefined;
+
+    mockFetch.mockImplementation(
+      async (
+        _input: RequestInfo | URL,
+        init?: RequestInit,
+      ): Promise<Response> => {
+        if (init?.body instanceof Blob) {
+          capturedBody = await init.body.text();
+        }
+
+        const encoder = new TextEncoder();
+        const stream = new ReadableStream({
+          start(controller) {
+            controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+            controller.close();
+          },
+        });
+
+        return new Response(stream, {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        });
+      },
+    );
+
+    const options = createProviderCallOptions({
+      providerName: provider.name,
+      settings,
+      runtime,
+      contents: [
+        { speaker: 'human', blocks: [{ type: 'text', text: 'test' }] },
+      ],
+    });
+
+    for await (const _content of provider.generateChatCompletion(options)) {
+      // Consume generator
+    }
+
+    expect(capturedBody).toBeDefined();
+    const parsedBody = JSON.parse(capturedBody!) as {
+      reasoning?: Record<string, unknown>;
+    };
+
+    expect(parsedBody.reasoning).toEqual({ effort: 'xhigh' });
+  });
+});

--- a/packages/core/src/providers/openai/openaiRequestParams.test.ts
+++ b/packages/core/src/providers/openai/openaiRequestParams.test.ts
@@ -30,4 +30,25 @@ describe('filterOpenAIRequestParams', () => {
       user: 'tester',
     });
   });
+
+  it('drops internal reasoning settings nested under reasoning', () => {
+    const filtered = filterOpenAIRequestParams({
+      temperature: 0.7,
+      reasoning: {
+        effort: 'xhigh',
+        enabled: true,
+        includeInContext: true,
+        includeInResponse: false,
+        format: 'field',
+        stripFromContext: 'none',
+      },
+    });
+
+    expect(filtered).toEqual({
+      temperature: 0.7,
+      reasoning: {
+        effort: 'xhigh',
+      },
+    });
+  });
 });

--- a/packages/core/src/runtime/AgentRuntimeContext.ts
+++ b/packages/core/src/runtime/AgentRuntimeContext.ts
@@ -43,7 +43,7 @@ export interface ReadonlySettingsSnapshot {
   /** @plan PLAN-20251202-THINKING.P03b @requirement REQ-THINK-006.5 */
   'reasoning.stripFromContext'?: 'all' | 'allButLast' | 'none';
   /** @plan PLAN-20251202-THINKING.P03b @requirement REQ-THINK-006.6 */
-  'reasoning.effort'?: 'minimal' | 'low' | 'medium' | 'high';
+  'reasoning.effort'?: 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
   /** @plan PLAN-20251202-THINKING.P03b @requirement REQ-THINK-006.7 */
   'reasoning.maxTokens'?: number;
 }
@@ -192,7 +192,7 @@ export interface AgentRuntimeContext {
       includeInResponse(): boolean;
       format(): 'native' | 'field';
       stripFromContext(): 'all' | 'allButLast' | 'none';
-      effort(): 'minimal' | 'low' | 'medium' | 'high' | undefined;
+      effort(): 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | undefined;
       maxTokens(): number | undefined;
     };
   };

--- a/packages/core/src/runtime/createAgentRuntimeContext.ts
+++ b/packages/core/src/runtime/createAgentRuntimeContext.ts
@@ -99,12 +99,13 @@ export function createAgentRuntimeContext(
           | 'all'
           | 'allButLast'
           | 'none') ?? EPHEMERAL_DEFAULTS.reasoning.stripFromContext,
-      effort: (): 'minimal' | 'low' | 'medium' | 'high' | undefined =>
+      effort: (): 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | undefined =>
         options.settings['reasoning.effort'] as
           | 'minimal'
           | 'low'
           | 'medium'
           | 'high'
+          | 'xhigh'
           | undefined,
       maxTokens: (): number | undefined =>
         typeof options.settings['reasoning.maxTokens'] === 'number'


### PR DESCRIPTION
Closes #866

## What
- Adds `xhigh` to `/set reasoning.effort` autocomplete and CLI `--set` validation.
- Extends runtime typing so `reasoning.effort` can be `xhigh`.
- Sanitizes OpenAI request params so the nested `reasoning` object only forwards API-relevant keys (keeps `effort`; strips LLXPRT-only fields like `enabled/includeInContext/includeInResponse/format/stripFromContext`).

## Why
- GPT-5.2 / gpt-5.1-codex variants support `reasoning.effort=xhigh`; LLXPRT should expose that option cleanly.
- LLXPRT stores `reasoning.*` ephemerals as a nested `reasoning` object (via `SettingsService`). OpenAI providers forward that object when present. Without sanitization, purely-UX toggles can leak into the API payload and trigger 400s.

## Implementation Notes
- No extra “dot-key → nested object” conversion: `SettingsService` already nests `reasoning.effort` into `reasoning: { effort: … }`; this change focuses on validation + safe forwarding.
- Sanitization lives in `packages/core/src/providers/openai/openaiRequestParams.ts` so it applies consistently to both `OpenAIProvider` and `OpenAIResponsesProvider`.

## Tests
- Core: `filterOpenAIRequestParams` strips non-API keys nested under `reasoning`.
- Core: captures OpenAI `/responses` request body and asserts `reasoning` equals `{ effort: "xhigh" }`.
- CLI: `--set reasoning.effort=xhigh` parses and applies.

## Verification
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run build`
- `node scripts/start.js --profile-load synthetic --prompt "write me a haiku"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "xhigh" option for the reasoning effort setting, providing an additional level of reasoning capability beyond the existing options.

* **Tests**
  * Added test coverage to verify the new "xhigh" reasoning effort level is properly validated and transmitted to API requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->