### PR TITLE
fix: restore unconditional passthrough for reliable bracketed paste

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -271,6 +271,10 @@ export function KeypressProvider({
       setRawMode(true);
     }
 
+    process.stdout.write(ENABLE_BRACKETED_PASTE);
+    process.stdout.write(ENABLE_FOCUS_TRACKING);
+    enableSupportedProtocol();
+
     const keypressStream = new PassThrough();
     // Always use passthrough mode for reliable bracketed paste handling.
     // This ensures paste markers are always detected via handleRawKeypress.
@@ -1132,13 +1136,14 @@ export function KeypressProvider({
         setRawMode(false);
       }
 
-      // Best-effort restore of terminal modes we enable while running.
-      // If we exit without running these, the user's terminal can be left with
-      // bracketed paste / focus tracking enabled, which makes subsequent shells
-      // print escape sequences for mouse/keys.
-      process.stdout.write(SHOW_CURSOR);
-      process.stdout.write(DISABLE_BRACKETED_PASTE);
-      process.stdout.write(DISABLE_FOCUS_TRACKING);
+      // Only restore terminal modes if we enabled/managed them.
+      // This effect re-runs on refresh; we must not disable bracketed paste
+      // while the app remains active.
+      if (rawManaged) {
+        process.stdout.write(SHOW_CURSOR);
+        process.stdout.write(DISABLE_BRACKETED_PASTE);
+        process.stdout.write(DISABLE_FOCUS_TRACKING);
+      }
 
       if (backslashTimeout) {
         clearTimeout(backslashTimeout);


### PR DESCRIPTION
## Summary

Fixes #956 - Block paste regression causing immediate carriage return

## Root Cause

The mouse scroll fix (commit 4e51be59b) reintroduced conditional passthrough logic that broke paste handling on Node 20+ when mouse events are disabled.

In v0.6.2, commit a7fa6161b ("Fix bracketed paste handling") made passthrough **unconditional** - it always used the PassThrough stream and always attached `handleRawKeypress` for reliable paste marker detection.

The mouse scroll fix accidentally reintroduced the conditional:
```typescript
if (
  mouseEventsEnabled ||
  nodeMajorVersion < 20 ||
  process.env['PASTE_WORKAROUND'] === '1'
) {
  usePassthrough = true;
}
```

On Node 20+ without mouse events enabled, this resulted in `usePassthrough=false`, meaning:
- `handleRawKeypress()` was never attached
- Paste markers (`ESC[200~` / `ESC[201~`) were never detected
- Each character in pasted content was processed individually
- Carriage returns triggered immediate submission

## Fix

Restore unconditional passthrough mode as it was in v0.6.2:
```typescript
const usePassthrough = true;
```

## Testing

- Verified block paste works correctly with multi-line content
- No premature carriage return processing
- Works regardless of mouse events setting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * CLI input now consistently uses a unified passthrough approach, with streamlined listener setup/teardown for more reliable keyboard and paste handling.
* **Bug Fixes**
  * Improved handling of pasted input and focus-related edge cases to avoid spurious return events.
* **Tests**
  * Added tests validating paste aggregation and edge-case behaviors (split chunks, trailing CR/LF, buffering).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->