### PR TITLE
feat(sandbox): profiles + engine flag + ssh-agent passthrough

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   lsof \
   socat \
   ca-certificates \
+  openssh-client \
+  git-lfs \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -67,6 +67,27 @@ llxprt "run the test suite"
 2. **Environment variable**: `LLXPRT_SANDBOX=true|docker|podman|sandbox-exec`
 3. **Settings file**: `"sandbox": true` in `settings.json`
 
+### Sandbox profiles
+
+Sandbox profiles live in `~/.llxprt/sandboxes/<name>.json` and are created on first run.
+
+```bash
+llxprt --sandbox-profile-load dev
+llxprt --sandbox-engine podman --sandbox-profile-load dev
+llxprt --sandbox-engine none
+```
+
+Profiles can set engine, image, resources, network, sshAgent, mounts, and env.
+
+### SSH agent passthrough
+
+Enable SSH agent passthrough in profiles with `"sshAgent": "auto"` or `"sshAgent": "on"`.
+
+**Notes:**
+- Docker: works reliably by mounting `SSH_AUTH_SOCK` into `/ssh-agent`.
+- Podman Linux: uses `:z` relabeling for the socket mount.
+- Podman macOS: launchd sockets often fail inside the VM. Prefer Docker, or use a custom SSH_AUTH_SOCK path under a regular filesystem (e.g. `~/.llxprt/ssh-agent.sock`).
+
 ### macOS Seatbelt profiles
 
 Built-in profiles (set via `SEATBELT_PROFILE` env var):

--- a/packages/cli/src/config/__tests__/sandboxConfig.test.ts
+++ b/packages/cli/src/config/__tests__/sandboxConfig.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { loadSandboxConfig } from '../sandboxConfig.js';
+import type { Settings } from '../settings.js';
+
+const baseSettings: Settings = {
+  sandbox: true,
+};
+
+vi.mock('../../utils/resolvePath.js', () => ({
+  resolvePath: (value: string) =>
+    value.replace('~', process.env.HOME || '/mock/home/user'),
+}));
+
+vi.mock('../../utils/package.js', () => ({
+  getPackageJson: vi.fn(async () => ({
+    config: { sandboxImageUri: 'ghcr.io/vybestack/llxprt-code/sandbox:0.7.0' },
+  })),
+}));
+
+vi.mock('command-exists', () => ({
+  default: {
+    sync: vi.fn((command: string) => command === 'docker' || command === 'podman'),
+  },
+}));
+
+vi.mock('../sandboxProfiles.js', () => ({
+  ensureDefaultSandboxProfiles: vi.fn(async () => undefined),
+  loadSandboxProfile: vi.fn(async () => ({
+    engine: 'docker',
+    image: 'ghcr.io/vybestack/llxprt-code/sandbox:0.7.0',
+    resources: { cpus: 2, memory: '4g', pids: 128 },
+    network: 'off',
+    sshAgent: 'on',
+    mounts: [
+      { from: '~/.llxprt', to: '/home/node/.llxprt', mode: 'rw' },
+    ],
+    env: { SAMPLE_ENV: 'true' },
+  })),
+}));
+
+const ORIGINAL_ENV = { ...process.env };
+
+describe('loadSandboxConfig', () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.LLXPRT_SANDBOX_NETWORK;
+    delete process.env.LLXPRT_SANDBOX_SSH_AGENT;
+    delete process.env.LLXPRT_SANDBOX_CPUS;
+    delete process.env.LLXPRT_SANDBOX_MEMORY;
+    delete process.env.LLXPRT_SANDBOX_PIDS;
+    delete process.env.LLXPRT_SANDBOX_MOUNTS;
+    delete process.env.SANDBOX;
+    delete process.env.LLXPRT_SANDBOX;
+    delete process.env.LLXPRT_SANDBOX_IMAGE;
+    process.env.HOME = '/mock/home/user';
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.clearAllMocks();
+  });
+
+  it('applies sandbox profile settings and env vars', async () => {
+    process.env.LLXPRT_SANDBOX_NETWORK = 'on';
+
+    const config = await loadSandboxConfig(baseSettings, {
+      sandboxProfileLoad: 'dev',
+      sandboxEngine: 'auto',
+    });
+
+    expect(config).toEqual({
+      command: 'docker',
+      image: 'ghcr.io/vybestack/llxprt-code/sandbox:0.7.0',
+    });
+    expect(process.env.LLXPRT_SANDBOX_NETWORK).toBe('off');
+    expect(process.env.LLXPRT_SANDBOX_SSH_AGENT).toBe('on');
+    expect(process.env.LLXPRT_SANDBOX_CPUS).toBe('2');
+    expect(process.env.LLXPRT_SANDBOX_MEMORY).toBe('4g');
+    expect(process.env.LLXPRT_SANDBOX_PIDS).toBe('128');
+    expect(process.env.LLXPRT_SANDBOX_MOUNTS).toContain('/home/node/.llxprt');
+    expect(process.env.SANDBOX_MOUNTS).toContain('/home/node/.llxprt');
+    expect(process.env.SAMPLE_ENV).toBe('true');
+  });
+
+  it('disables sandbox when engine is none', async () => {
+    const config = await loadSandboxConfig(baseSettings, {
+      sandboxEngine: 'none',
+    });
+
+    expect(config).toBeUndefined();
+  });
+});

--- a/packages/cli/src/config/config.loadMemory.test.ts
+++ b/packages/cli/src/config/config.loadMemory.test.ts
@@ -288,6 +288,8 @@ describe('loadCliConfig memory discovery', () => {
       model: undefined,
       sandbox: undefined,
       sandboxImage: undefined,
+      sandboxEngine: undefined,
+      sandboxProfileLoad: undefined,
       debug: false,
       prompt: undefined,
       promptInteractive: undefined,

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -130,6 +130,8 @@ export interface CliArgs {
   model: string | undefined;
   sandbox: boolean | string | undefined;
   sandboxImage: string | undefined;
+  sandboxEngine: string | undefined;
+  sandboxProfileLoad: string | undefined;
   debug: boolean | undefined;
   prompt: string | undefined;
   promptInteractive: string | undefined;
@@ -208,12 +210,21 @@ export async function parseArguments(settings: Settings): Promise<CliArgs> {
           type: 'string',
           description: 'Sandbox image URI.',
         })
+        .option('sandbox-engine', {
+          type: 'string',
+          description: 'Sandbox engine (auto|docker|podman|sandbox-exec|none).',
+        })
+        .option('sandbox-profile-load', {
+          type: 'string',
+          description: 'Load a sandbox profile from ~/.llxprt/sandboxes/<name>.json',
+        })
         .option('debug', {
           alias: 'd',
           type: 'boolean',
           description: 'Run in debug mode?',
           default: false,
         })
+
         .option('all-files', {
           alias: ['a'],
           type: 'boolean',
@@ -586,6 +597,8 @@ export async function parseArguments(settings: Settings): Promise<CliArgs> {
     model: result.model as string | undefined,
     sandbox: result.sandbox as boolean | string | undefined,
     sandboxImage: result.sandboxImage as string | undefined,
+    sandboxEngine: result.sandboxEngine as string | undefined,
+    sandboxProfileLoad: result.sandboxProfileLoad as string | undefined,
     debug: result.debug as boolean | undefined,
     prompt:
       (result.prompt as string | undefined) ||

--- a/packages/cli/src/config/sandboxConfig.ts
+++ b/packages/cli/src/config/sandboxConfig.ts
@@ -10,12 +10,22 @@ import commandExists from 'command-exists';
 import * as os from 'node:os';
 import { getPackageJson } from '../utils/package.js';
 import { Settings } from './settings.js';
+import { resolvePath } from '../utils/resolvePath.js';
+import {
+  ensureDefaultSandboxProfiles,
+  loadSandboxProfile,
+  type SandboxProfile,
+  type SandboxProfileEngine,
+  type SandboxProfileMount,
+} from './sandboxProfiles.js';
 
 // This is a stripped-down version of the CliArgs interface from config.ts
 // to avoid circular dependencies.
 interface SandboxCliArgs {
   sandbox?: boolean | string;
   sandboxImage?: string;
+  sandboxEngine?: string;
+  sandboxProfileLoad?: string;
 }
 
 const VALID_SANDBOX_COMMANDS: ReadonlyArray<SandboxConfig['command']> = [
@@ -24,8 +34,198 @@ const VALID_SANDBOX_COMMANDS: ReadonlyArray<SandboxConfig['command']> = [
   'sandbox-exec',
 ];
 
+const VALID_ENGINE_CHOICES: readonly SandboxProfileEngine[] = [
+  'auto',
+  'docker',
+  'podman',
+  'sandbox-exec',
+  'none',
+];
+
+const VALID_NETWORK_CHOICES = ['on', 'off', 'proxied'] as const;
+const VALID_SSH_AGENT_CHOICES = ['auto', 'on', 'off'] as const;
+
 function isSandboxCommand(value: string): value is SandboxConfig['command'] {
   return (VALID_SANDBOX_COMMANDS as readonly string[]).includes(value);
+}
+
+function isEngineChoice(value: string): value is SandboxProfileEngine {
+  return (VALID_ENGINE_CHOICES as readonly string[]).includes(value);
+}
+
+function normalizeEngineInput(
+  value: string | undefined,
+): SandboxProfileEngine | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const trimmed = value.trim().toLowerCase();
+  if (trimmed.length === 0) {
+    return undefined;
+  }
+  if (!isEngineChoice(trimmed)) {
+    throw new FatalSandboxError(
+      `Invalid sandbox engine '${value}'. Must be one of ${VALID_ENGINE_CHOICES.join(
+        ', ',
+      )}`,
+    );
+  }
+  return trimmed;
+}
+
+function parseMemoryLimit(memory: string): string {
+  const trimmed = memory.trim();
+  if (trimmed.length === 0) {
+    throw new FatalSandboxError('Sandbox memory value cannot be empty');
+  }
+  const match = trimmed.match(/^(\d+)([kKmMgG])?$/);
+  if (!match) {
+    throw new FatalSandboxError(
+      `Invalid sandbox memory value '${memory}'. Expected values like 512m or 2g.`,
+    );
+  }
+  const value = Number(match[1]);
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new FatalSandboxError(
+      `Sandbox memory value must be positive, got '${memory}'.`,
+    );
+  }
+  const unit = match[2]?.toLowerCase() ?? 'm';
+  return `${value}${unit}`;
+}
+
+function parseCpuLimit(value: number | string): number {
+  const cpuValue = typeof value === 'string' ? Number(value) : value;
+  if (!Number.isFinite(cpuValue) || cpuValue <= 0) {
+    throw new FatalSandboxError(
+      `Sandbox CPU value must be greater than zero, got '${value}'.`,
+    );
+  }
+  return cpuValue;
+}
+
+function parsePidsLimit(value: number | string): number {
+  const pidsValue = typeof value === 'string' ? Number(value) : value;
+  if (!Number.isFinite(pidsValue) || pidsValue <= 0) {
+    throw new FatalSandboxError(
+      `Sandbox pids value must be greater than zero, got '${value}'.`,
+    );
+  }
+  return Math.floor(pidsValue);
+}
+
+function resolveMountPath(input: string): string {
+  const resolved = resolvePath(input);
+  if (!resolved) {
+    throw new FatalSandboxError(`Mount path cannot be empty.`);
+  }
+  return resolved;
+}
+
+function normalizeEnvEntries(
+  env: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!env) {
+    return undefined;
+  }
+  const entries: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (typeof value !== 'string') {
+      throw new FatalSandboxError(
+        `Sandbox env value for '${key}' must be a string.`,
+      );
+    }
+    const trimmedValue = value.trim();
+    if (
+      trimmedValue.startsWith('~') ||
+      trimmedValue.toLowerCase().startsWith('%userprofile%')
+    ) {
+      entries[key] = resolvePath(trimmedValue);
+    } else {
+      entries[key] = value;
+    }
+  }
+  return entries;
+}
+
+function normalizeMounts(
+  mounts: SandboxProfileMount[] | undefined,
+): SandboxProfileMount[] | undefined {
+  if (!mounts) {
+    return undefined;
+  }
+  return mounts.map((mount) => {
+    if (!mount.from || mount.from.trim().length === 0) {
+      throw new FatalSandboxError('Sandbox mount requires a "from" path.');
+    }
+    const from = resolveMountPath(mount.from);
+    const to = mount.to ? resolveMountPath(mount.to) : undefined;
+    const mode = mount.mode ?? 'ro';
+    if (mode !== 'ro' && mode !== 'rw') {
+      throw new FatalSandboxError(
+        `Sandbox mount mode must be 'ro' or 'rw', got '${mode}'.`,
+      );
+    }
+    return { from, to, mode };
+  });
+}
+
+function normalizeSandboxProfile(profile: SandboxProfile): SandboxProfile {
+  const normalized: SandboxProfile = { ...profile };
+
+  if (profile.engine) {
+    const engine = normalizeEngineInput(profile.engine);
+    normalized.engine = engine;
+  }
+
+  if (profile.network) {
+    const normalizedNetwork = profile.network.trim().toLowerCase();
+    if (!VALID_NETWORK_CHOICES.includes(normalizedNetwork as never)) {
+      throw new FatalSandboxError(
+        `Invalid sandbox network '${profile.network}'. Must be one of ${VALID_NETWORK_CHOICES.join(
+          ', ',
+        )}`,
+      );
+    }
+    normalized.network =
+      normalizedNetwork as (typeof VALID_NETWORK_CHOICES)[number];
+  }
+
+  if (profile.sshAgent) {
+    const normalizedSsh = profile.sshAgent.trim().toLowerCase();
+    if (!VALID_SSH_AGENT_CHOICES.includes(normalizedSsh as never)) {
+      throw new FatalSandboxError(
+        `Invalid sandbox sshAgent '${profile.sshAgent}'. Must be one of ${VALID_SSH_AGENT_CHOICES.join(
+          ', ',
+        )}`,
+      );
+    }
+    normalized.sshAgent =
+      normalizedSsh as (typeof VALID_SSH_AGENT_CHOICES)[number];
+  }
+
+  if (profile.resources) {
+    normalized.resources = {
+      ...profile.resources,
+      cpus:
+        profile.resources.cpus !== undefined
+          ? parseCpuLimit(profile.resources.cpus)
+          : undefined,
+      memory:
+        profile.resources.memory !== undefined
+          ? parseMemoryLimit(profile.resources.memory)
+          : undefined,
+      pids:
+        profile.resources.pids !== undefined
+          ? parsePidsLimit(profile.resources.pids)
+          : undefined,
+    };
+  }
+
+  normalized.mounts = normalizeMounts(profile.mounts);
+  normalized.env = normalizeEnvEntries(profile.env);
+
+  return normalized;
 }
 
 function getSandboxCommand(
@@ -88,18 +288,218 @@ function getSandboxCommand(
   return '';
 }
 
+function resolveSandboxEngine(
+  engine: SandboxProfileEngine | undefined,
+  baseCommand: SandboxConfig['command'] | '',
+): SandboxConfig['command'] | '' {
+  if (engine === 'none') {
+    return '';
+  }
+
+  const pickFallback = (): SandboxConfig['command'] | '' => {
+    if (commandExists.sync('docker')) {
+      return 'docker';
+    }
+    if (commandExists.sync('podman')) {
+      return 'podman';
+    }
+    if (os.platform() === 'darwin' && commandExists.sync('sandbox-exec')) {
+      return 'sandbox-exec';
+    }
+    return '';
+  };
+
+  if (engine && engine !== 'auto') {
+    if (engine === 'sandbox-exec') {
+      if (os.platform() === 'darwin' && commandExists.sync('sandbox-exec')) {
+        return 'sandbox-exec';
+      }
+      return pickFallback();
+    }
+    if (engine === 'docker' || engine === 'podman') {
+      if (commandExists.sync(engine)) {
+        return engine;
+      }
+      return pickFallback();
+    }
+  }
+
+  if (baseCommand) {
+    return baseCommand;
+  }
+
+  return pickFallback();
+}
+
+function applyProfileEnvironment(
+  profile: SandboxProfile,
+): Record<string, string> {
+  const env: Record<string, string> = {};
+
+  if (profile.env) {
+    for (const [key, value] of Object.entries(profile.env)) {
+      env[key] = value;
+    }
+  }
+
+  if (profile.network) {
+    env.LLXPRT_SANDBOX_NETWORK = profile.network;
+  }
+
+  if (profile.sshAgent) {
+    env.LLXPRT_SANDBOX_SSH_AGENT = profile.sshAgent;
+  }
+
+  if (profile.resources?.cpus !== undefined) {
+    env.LLXPRT_SANDBOX_CPUS = String(profile.resources.cpus);
+  }
+
+  if (profile.resources?.memory !== undefined) {
+    env.LLXPRT_SANDBOX_MEMORY = profile.resources.memory;
+  }
+
+  if (profile.resources?.pids !== undefined) {
+    env.LLXPRT_SANDBOX_PIDS = String(profile.resources.pids);
+  }
+
+  if (profile.mounts && profile.mounts.length > 0) {
+    const mountsValue = profile.mounts
+      .map((mount) => {
+        const target = mount.to ?? mount.from;
+        const mode = mount.mode ?? 'ro';
+        return `${mount.from}:${target}:${mode}`;
+      })
+      .join(',');
+    env.SANDBOX_MOUNTS = mountsValue;
+    env.LLXPRT_SANDBOX_MOUNTS = mountsValue;
+  }
+
+  return env;
+}
+
+function applySandboxProfileEnv(profile: SandboxProfile | undefined): void {
+  if (!profile) {
+    return;
+  }
+  const env = applyProfileEnvironment(profile);
+  for (const [key, value] of Object.entries(env)) {
+    process.env[key] = value;
+  }
+
+  // Preserve backward-compatible env vars used by the sandbox launcher while
+  // ensuring the profile's explicit choices win over ambient env.
+  if (profile.network) {
+    process.env.SANDBOX_NETWORK = profile.network;
+  }
+
+  if (profile.sshAgent) {
+    process.env.SANDBOX_SSH_AGENT = profile.sshAgent;
+  }
+
+  if (profile.resources?.cpus !== undefined) {
+    process.env.SANDBOX_CPUS = String(profile.resources.cpus);
+  }
+
+  if (profile.resources?.memory !== undefined) {
+    process.env.SANDBOX_MEMORY = profile.resources.memory;
+  }
+
+  if (profile.resources?.pids !== undefined) {
+    process.env.SANDBOX_PIDS = String(profile.resources.pids);
+  }
+}
+
+function resolveSandboxImage(
+  packageImage: string | undefined,
+  profile: SandboxProfile | undefined,
+  argvImage?: string,
+): string | undefined {
+  return argvImage ?? profile?.image ?? process.env.LLXPRT_SANDBOX_IMAGE ?? packageImage;
+}
+
+function resolveSandboxProfileName(value?: string): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizeProfileName(profileName: string): string {
+  return profileName.replace(/\.json$/i, '');
+}
+
 export async function loadSandboxConfig(
   settings: Settings,
   argv: SandboxCliArgs,
 ): Promise<SandboxConfig | undefined> {
-  const sandboxOption = argv.sandbox ?? settings.sandbox;
-  const command = getSandboxCommand(sandboxOption);
+  const cliEngine = normalizeEngineInput(argv.sandboxEngine);
+  if (cliEngine === 'none') {
+    return undefined;
+  }
 
   const packageJson = await getPackageJson();
-  const image =
-    argv.sandboxImage ??
-    process.env.LLXPRT_SANDBOX_IMAGE ??
-    packageJson?.config?.sandboxImageUri;
+  const packageImage = packageJson?.config?.sandboxImageUri;
 
-  return command && image ? { command, image } : undefined;
+  await ensureDefaultSandboxProfiles(packageImage);
+
+  let sandboxProfile: SandboxProfile | undefined;
+  const profileName = resolveSandboxProfileName(argv.sandboxProfileLoad);
+  if (profileName) {
+    try {
+      sandboxProfile = normalizeSandboxProfile(
+        await loadSandboxProfile(normalizeProfileName(profileName)),
+      );
+    } catch (error) {
+      throw new FatalSandboxError(
+        `Failed to load sandbox profile '${profileName}': ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  const sandboxOption = argv.sandbox ?? settings.sandbox;
+  let baseCommand: SandboxConfig['command'] | '' = '';
+  try {
+    baseCommand = getSandboxCommand(sandboxOption);
+  } catch (error) {
+    // If the user is driving sandbox selection via --sandbox-engine or a profile engine,
+    // allow sandboxOption parsing to fail without aborting.
+    if (!cliEngine && !sandboxProfile?.engine) {
+      throw error;
+    }
+  }
+
+  // Loading a sandbox profile implies sandboxing intent, even if --sandbox isn't set.
+  if (!baseCommand && sandboxProfile) {
+    baseCommand = commandExists.sync('docker')
+      ? 'docker'
+      : commandExists.sync('podman')
+        ? 'podman'
+        : os.platform() === 'darwin' && commandExists.sync('sandbox-exec')
+          ? 'sandbox-exec'
+          : '';
+  }
+
+  const command = resolveSandboxEngine(
+    cliEngine ?? sandboxProfile?.engine,
+    baseCommand,
+  );
+
+  if (!command) {
+    return undefined;
+  }
+
+  const image = resolveSandboxImage(
+    packageImage,
+    sandboxProfile,
+    argv.sandboxImage,
+  );
+
+  if (!image) {
+    return undefined;
+  }
+
+  applySandboxProfileEnv(sandboxProfile);
+
+  return { command, image };
 }

--- a/packages/cli/src/config/sandboxProfiles.ts
+++ b/packages/cli/src/config/sandboxProfiles.ts
@@ -1,0 +1,123 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { Storage } from '@vybestack/llxprt-code-core';
+
+export type SandboxProfileEngine =
+  | 'auto'
+  | 'docker'
+  | 'podman'
+  | 'sandbox-exec'
+  | 'none';
+
+export type SandboxProfileNetwork = 'on' | 'off' | 'proxied';
+
+export type SandboxProfileSshAgent = 'auto' | 'on' | 'off';
+
+export interface SandboxProfileResources {
+  cpus?: number;
+  memory?: string;
+  pids?: number;
+}
+
+export interface SandboxProfileMount {
+  from: string;
+  to?: string;
+  mode?: 'ro' | 'rw';
+}
+
+export interface SandboxProfile {
+  engine?: SandboxProfileEngine;
+  image?: string;
+  resources?: SandboxProfileResources;
+  network?: SandboxProfileNetwork;
+  sshAgent?: SandboxProfileSshAgent;
+  mounts?: SandboxProfileMount[];
+  env?: Record<string, string>;
+}
+
+export const SANDBOX_PROFILES_DIR_NAME = 'sandboxes';
+
+export function getSandboxProfilesDir(): string {
+  return path.join(Storage.getGlobalLlxprtDir(), SANDBOX_PROFILES_DIR_NAME);
+}
+
+export function getDefaultSandboxProfiles(
+  image: string | undefined,
+): Record<string, SandboxProfile> {
+  const defaultImage = image ?? '';
+  return {
+    dev: {
+      engine: 'auto',
+      image: defaultImage,
+      resources: { cpus: 2, memory: '4g', pids: 256 },
+      network: 'on',
+      sshAgent: 'auto',
+      mounts: [],
+      env: {},
+    },
+    safe: {
+      engine: 'auto',
+      image: defaultImage,
+      resources: { cpus: 2, memory: '4g', pids: 128 },
+      network: 'off',
+      sshAgent: 'off',
+      mounts: [],
+      env: {},
+    },
+    tight: {
+      engine: 'auto',
+      image: defaultImage,
+      resources: { cpus: 1, memory: '2g', pids: 64 },
+      network: 'off',
+      sshAgent: 'off',
+      mounts: [],
+      env: {},
+    },
+    offline: {
+      engine: 'auto',
+      image: defaultImage,
+      resources: { cpus: 2, memory: '4g', pids: 128 },
+      network: 'off',
+      sshAgent: 'off',
+      mounts: [],
+      env: {},
+    },
+  };
+}
+
+export async function ensureDefaultSandboxProfiles(
+  image: string | undefined,
+): Promise<void> {
+  const profilesDir = getSandboxProfilesDir();
+  await fs.mkdir(profilesDir, { recursive: true, mode: 0o755 });
+
+  const defaults = getDefaultSandboxProfiles(image);
+
+  await Promise.all(
+    Object.entries(defaults).map(async ([name, profile]) => {
+      const profilePath = path.join(profilesDir, `${name}.json`);
+      try {
+        await fs.stat(profilePath);
+        return;
+      } catch {
+        const payload = JSON.stringify(profile, null, 2);
+        await fs.writeFile(profilePath, `${payload}\n`, { mode: 0o644 });
+      }
+    }),
+  );
+}
+
+export async function loadSandboxProfile(
+  profileName: string,
+): Promise<SandboxProfile> {
+  const profilesDir = getSandboxProfilesDir();
+  const profilePath = path.join(profilesDir, `${profileName}.json`);
+  const raw = await fs.readFile(profilePath, 'utf8');
+  return JSON.parse(raw) as SandboxProfile;
+}


### PR DESCRIPTION
Implements sandbox profiles stored in `~/.llxprt/sandboxes/*.json` and adds `--sandbox-engine` / `--sandbox-profile-load`.

- Boots default profiles (`dev`, `safe`, `tight`, `offline`) on first run
- Applies resource limits (cpu/memory/pids) + network mode at container runtime
- Adds optional SSH agent passthrough for SSH git workflows (with Podman caveats)
- Updates docs and adds unit tests

Closes #943

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sandbox profiles enable pre-configured execution environments with engine selection, networking, resource constraints, and mount management
  * SSH agent passthrough support for secure credential handling in containers
  * Network and resource configuration options (CPU, memory, process limits)
  * Custom mount and environment variable support for sandboxed execution

* **Documentation**
  * Added comprehensive sandbox configuration guide with profile management and SSH agent setup instructions

* **Chores**
  * Added OpenSSH and Git LFS packages to container image

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->