### PR TITLE
fix: isolate subagent provider state

### DIFF
--- a/packages/core/src/runtime/AgentRuntimeContext.ts
+++ b/packages/core/src/runtime/AgentRuntimeContext.ts
@@ -254,6 +254,7 @@ import type { ProviderRuntimeContext } from './providerRuntimeContext.js';
 export interface AgentRuntimeProviderAdapter {
   getActiveProvider(): IProvider;
   setActiveProvider(name: string): void;
+  getProviderByName?(name: string): IProvider | undefined;
 }
 
 /**

--- a/packages/core/src/runtime/runtimeAdapters.ts
+++ b/packages/core/src/runtime/runtimeAdapters.ts
@@ -6,6 +6,7 @@
 
 import type { ProviderManager } from '../providers/ProviderManager.js';
 import type { IProviderManager } from '../providers/IProviderManager.js';
+import type { IProvider } from '../providers/IProvider.js';
 import type { Config } from '../config/config.js';
 import type { ToolRegistry } from '../tools/tool-registry.js';
 import {
@@ -42,12 +43,27 @@ export function createProviderAdapterFromManager(
           'AgentRuntimeContext provider adapter requires a ProviderManager instance.',
         );
       },
+      getProviderByName: () => {
+        throw new Error(
+          'AgentRuntimeContext provider adapter requires a ProviderManager instance.',
+        );
+      },
     };
   }
 
   return {
     getActiveProvider: () => manager.getActiveProvider(),
     setActiveProvider: (name: string) => manager.setActiveProvider(name),
+    getProviderByName:
+      typeof (manager as unknown as { getProviderByName?: unknown })
+        .getProviderByName === 'function'
+        ? (name: string) =>
+            (
+              manager as unknown as {
+                getProviderByName: (providerName: string) => unknown;
+              }
+            ).getProviderByName(name) as IProvider | undefined
+        : undefined,
   };
 }
 


### PR DESCRIPTION
Fixes #895

## Problem
Subagents launched via `task` were inheriting foreground ephemerals (especially `base-url` / `auth-key`) and, in some cases, mutating the shared `ProviderManager` active provider. This caused subagent traffic (e.g. Anthropic OAuth subagents like `typescriptexpert`) to be sent to the foreground backend:

- Cloudflare HTML wall when Anthropic requests hit the ChatGPT/Codex endpoint
- `404 {"error":"API route not found: '/openai/v1/v1/messages'..."}` when an OpenAI-style `base-url` leaked and Anthropic appended its `/v1/messages` path

## Why it happened
- Subagent runtimes create a new `SettingsService`, but reuse the foreground `Config`/`ProviderManager`.
- `ProviderManager.normalizeRuntimeInputs()` used `config.getModel()` and `config.getEphemeralSetting('base-url'|'auth-key')` as fallbacks, so foreground ephemerals could leak into subagent provider resolution.
- `GeminiChat` enforced `runtimeState.provider` by calling `setActiveProvider()` on the (shared) provider adapter, which bypasses the CLI provider-switch flow that clears ephemerals.

## What this PR changes
This is a test-first fix that makes the *shared* objects safe for subagents (without a large refactor to construct fully separate `Config`/`ProviderManager` instances per subagent runtime).

### 1) Guardrails in provider option normalization
- `ProviderManager.normalizeRuntimeInputs()` now prefers provider-scoped settings (`SettingsService.getProviderSettings(targetProvider)`) over config-derived values.
- Global ephemeral fallbacks (`auth-key`, `base-url`, and `config.getModel()`) are only applied when:
  - the provided `config` is backed by the same `SettingsService` as the call site, and
  - `settingsService.activeProvider` is unset or matches the *target* provider.

Net: a subagent call targeting provider `anthropic` cannot accidentally pick up a foreground `codex/openai` `base-url`/`auth-key`.

### 2) Avoid mutating the foreground provider from subagent calls
- The runtime provider adapter now optionally exposes `getProviderByName()`.
- `GeminiChat` prefers call-scoped provider selection via `getProviderByName(runtimeState.provider)` and only falls back to `setActiveProvider()` when lookup isn’t available.

Net: subagents can use their intended provider without switching the shared active provider mid-flight.

## Tests
- Added regressions ensuring `ProviderManager.normalizeRuntimeInputs()` doesn’t apply global ephemerals across providers/runtimes.
- Added regression ensuring `GeminiChat` does not mutate `ProviderManager` active provider when a runtime requests a different provider.

## Validation (repo checklist + UAT)
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run build`
- `node scripts/start.js --profile-load synthetic --prompt "write me a haiku"`
- `LLXPRT_DEBUG=llxprt:* node scripts/start.js --profile-load gpt52 --prompt "please ask the typescriptexpert subagent to write a haiku, if you cannot or it fails then please let us know and do not use a different subagent or write it yourself"`

## Notes / follow-ups
A future improvement could still make subagent isolation more explicit by constructing fully isolated per-subagent `Config` + `ProviderManager` instances (similar to the CLI `createIsolatedRuntimeContext` pattern), but this PR resolves the concrete leakage/misrouting described in #895 with minimal surface area.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed provider isolation issues where settings could leak between different runtime contexts.
  * Improved provider selection logic to respect runtime-specific configurations over global settings.

* **Tests**
  * Added comprehensive test coverage for runtime context isolation and provider configuration handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->