### PR TITLE
Make sandbox image public after release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -359,7 +359,6 @@ jobs:
             /orgs/${{ github.repository_owner }}/packages/container/${{ env.SANDBOX_PACKAGE_NAME }} \
             -f visibility=public
 
-
       - name: Generate Release Notes
         if: ${{ steps.vars.outputs.should_run_standard_release == 'true' && steps.vars.outputs.is_dry_run == 'false' }}
         id: release_notes


### PR DESCRIPTION
## Summary
- set the GHCR sandbox package visibility to public after the image push
- publish a multi-arch sandbox image for linux/amd64 and linux/arm64

## Testing
- 
> @vybestack/llxprt-code@0.7.0 format
> prettier --experimental-cli --write .

Fixes #932


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Ensure sandbox image is made public during standard releases.
  * Publish sandbox image as multi-architecture (amd64 and arm64) to broaden platform compatibility.
  * Minor tweak to release notes generation to improve tag handling and fallback when no stable tag exists.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->