### PR TITLE
fix: race conditions in shell execution and tool scheduler

### DIFF
--- a/packages/core/src/core/coreToolScheduler.raceCondition.test.ts
+++ b/packages/core/src/core/coreToolScheduler.raceCondition.test.ts
@@ -1,0 +1,452 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  CoreToolScheduler,
+  type CompletedToolCall,
+} from './coreToolScheduler.js';
+import {
+  BaseDeclarativeTool,
+  BaseToolInvocation,
+  ToolInvocation,
+  ToolResult,
+  Config,
+  Kind,
+  ApprovalMode,
+  ToolRegistry,
+} from '../index.js';
+import { PolicyDecision } from '../policy/types.js';
+
+// Helper function to create a mock MessageBus
+function createMockMessageBus() {
+  return {
+    subscribe: vi.fn().mockReturnValue(() => {}),
+    publish: vi.fn(),
+    respondToConfirmation: vi.fn(),
+    requestConfirmation: vi.fn().mockResolvedValue(true),
+    removeAllListeners: vi.fn(),
+    listenerCount: vi.fn().mockReturnValue(0),
+  };
+}
+
+// Helper function to create a mock PolicyEngine
+function createMockPolicyEngine() {
+  return {
+    evaluate: vi.fn().mockReturnValue(PolicyDecision.ALLOW),
+    checkDecision: vi.fn().mockReturnValue(PolicyDecision.ALLOW),
+  };
+}
+
+// Fast-completing tool invocation
+class FastToolInvocation extends BaseToolInvocation<
+  Record<string, unknown>,
+  ToolResult
+> {
+  constructor(
+    params: Record<string, unknown>,
+    private readonly delayMs: number = 0,
+    private readonly result: ToolResult = {
+      llmContent: 'Fast tool completed',
+      returnDisplay: 'Fast tool completed',
+    },
+  ) {
+    super(params);
+  }
+
+  async execute(): Promise<ToolResult> {
+    if (this.delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, this.delayMs));
+    }
+    return this.result;
+  }
+
+  getDescription(): string {
+    return 'Fast tool invocation';
+  }
+}
+
+// Fast-completing tool
+class FastTool extends BaseDeclarativeTool<
+  Record<string, unknown>,
+  ToolResult
+> {
+  constructor(
+    name: string = 'fast_tool',
+    private readonly delayMs: number = 0,
+    private readonly result?: ToolResult,
+  ) {
+    super(name, 'Fast Tool', 'A tool that completes quickly', Kind.Other, {
+      type: 'object',
+      properties: {},
+    });
+  }
+
+  protected createInvocation(
+    params: Record<string, unknown>,
+  ): ToolInvocation<Record<string, unknown>, ToolResult> {
+    return new FastToolInvocation(params, this.delayMs, this.result);
+  }
+}
+
+describe('CoreToolScheduler - Issue #987 Race Condition Tests', () => {
+  let onAllToolCallsComplete: ReturnType<typeof vi.fn>;
+  let onToolCallsUpdate: ReturnType<typeof vi.fn>;
+
+  function createConfig(tools: Map<string, FastTool>): Config {
+    const mockMessageBus = createMockMessageBus();
+    const mockPolicyEngine = createMockPolicyEngine();
+
+    const mockToolRegistry = {
+      getTool: (name: string) => tools.get(name) ?? null,
+      getFunctionDeclarations: () => [],
+      tools: new Map(),
+      discovery: {},
+      registerTool: () => {},
+      getToolByName: (name: string) => tools.get(name) ?? null,
+      getToolByDisplayName: (name: string) => tools.get(name) ?? null,
+      getTools: () => [],
+      discoverTools: async () => {},
+      getAllTools: () => Array.from(tools.values()),
+      getToolsByServer: () => [],
+      getAllToolNames: () => Array.from(tools.keys()),
+    } as unknown as ToolRegistry;
+
+    return {
+      getSessionId: () => 'test-session-id',
+      getUsageStatisticsEnabled: () => true,
+      getDebugMode: () => false,
+      getApprovalMode: () => ApprovalMode.YOLO,
+      getEphemeralSettings: () => ({}),
+      getAllowedTools: () => [],
+      getContentGeneratorConfig: () => ({
+        model: 'test-model',
+        authType: 'oauth-personal',
+      }),
+      getToolRegistry: () => mockToolRegistry,
+      getMessageBus: () => mockMessageBus,
+      getPolicyEngine: () => mockPolicyEngine,
+    } as unknown as Config;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    onAllToolCallsComplete = vi.fn();
+    onToolCallsUpdate = vi.fn();
+  });
+
+  describe('Batch Size Race Condition', () => {
+    it('should complete even when tools finish before batch is fully initialized', async () => {
+      // This test verifies the fix for the race condition where
+      // currentBatchSize is 0 but pendingResults has entries
+
+      const tools = new Map([['fast_tool', new FastTool('fast_tool', 0)]]);
+      const config = createConfig(tools);
+
+      const scheduler = new CoreToolScheduler({
+        config,
+        onAllToolCallsComplete,
+        onToolCallsUpdate,
+        getPreferredEditor: () => 'vscode',
+        onEditorClose: vi.fn(),
+      });
+
+      const abortController = new AbortController();
+
+      // Schedule a single fast-completing tool
+      await scheduler.schedule(
+        [
+          {
+            callId: 'fast-1',
+            name: 'fast_tool',
+            args: {},
+            isClientInitiated: false,
+            prompt_id: 'prompt-1',
+          },
+        ],
+        abortController.signal,
+      );
+
+      // Tool should complete successfully, not hang
+      expect(onAllToolCallsComplete).toHaveBeenCalled();
+      const completedCalls = onAllToolCallsComplete.mock
+        .calls[0][0] as CompletedToolCall[];
+      expect(completedCalls[0].status).toBe('success');
+
+      scheduler.dispose();
+    });
+
+    it('should handle multiple fast tools completing simultaneously', async () => {
+      // Create tools with different completion times
+      const tools = new Map([
+        ['fast_tool_1', new FastTool('fast_tool_1', 0)],
+        ['fast_tool_2', new FastTool('fast_tool_2', 5)],
+        ['fast_tool_3', new FastTool('fast_tool_3', 10)],
+      ]);
+      const config = createConfig(tools);
+
+      const scheduler = new CoreToolScheduler({
+        config,
+        onAllToolCallsComplete,
+        onToolCallsUpdate,
+        getPreferredEditor: () => 'vscode',
+        onEditorClose: vi.fn(),
+      });
+
+      const abortController = new AbortController();
+
+      // Schedule multiple tools that complete at different times
+      await scheduler.schedule(
+        [
+          {
+            callId: 'fast-1',
+            name: 'fast_tool_1',
+            args: {},
+            isClientInitiated: false,
+            prompt_id: 'prompt-1',
+          },
+          {
+            callId: 'fast-2',
+            name: 'fast_tool_2',
+            args: {},
+            isClientInitiated: false,
+            prompt_id: 'prompt-2',
+          },
+          {
+            callId: 'fast-3',
+            name: 'fast_tool_3',
+            args: {},
+            isClientInitiated: false,
+            prompt_id: 'prompt-3',
+          },
+        ],
+        abortController.signal,
+      );
+
+      // Wait for async completion
+      await vi.waitFor(() => {
+        expect(onAllToolCallsComplete).toHaveBeenCalled();
+      });
+
+      const completedCalls = onAllToolCallsComplete.mock
+        .calls[0][0] as CompletedToolCall[];
+      expect(completedCalls).toHaveLength(3);
+      expect(completedCalls.every((call) => call.status === 'success')).toBe(
+        true,
+      );
+
+      scheduler.dispose();
+    });
+
+    it('should publish results in order even when tools complete out of order', async () => {
+      // Create tools that complete in reverse order
+      const tools = new Map([
+        ['slow_first', new FastTool('slow_first', 50)],
+        ['fast_second', new FastTool('fast_second', 10)],
+        ['fastest_third', new FastTool('fastest_third', 0)],
+      ]);
+      const config = createConfig(tools);
+
+      const scheduler = new CoreToolScheduler({
+        config,
+        onAllToolCallsComplete,
+        onToolCallsUpdate,
+        getPreferredEditor: () => 'vscode',
+        onEditorClose: vi.fn(),
+      });
+
+      const abortController = new AbortController();
+
+      await scheduler.schedule(
+        [
+          {
+            callId: 'tool-1',
+            name: 'slow_first',
+            args: {},
+            isClientInitiated: false,
+            prompt_id: 'prompt-1',
+          },
+          {
+            callId: 'tool-2',
+            name: 'fast_second',
+            args: {},
+            isClientInitiated: false,
+            prompt_id: 'prompt-2',
+          },
+          {
+            callId: 'tool-3',
+            name: 'fastest_third',
+            args: {},
+            isClientInitiated: false,
+            prompt_id: 'prompt-3',
+          },
+        ],
+        abortController.signal,
+      );
+
+      // Wait for async completion
+      await vi.waitFor(() => {
+        expect(onAllToolCallsComplete).toHaveBeenCalled();
+      });
+
+      const completedCalls = onAllToolCallsComplete.mock
+        .calls[0][0] as CompletedToolCall[];
+      expect(completedCalls).toHaveLength(3);
+
+      scheduler.dispose();
+    });
+
+    it('should not enter infinite setImmediate loop when currentBatchSize is 0', async () => {
+      // This test verifies the fix prevents the infinite loop described in issue #987
+
+      const tools = new Map([['fast_tool', new FastTool('fast_tool', 0)]]);
+      const config = createConfig(tools);
+
+      const scheduler = new CoreToolScheduler({
+        config,
+        onAllToolCallsComplete,
+        onToolCallsUpdate,
+        getPreferredEditor: () => 'vscode',
+        onEditorClose: vi.fn(),
+      });
+
+      const abortController = new AbortController();
+
+      // Track setImmediate calls
+      const originalSetImmediate = global.setImmediate;
+      let setImmediateCount = 0;
+      global.setImmediate = ((callback: () => void) => {
+        setImmediateCount++;
+        if (setImmediateCount > 100) {
+          throw new Error('Infinite setImmediate loop detected!');
+        }
+        return originalSetImmediate(callback);
+      }) as typeof setImmediate;
+
+      try {
+        await scheduler.schedule(
+          [
+            {
+              callId: 'test-1',
+              name: 'fast_tool',
+              args: {},
+              isClientInitiated: false,
+              prompt_id: 'prompt-1',
+            },
+          ],
+          abortController.signal,
+        );
+
+        // Should complete without entering infinite loop
+        expect(onAllToolCallsComplete).toHaveBeenCalled();
+        // The count should be reasonable, not excessive
+        expect(setImmediateCount).toBeLessThan(50);
+      } finally {
+        global.setImmediate = originalSetImmediate;
+        scheduler.dispose();
+      }
+    });
+  });
+
+  describe('Cancel During Execution', () => {
+    it('should handle cancellation before execution starts without hanging', async () => {
+      // Create a slow tool that would hang if not cancelled properly
+      const tools = new Map([['slow_tool', new FastTool('slow_tool', 5000)]]);
+      const config = createConfig(tools);
+
+      const scheduler = new CoreToolScheduler({
+        config,
+        onAllToolCallsComplete,
+        onToolCallsUpdate,
+        getPreferredEditor: () => 'vscode',
+        onEditorClose: vi.fn(),
+      });
+
+      const abortController = new AbortController();
+
+      // Abort before scheduling
+      abortController.abort();
+
+      // Schedule with pre-aborted signal
+      await scheduler.schedule(
+        [
+          {
+            callId: 'slow-1',
+            name: 'slow_tool',
+            args: {},
+            isClientInitiated: false,
+            prompt_id: 'prompt-1',
+          },
+        ],
+        abortController.signal,
+      );
+
+      // Wait for async completion - should be cancelled, not hung
+      await vi.waitFor(() => {
+        expect(onAllToolCallsComplete).toHaveBeenCalled();
+      });
+
+      const completedCalls = onAllToolCallsComplete.mock
+        .calls[0][0] as CompletedToolCall[];
+      expect(completedCalls[0].status).toBe('cancelled');
+
+      scheduler.dispose();
+    });
+  });
+
+  describe('State Reset After Completion', () => {
+    it('should properly reset state after batch completion for subsequent batches', async () => {
+      const tools = new Map([['fast_tool', new FastTool('fast_tool', 0)]]);
+      const config = createConfig(tools);
+
+      const scheduler = new CoreToolScheduler({
+        config,
+        onAllToolCallsComplete,
+        onToolCallsUpdate,
+        getPreferredEditor: () => 'vscode',
+        onEditorClose: vi.fn(),
+      });
+
+      // First batch
+      await scheduler.schedule(
+        [
+          {
+            callId: 'batch1-tool1',
+            name: 'fast_tool',
+            args: {},
+            isClientInitiated: false,
+            prompt_id: 'prompt-1',
+          },
+        ],
+        new AbortController().signal,
+      );
+
+      await vi.waitFor(() => {
+        expect(onAllToolCallsComplete).toHaveBeenCalledTimes(1);
+      });
+
+      // Second batch should also complete successfully
+      await scheduler.schedule(
+        [
+          {
+            callId: 'batch2-tool1',
+            name: 'fast_tool',
+            args: {},
+            isClientInitiated: false,
+            prompt_id: 'prompt-2',
+          },
+        ],
+        new AbortController().signal,
+      );
+
+      await vi.waitFor(() => {
+        expect(onAllToolCallsComplete).toHaveBeenCalledTimes(2);
+      });
+
+      scheduler.dispose();
+    });
+  });
+});

--- a/packages/core/src/services/shellExecutionService.raceCondition.test.ts
+++ b/packages/core/src/services/shellExecutionService.raceCondition.test.ts
@@ -1,0 +1,215 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, describe, it, expect, beforeEach, type Mock } from 'vitest';
+import EventEmitter from 'events';
+import {
+  ShellExecutionService,
+  ShellOutputEvent,
+} from './shellExecutionService.js';
+
+// Hoisted Mocks
+const mockPtySpawn = vi.hoisted(() => vi.fn());
+const mockCpSpawn = vi.hoisted(() => vi.fn());
+const mockIsBinary = vi.hoisted(() => vi.fn());
+const mockPlatform = vi.hoisted(() => vi.fn());
+const mockGetPty = vi.hoisted(() => vi.fn());
+
+// Top-level Mocks
+vi.mock('@lydell/node-pty', () => ({
+  spawn: mockPtySpawn,
+}));
+vi.mock('child_process', () => ({
+  spawn: mockCpSpawn,
+}));
+vi.mock('../utils/textUtils.js', () => ({
+  isBinary: mockIsBinary,
+}));
+vi.mock('os', () => ({
+  default: {
+    platform: mockPlatform,
+    constants: {
+      signals: {
+        SIGTERM: 15,
+        SIGKILL: 9,
+      },
+    },
+  },
+  platform: mockPlatform,
+  constants: {
+    signals: {
+      SIGTERM: 15,
+      SIGKILL: 9,
+    },
+  },
+}));
+vi.mock('../utils/getPty.js', () => ({
+  getPty: mockGetPty,
+}));
+
+vi.spyOn(process, 'kill').mockImplementation(() => true);
+
+describe('ShellExecutionService - Issue #983 Race Condition Tests', () => {
+  let mockPtyProcess: EventEmitter & {
+    pid: number;
+    kill: Mock;
+    onData: Mock;
+    onExit: Mock;
+  };
+  let onOutputEventMock: Mock<(event: ShellOutputEvent) => void>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockIsBinary.mockReturnValue(false);
+    mockPlatform.mockReturnValue('linux');
+    mockGetPty.mockResolvedValue({
+      module: { spawn: mockPtySpawn },
+      name: 'mock-pty',
+    });
+
+    onOutputEventMock = vi.fn();
+
+    mockPtyProcess = new EventEmitter() as EventEmitter & {
+      pid: number;
+      kill: Mock;
+      onData: Mock;
+      onExit: Mock;
+    };
+    mockPtyProcess.pid = 12345;
+    mockPtyProcess.kill = vi.fn();
+    mockPtyProcess.onData = vi.fn();
+    mockPtyProcess.onExit = vi.fn();
+
+    mockPtySpawn.mockReturnValue(mockPtyProcess);
+  });
+
+  describe('Fast Command Race Condition (Issue #983)', () => {
+    it('should finalize within timeout even if xterm write callback never fires', async () => {
+      // This test simulates the scenario where xterm.write() callback never fires
+      // The fix adds a timeout to prevent indefinite hanging
+
+      const abortController = new AbortController();
+      const handle = await ShellExecutionService.execute(
+        'echo hello',
+        '/test/dir',
+        onOutputEventMock,
+        abortController.signal,
+        true,
+      );
+
+      await new Promise((resolve) => setImmediate(resolve));
+
+      // Simulate data being sent but xterm.write callback potentially stalled
+      mockPtyProcess.onData.mock.calls[0][0]('hello\n');
+
+      // Immediately trigger exit - this creates the race condition where
+      // the processing chain might not have completed
+      mockPtyProcess.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
+
+      // The fix ensures this resolves within a reasonable timeout instead of hanging
+      const result = await Promise.race([
+        handle.result,
+        new Promise<null>((resolve) => setTimeout(() => resolve(null), 2000)),
+      ]);
+
+      // Should have a result, not null (which would indicate timeout)
+      expect(result).not.toBeNull();
+      expect(result?.exitCode).toBe(0);
+    });
+
+    it('should handle burst of output followed by immediate exit', async () => {
+      // Simulates fast commands that output a burst of data and exit quickly
+      const abortController = new AbortController();
+      const handle = await ShellExecutionService.execute(
+        'fast-command',
+        '/test/dir',
+        onOutputEventMock,
+        abortController.signal,
+        true,
+      );
+
+      await new Promise((resolve) => setImmediate(resolve));
+
+      // Rapid-fire data events followed by immediate exit
+      for (let i = 0; i < 10; i++) {
+        mockPtyProcess.onData.mock.calls[0][0](`line ${i}\n`);
+      }
+
+      // Exit immediately after data burst
+      mockPtyProcess.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
+
+      // Should resolve without hanging
+      const result = await Promise.race([
+        handle.result,
+        new Promise<null>((resolve) => setTimeout(() => resolve(null), 2000)),
+      ]);
+
+      expect(result).not.toBeNull();
+      expect(result?.exitCode).toBe(0);
+    });
+
+    it('should complete even with zero output commands', async () => {
+      // Commands like 'rm file' that produce no output should not hang
+      const abortController = new AbortController();
+      const handle = await ShellExecutionService.execute(
+        'rm somefile',
+        '/test/dir',
+        onOutputEventMock,
+        abortController.signal,
+        true,
+      );
+
+      await new Promise((resolve) => setImmediate(resolve));
+
+      // Exit with no data events
+      mockPtyProcess.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
+
+      const result = await Promise.race([
+        handle.result,
+        new Promise<null>((resolve) => setTimeout(() => resolve(null), 2000)),
+      ]);
+
+      expect(result).not.toBeNull();
+      expect(result?.exitCode).toBe(0);
+      expect(result?.output).toBe('');
+    });
+  });
+
+  describe('Processing Chain Timeout Protection', () => {
+    it('should not wait indefinitely for processing chain after exit', async () => {
+      vi.useFakeTimers();
+
+      const abortController = new AbortController();
+      const handlePromise = ShellExecutionService.execute(
+        'test-command',
+        '/test/dir',
+        onOutputEventMock,
+        abortController.signal,
+        true,
+      );
+
+      await vi.advanceTimersByTimeAsync(0);
+      const handle = await handlePromise;
+
+      // Send data
+      mockPtyProcess.onData.mock.calls[0][0]('output\n');
+
+      // Exit while processing might still be pending
+      mockPtyProcess.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
+
+      // Advance time past the finalization timeout
+      await vi.advanceTimersByTimeAsync(1000);
+
+      // The result should be available (not hanging)
+      const result = await handle.result;
+
+      vi.useRealTimers();
+
+      expect(result.exitCode).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes two related race conditions that caused tool execution to hang indefinitely.

## Issue #983 - Shell Tool Hanging for Fast Commands

### The Problem
Users reported that shell commands (especially fast ones like `echo hello`, `rm file`) sometimes hung indefinitely, requiring ESC to abort. The issue was more prevalent with fast commands than slow ones like `npm install`.

### Root Cause Analysis
The hang occurred in `shellExecutionService.ts` in the PTY execution path. After the process exited (`onExit`), the code waited for the processing chain to complete via `Promise.race`:

```typescript
Promise.race([processingComplete, abortFired]).then(() => {
  finalize();
});
```

The `processingChain` is a sequence of promises that resolve when each `headlessTerminal.write()` callback fires. For fast commands:
- The process exits quickly
- A burst of output chunks are queued in the processing chain
- The xterm terminal's write callbacks may not have fired yet
- `Promise.race` waits indefinitely since only `processingComplete` or `abortFired` can resolve it

### The Fix
Added a 500ms timeout to the `Promise.race`:

```typescript
const timeout = new Promise<'timeout'>((res) =>
  setTimeout(() => res('timeout'), FINALIZE_TIMEOUT_MS),
);

Promise.race([processingComplete, abortFired, timeout]).then(() => {
  finalize();
});
```

This ensures finalization happens within a bounded time even if terminal write callbacks are delayed.

## Issue #987 - Scheduler Infinite `setImmediate` Loop

### The Problem
Tools (including non-shell tools like `read_file`) sometimes hung in 'executing' state forever, blocking the scheduler.

### Root Cause Analysis
The hang occurred in `coreToolScheduler.ts` in `publishBufferedResults()`. When tools completed before `currentBatchSize` was properly set (or after `cancelAll` reset it to 0), the function would:

1. Find `pendingResults` with entries but `currentBatchSize === 0`
2. The while loop condition `nextPublishIndex < currentBatchSize` (0 < 0) was `false`
3. Nothing was published
4. But `pendingResults.size > 0` triggered `setImmediate` to reschedule
5. This created an infinite loop with no progress

### The Fix
Added defensive code to detect and recover from the inconsistent state:

```typescript
if (this.currentBatchSize === 0 && this.pendingResults.size > 0) {
  // Recalculate batch size from pending results
  let maxIndex = -1;
  for (const buffered of this.pendingResults.values()) {
    if (buffered.executionIndex > maxIndex) {
      maxIndex = buffered.executionIndex;
    }
  }
  // Sanity check: batch size should not exceed pending results count
  const recoveredBatchSize = Math.min(maxIndex + 1, this.pendingResults.size);
  this.currentBatchSize = recoveredBatchSize > 0 ? recoveredBatchSize : 1;
}
```

## Relationship Between Issues

The two issues are **compounding**:
- Either can independently cause hangs
- Shell tools are more likely to hit both issues due to their fast execution patterns
- Fixing both ensures tools don't hang regardless of which race condition is triggered

## Testing

Added comprehensive test suites for both race conditions:
- `shellExecutionService.raceCondition.test.ts` - 4 tests for PTY timeout protection
- `coreToolScheduler.raceCondition.test.ts` - 6 tests for scheduler batch size recovery

All existing tests pass, confirming no regressions.

## Verification

- ✅ All tests pass (2557 tests)
- ✅ Lint passes
- ✅ Type check passes
- ✅ Build succeeds
- ✅ Manual verification with `node scripts/start.js --profile-load synthetic "write me a haiku"`

Closes #983
Closes #987

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed race conditions in the tool scheduler that could cause improper batch processing when tools complete with timing variations or before batch size is established.
- Enhanced shell execution service reliability by adding timeout protection to prevent indefinite hanging when terminal write callbacks stall during command execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->