### PR TITLE
revert: remove VITEST_MAX_THREADS=1 thread limiting (#887)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "build:packages": "npm run build --workspaces",
     "build:sandbox": "node scripts/build_sandbox.js --skip-npm-install-build",
     "bundle": "npm run generate && node esbuild.config.js && node scripts/copy_bundle_assets.js",
-    "test": "cross-env VITEST_MAX_THREADS=1 VITEST_MIN_THREADS=1 npm run test --workspaces --if-present",
+    "test": "npm run test --workspaces --if-present",
     "test:ci": "cross-env NODE_OPTIONS=--max-old-space-size=6144 npm run test:ci --workspaces --if-present && npm run test:scripts",
     "test:scripts": "vitest run --config ./scripts/tests/vitest.config.ts",
     "test:e2e": "cross-env VERBOSE=true KEEP_OUTPUT=true npm run test:integration:sandbox:none",


### PR DESCRIPTION
## Summary

Fixes #887

Removes the unexplained `VITEST_MAX_THREADS=1 VITEST_MIN_THREADS=1` environment variables from the `test` script in package.json.

## Background

This was added in commit b511b6d7 as part of PR #845 (fix-oldui) without any explanation in the commit message or PR discussion. It forces all vitest workspace runs to be sequential, significantly slowing down test runs across 551 test files.

The change appears to have been added by an LLM as a 'stabilization' measure without clear justification.

## Testing

- `npm run test` - all tests pass (4767 + 2425 + 23 tests across packages)
- `npm run lint` - passes
- `npm run typecheck` - passes
- `npm run format` - passes
- `npm run build` - passes

## Impact

This should speed up local test runs and CI by allowing vitest to parallelize test execution across workspaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test execution configuration to remove explicit thread constraints and use default test runner behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->