### PR TITLE
fix: discover project-scoped memories in .llxprt/ directories during upward scan

### DIFF
--- a/packages/core/src/utils/memoryDiscovery.ts
+++ b/packages/core/src/utils/memoryDiscovery.ts
@@ -199,6 +199,20 @@ async function getGeminiMdFilePathsInternalForEachDir(
           // Not found, continue.
         }
 
+        const llxprtDirPath = path.join(
+          currentDir,
+          GEMINI_DIR,
+          geminiMdFilename,
+        );
+        try {
+          await fs.access(llxprtDirPath, fsSync.constants.R_OK);
+          if (llxprtDirPath !== globalMemoryPath) {
+            upwardPaths.unshift(llxprtDirPath);
+          }
+        } catch {
+          // Not found, continue.
+        }
+
         if (currentDir === ultimateStopDir) {
           break;
         }


### PR DESCRIPTION
## Summary

Fixes the issue where project-scoped memories saved to `.llxprt/LLXPRT.md` were not being loaded by the memory discovery system.

## Problem

When using `save_memory` with `scope: 'project'`, memories are saved to `./.llxprt/LLXPRT.md`. However, the memory discovery system's upward scan only looked for `LLXPRT.md` directly in directories (e.g., `./LLXPRT.md`, `../LLXPRT.md`), not inside `.llxprt/` subdirectories.

This caused project-scoped memories to not be reliably loaded because:
1. The upward scan missed `.llxprt/LLXPRT.md` entirely
2. The downward BFS search might find it, but is unreliable due to maxDirs limits, ignore rules, and search order

## Solution

Modified the upward scan in `memoryDiscovery.ts` to also check for `LLXPRT.md` files inside `.llxprt/` subdirectories at each directory level. This ensures project-scoped memories are discovered during the reliable upward traversal, matching the behavior already used for the global memory path (`~/.llxprt/LLXPRT.md`).

## Changes

- **`packages/core/src/utils/memoryDiscovery.ts`**: Added check for `.llxprt/LLXPRT.md` in the upward scan loop
- **`packages/core/src/utils/memoryDiscovery.test.ts`**: Added 4 behavioral tests for project-scoped memory discovery

## Testing

All 20 memory discovery tests pass, including the 4 new tests:
- `should discover memory files saved to .llxprt/ subdirectory during upward scan`
- `should discover memory files in .llxprt/ at multiple directory levels during upward scan`
- `should load both direct LLXPRT.md and .llxprt/LLXPRT.md from the same directory`
- `should not duplicate global memory path when scanning .llxprt/ directories`

Closes #985

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced memory discovery to locate project-scoped memory files at multiple directory levels during upward traversal.

* **Tests**
  * Added comprehensive test suite validating upward-scanning memory discovery behavior, including duplicate prevention and multi-level file detection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->