### PR TITLE
fix: change default memory scope from 'global' to 'project'

### DIFF
--- a/packages/core/src/tools/memoryTool.ts
+++ b/packages/core/src/tools/memoryTool.ts
@@ -45,8 +45,8 @@ const memoryToolSchemaData: FunctionDeclaration = {
         type: 'string',
         enum: ['global', 'project'],
         description:
-          'Where to save the memory: "global" (default, saves to ~/.llxprt) or "project" (saves to project-local .llxprt directory)',
-        default: 'global',
+          'Where to save the memory: "global" or "project" (default, saves to project-local .llxprt directory)',
+        default: 'project',
       },
     },
     required: ['fact'],
@@ -193,7 +193,7 @@ class MemoryToolInvocation extends BaseToolInvocation<
   }
 
   getMemoryFilePath(): string {
-    const scope = this.params.scope || 'global';
+    const scope = this.params.scope || 'project';
     if (scope === 'project' && this.workingDir) {
       return getProjectMemoryFilePath(this.workingDir);
     }
@@ -397,7 +397,8 @@ export class MemoryTool
 
   getModifyContext(_abortSignal: AbortSignal): ModifyContext<SaveMemoryParams> {
     const resolvePath = (scope?: 'global' | 'project'): string => {
-      if (scope === 'project' && this.config) {
+      const resolvedScope = scope || 'project';
+      if (resolvedScope === 'project' && this.config) {
         return getProjectMemoryFilePath(this.config.getWorkingDir());
       }
       return getGlobalMemoryFilePath();


### PR DESCRIPTION
## Problem

Previously, the `save_memory` tool defaulted to 'global' scope, which saved memories to `~/.llxprt/LLXPRT.md`. This caused a significant issue where memories from one project would interfere with agents working in different repositories.

For example, if one agent working on project A saved memories about "graphics.rs for phase 2 was implemented", and another agent working on project B looked for graphics.rs, it would incorrectly believe that file existed in project B based on the global memory. This cross-project memory contamination made the memory feature unreliable and potentially misleading.

## Solution

This PR changes the default memory scope from 'global' to 'project'. The `scope` parameter already existed in the schema and supported both 'global' and 'project' values—the fix simply changes the default behavior.

### Changes Made

**packages/core/src/tools/memoryTool.ts:**
- Changed schema default from `'global'` to `'project'` (line 48)
- Updated schema description to reflect new default behavior (line 47)
- Changed `getMemoryFilePath()` fallback from `'global'` to `'project'` (line 196)
- Fixed `getModifyContext()` to default undefined scope to `'project'` (line 399)

**packages/core/src/tools/memoryTool.test.ts:**
- Updated schema validation tests to expect `'project'` as default (lines 232, 487)
- Split test "should save to global directory when scope is 'global' or undefined" into two distinct tests:
  - "should save to project directory by default (when scope is undefined and workingDir is set)"
  - "should save to global directory when scope is explicitly 'global'`
- Updated all affected test expectations to match new behavior

### New Behavior

- **Default (no scope specified)**: Saves to `<project>/.llxprt/LLXPRT.md` ✅
- **`scope: 'project'`**: Saves to `<project>/.llxprt/LLXPRT.md` ✅  
- **`scope: 'global'`**: Saves to `~/.llxprt/LLXPRT.md` ✅

## Verification

All verification steps completed successfully:
- ✅ All tests pass (5017 tests across 312 files)
- ✅ Typecheck succeeds with no errors
- ✅ Lint succeeds with no errors
- ✅ Format check successful
- ✅ Build completes successfully
- ✅ Haiku test validates functionality

## Impact

This fix prevents memories from different projects from interfering with each other by defaulting to project-local storage. Each project now maintains its own isolated memory file, while still allowing agents to explicitly use global scope when needed (e.g., for truly cross-project knowledge).

This resolves the issue where GLM 4.7's memories about project-specific files would affect other agents working on unrelated repositories, making the memory feature more reliable and predictable.

closes #1022

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Memory storage now defaults to project-level scope instead of global scope when no specific scope is provided and a working directory is set.

* **Tests**
  * Updated test suite to verify project-level memory storage behavior by default when working directory exists.
  * Added tests for explicit global scope and global fallback scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->