### PR TITLE
feat: add mistral alias and gpt-5.2-codex fixes #912 and fixes #875 

### DIFF
--- a/packages/cli/src/providers/aliases/mistral.config
+++ b/packages/cli/src/providers/aliases/mistral.config
@@ -1,0 +1,8 @@
+{
+  "name": "mistral",
+  "baseProvider": "openai",
+  "baseUrl": "https://api.mistral.ai/v1",
+  "defaultModel": "mistral-large-latest",
+  "description": "Mistral AI OpenAI-compatible endpoint",
+  "apiKeyEnv": "MISTRAL_API_KEY"
+}

--- a/packages/core/src/providers/openai-responses/CODEX_MODELS.ts
+++ b/packages/core/src/providers/openai-responses/CODEX_MODELS.ts
@@ -25,6 +25,12 @@ import { type IModel } from '../IModel.js';
 
 export const CODEX_MODELS: IModel[] = [
   {
+    id: 'gpt-5.2-codex',
+    name: 'gpt-5.2-codex',
+    provider: 'codex',
+    supportedToolFormats: ['openai'],
+  },
+  {
     id: 'gpt-5.1-codex-max',
     name: 'gpt-5.1-codex-max',
     provider: 'codex',

--- a/packages/core/src/providers/openai-responses/__tests__/OpenAIResponsesProvider.models.test.ts
+++ b/packages/core/src/providers/openai-responses/__tests__/OpenAIResponsesProvider.models.test.ts
@@ -59,14 +59,15 @@ describe('OpenAIResponsesProvider - Codex Model Listing', () => {
 
       // Verify all expected Codex models are present (based on codex-rs list_models.rs)
       const modelIds = models.map((m) => m.id);
+      expect(modelIds).toContain('gpt-5.2-codex');
       expect(modelIds).toContain('gpt-5.1-codex-max');
       expect(modelIds).toContain('gpt-5.1-codex');
       expect(modelIds).toContain('gpt-5.1-codex-mini');
       expect(modelIds).toContain('gpt-5.2');
       expect(modelIds).toContain('gpt-5.1');
 
-      // Verify gpt-5.1-codex-max is first (highest priority in codex-rs)
-      expect(models[0].id).toBe('gpt-5.1-codex-max');
+      // Verify gpt-5.2-codex is first (highest priority in codex-rs)
+      expect(models[0].id).toBe('gpt-5.2-codex');
 
       // Verify all models have correct provider and tool format
       for (const model of models) {
@@ -102,6 +103,7 @@ describe('OpenAIResponsesProvider - Codex Model Listing', () => {
 
       // Expected models in priority order (based on codex-rs list_models.rs)
       const expectedModelIds = [
+        'gpt-5.2-codex',
         'gpt-5.1-codex-max',
         'gpt-5.1-codex',
         'gpt-5.1-codex-mini',


### PR DESCRIPTION
simply adds a provider alias for mistral with the baseurl and adds gpt-5.2-codex to the model list for codex.
 fixes #912 and fixes #875


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Mistral AI as a provider option with OpenAI-compatible endpoint integration
  * Added new gpt-5.2-codex model to the available models list

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->