### PR TITLE
feat(core): add showLineNumbers to read_file/read_line_range

### DIFF
--- a/docs/tools/file-system.md
+++ b/docs/tools/file-system.md
@@ -45,8 +45,10 @@ The LLxprt Code provides a comprehensive suite of tools for interacting with the
     ```
 
     This virtual numbering is not part of the file itself; it is a visual aid for precise navigation and editing.
+
   - For image and PDF files: Returns the file content as a base64-encoded data structure suitable for model consumption.
   - For other binary files: Attempts to identify and skip them, returning a message indicating it's a generic binary file.
+
 - **Output:** (`llmContent`):
   - For text files: The file content, potentially prefixed with a truncation message (e.g., `[File content truncated: showing lines 1-100 of 500 total lines...]\nActual file content...`).
   - For image/PDF files: An object containing `inlineData` with `mimeType` and base64 `data` (e.g., `{ inlineData: { mimeType: 'image/png', data: 'base64encodedstring' } }`).

--- a/packages/core/src/prompt-config/defaults/tools/read_line_range.md
+++ b/packages/core/src/prompt-config/defaults/tools/read_line_range.md
@@ -2,8 +2,8 @@
 - The 'start_line' and 'end_line' parameters are 1-based and inclusive.
 - Optionally, you can set `showLineNumbers: true` to return each line with a virtual 1-based line number prefix for easier navigation in large files, for example:
 
-  294|            occurrences = 0;
-  295|          } else {
-  296|            const lineText = lines[replaceLine - 1];
+  294| occurrences = 0;
+  295| } else {
+  296| const lineText = lines[replaceLine - 1];
 
   This numbering is not part of the file itself; it is only a visual aid for precise navigation and editing.

--- a/packages/core/src/tools/read-file.test.ts
+++ b/packages/core/src/tools/read-file.test.ts
@@ -325,9 +325,11 @@ Action: To read more of the file, you can use the 'offset' and 'limit' parameter
 
         const result = await invocation.execute(abortSignal);
 
-        const expectedLlmContent = ['   1| Line 1', '   2| Line 2', '   3| Line 3'].join(
-          '\n',
-        );
+        const expectedLlmContent = [
+          '   1| Line 1',
+          '   2| Line 2',
+          '   3| Line 3',
+        ].join('\n');
 
         expect(result.llmContent).toEqual(expectedLlmContent);
       });

--- a/packages/core/src/tools/read-file.ts
+++ b/packages/core/src/tools/read-file.ts
@@ -58,10 +58,7 @@ export interface ReadFileToolParams {
   showLineNumbers?: boolean;
 }
 
-function formatWithLineNumbers(
-  content: string,
-  startLine: number,
-): string {
+function formatWithLineNumbers(content: string, startLine: number): string {
   const lines = content.split('\n');
   const maxLine = startLine + lines.length - 1;
   const width = Math.max(4, String(maxLine).length);

--- a/packages/core/src/tools/read-line-range.test.ts
+++ b/packages/core/src/tools/read-line-range.test.ts
@@ -16,7 +16,10 @@ import { Config } from '../config/config.js';
 import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
 import { StandardFileSystemService } from '../services/fileSystemService.js';
 import { createMockWorkspaceContext } from '../test-utils/mockWorkspaceContext.js';
-import { ReadLineRangeTool, ReadLineRangeToolParams } from './read_line_range.js';
+import {
+  ReadLineRangeTool,
+  ReadLineRangeToolParams,
+} from './read_line_range.js';
 import { ToolInvocation, ToolResult } from './tools.js';
 
 describe('ReadLineRangeTool', () => {
@@ -58,9 +61,10 @@ describe('ReadLineRangeTool', () => {
 
   it('should prefix returned lines with virtual line numbers when showLineNumbers is true', async () => {
     const filePath = path.join(tempRootDir, 'paginated.txt');
-    const fileContent = Array.from({ length: 6 }, (_, i) => `Line ${i + 1}`).join(
-      '\n',
-    );
+    const fileContent = Array.from(
+      { length: 6 },
+      (_, i) => `Line ${i + 1}`,
+    ).join('\n');
     await fsp.writeFile(filePath, fileContent, 'utf-8');
 
     const params: ReadLineRangeToolParams = {
@@ -86,9 +90,10 @@ describe('ReadLineRangeTool', () => {
 
   it('should not prefix returned lines when showLineNumbers is false/omitted', async () => {
     const filePath = path.join(tempRootDir, 'paginated.txt');
-    const fileContent = Array.from({ length: 6 }, (_, i) => `Line ${i + 1}`).join(
-      '\n',
-    );
+    const fileContent = Array.from(
+      { length: 6 },
+      (_, i) => `Line ${i + 1}`,
+    ).join('\n');
     await fsp.writeFile(filePath, fileContent, 'utf-8');
 
     const params: ReadLineRangeToolParams = {

--- a/packages/core/src/tools/read_line_range.ts
+++ b/packages/core/src/tools/read_line_range.ts
@@ -51,10 +51,7 @@ export interface ReadLineRangeToolParams {
   showLineNumbers?: boolean;
 }
 
-function formatWithLineNumbers(
-  content: string,
-  startLine: number,
-): string {
+function formatWithLineNumbers(content: string, startLine: number): string {
   const lines = content.split('\n');
   const maxLine = startLine + lines.length - 1;
   const width = Math.max(4, String(maxLine).length);


### PR DESCRIPTION
### Proposed change

Adds a `showLineNumbers` flag to `read_file` and `read_line_range`.
When enabled, each returned text line is prefixed with a virtual 1-based line number, for example:

```
 294|            occurrences = 0;
 295|          } else {
 296|            const lineText = lines[replaceLine - 1];
```

The numbering is **not part of the file content**; it is only a visual aid to make navigation and follow-up edits easier.
Binary outputs (e.g., image/pdf `inlineData`) are returned unchanged.

### Notes

* Intended for readability and stable references when working with larger files.
* Includes documentation updates and unit tests.

### Related issue

Refs #950 — this PR addresses the difficulty of referencing specific lines in large or truncated file outputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional showLineNumbers option to file-reading tools (read_file and read_line_range) to return content with virtual, left-padded line-number prefixes for easier navigation and reference (applies to paginated/truncated and full reads).

* **Documentation**
  * Updated docs to describe the visual line-numbering behavior and include usage examples.

* **Tests**
  * Added tests covering numbered and non-numbered outputs, including paginated/truncated scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->