### PR TITLE
fix(ui): avoid double-draining queued prompts (#862)

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1099,9 +1099,6 @@ export const useGeminiStream = (
         }
       } finally {
         setIsResponding(false);
-        if (!turnCancelledRef.current) {
-          scheduleNextQueuedSubmission();
-        }
       }
     },
     [


### PR DESCRIPTION
Fixes #862.

## Problem
When multiple prompts are submitted while a turn is already active (Responding/WaitingForConfirmation), they are enqueued. Under some timing conditions, the next queued prompt could be submitted more than once (seen as an extra sendMessageStream call).

## Root Cause
useGeminiStream had two independent triggers to drain the submission queue:

1. A useEffect that runs when streamingState becomes StreamingState.Idle and calls scheduleNextQueuedSubmission().
2. A second drain call in submitQuery's finally block (guarded by !turnCancelledRef.current).

scheduleNextQueuedSubmission() uses setTimeout(0) to call the next submitQuery. Calling it twice schedules two drain callbacks for the same queue state and can submit the same queued prompt multiple times or advance the queue unexpectedly.

## Fix
- Remove the submitQuery finally-block call to scheduleNextQueuedSubmission().
- Queue draining is now driven solely by the canonical state transition back to StreamingState.Idle.
- Early-return draining is preserved (prepareQueryForGemini returning shouldProceed=false still schedules the next queued item).
- Cancellation behavior is unchanged (cancelOngoingRequest clears queuedSubmissionsRef).

## Regression Test
Added an included regression test (runs in the default CLI test suite) to ensure sequential draining:
- packages/cli/src/ui/hooks/useGeminiStream.thinking.test.tsx: describe('Submission queue (regression #862)')
- Queues 3 prompts, resolves streams one-at-a-time, and asserts sendMessageStream is called exactly once per prompt.
- Includes a setTimeout(0) flush checkpoint to catch accidental double scheduling.

## Verification
- npm run format
- npm run lint
- npm run typecheck
- npm run test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where multiple submitted prompts could be processed incorrectly when submitted while a prior prompt was still streaming.

* **Tests**
  * Added regression test for queued submission handling to verify correct sequential processing when multiple prompts are submitted concurrently.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->