### PR TITLE
feat: change shell and task timeout from milliseconds to seconds

### DIFF
--- a/packages/cli/src/settings/ephemeralSettings.ts
+++ b/packages/cli/src/settings/ephemeralSettings.ts
@@ -91,15 +91,15 @@ export const ephemeralSettingHelp: Record<string, string> = {
   circuit_breaker_recovery_timeout_ms:
     'Cooldown period before retrying after circuit opens in milliseconds (positive integer, default: 30000, load balancer only)',
 
-  // Tool timeout settings (Issue #920)
-  task_default_timeout_ms:
-    'Default timeout for task tool executions in milliseconds (default: 60000, -1 for unlimited)',
-  task_max_timeout_ms:
-    'Maximum timeout allowed for task tool executions in milliseconds (default: 300000, -1 for unlimited)',
-  shell_default_timeout_ms:
-    'Default timeout for shell tool executions in milliseconds (default: 60000, -1 for unlimited)',
-  shell_max_timeout_ms:
-    'Maximum timeout allowed for shell tool executions in milliseconds (default: 300000, -1 for unlimited)',
+  // Tool timeout settings (Issue #920, #1028)
+  task_default_timeout_seconds:
+    'Default timeout for task tool executions in seconds (default: 60, -1 for unlimited)',
+  task_max_timeout_seconds:
+    'Maximum timeout allowed for task tool executions in seconds (default: 300, -1 for unlimited)',
+  shell_default_timeout_seconds:
+    'Default timeout for shell tool executions in seconds (default: 120, -1 for unlimited)',
+  shell_max_timeout_seconds:
+    'Maximum timeout allowed for shell tool executions in seconds (default: 600, -1 for unlimited)',
 };
 
 const validEphemeralKeys = Object.keys(ephemeralSettingHelp);
@@ -475,20 +475,16 @@ export function parseEphemeralSettingValue(
   }
 
   if (
-    key === 'task_default_timeout_ms' ||
-    key === 'task_max_timeout_ms' ||
-    key === 'shell_default_timeout_ms' ||
-    key === 'shell_max_timeout_ms'
+    key === 'task_default_timeout_seconds' ||
+    key === 'task_max_timeout_seconds' ||
+    key === 'shell_default_timeout_seconds' ||
+    key === 'shell_max_timeout_seconds'
   ) {
     const numValue = parsedValue as number;
-    if (
-      typeof numValue !== 'number' ||
-      !Number.isInteger(numValue) ||
-      (numValue !== -1 && numValue <= 0)
-    ) {
+    if (typeof numValue !== 'number' || (numValue !== -1 && numValue <= 0)) {
       return {
         success: false,
-        message: `${key} must be a positive integer in milliseconds or -1 for unlimited`,
+        message: `${key} must be a positive number in seconds or -1 for unlimited`,
       };
     }
   }

--- a/packages/cli/src/ui/commands/setCommand.test.ts
+++ b/packages/cli/src/ui/commands/setCommand.test.ts
@@ -114,7 +114,7 @@ describe('setCommand runtime integration', () => {
       type: 'message',
       messageType: 'error',
       content:
-        'Invalid setting key: invalid-key. Valid keys are: context-limit, compression-threshold, base-url, tool-format, api-version, custom-headers, user-agent, stream-options, streaming, shell-replacement, socket-timeout, socket-keepalive, socket-nodelay, tool-output-max-items, tool-output-max-tokens, tool-output-truncate-mode, tool-output-item-size-limit, max-prompt-tokens, emojifilter, retries, retrywait, maxTurnsPerPrompt, authOnly, dumponerror, dumpcontext, prompt-caching, include-folder-structure, rate-limit-throttle, rate-limit-throttle-threshold, rate-limit-max-wait, reasoning.enabled, reasoning.includeInContext, reasoning.includeInResponse, reasoning.format, reasoning.stripFromContext, reasoning.effort, reasoning.maxTokens, enable-tool-prompts, tpm_threshold, timeout_ms, circuit_breaker_enabled, circuit_breaker_failure_threshold, circuit_breaker_failure_window_ms, circuit_breaker_recovery_timeout_ms, task_default_timeout_ms, task_max_timeout_ms, shell_default_timeout_ms, shell_max_timeout_ms',
+        'Invalid setting key: invalid-key. Valid keys are: context-limit, compression-threshold, base-url, tool-format, api-version, custom-headers, user-agent, stream-options, streaming, shell-replacement, socket-timeout, socket-keepalive, socket-nodelay, tool-output-max-items, tool-output-max-tokens, tool-output-truncate-mode, tool-output-item-size-limit, max-prompt-tokens, emojifilter, retries, retrywait, maxTurnsPerPrompt, authOnly, dumponerror, dumpcontext, prompt-caching, include-folder-structure, rate-limit-throttle, rate-limit-throttle-threshold, rate-limit-max-wait, reasoning.enabled, reasoning.includeInContext, reasoning.includeInResponse, reasoning.format, reasoning.stripFromContext, reasoning.effort, reasoning.maxTokens, enable-tool-prompts, tpm_threshold, timeout_ms, circuit_breaker_enabled, circuit_breaker_failure_threshold, circuit_breaker_failure_window_ms, circuit_breaker_recovery_timeout_ms, task_default_timeout_seconds, task_max_timeout_seconds, shell_default_timeout_seconds, shell_max_timeout_seconds',
     });
   });
 
@@ -134,10 +134,10 @@ describe('setCommand runtime integration', () => {
   });
   it('validates task timeout settings', async () => {
     const testCases = [
-      { key: 'task_default_timeout_ms', value: '90000' },
-      { key: 'task_max_timeout_ms', value: '180000' },
-      { key: 'shell_default_timeout_ms', value: '60000' },
-      { key: 'shell_max_timeout_ms', value: '300000' },
+      { key: 'task_default_timeout_seconds', value: '90' },
+      { key: 'task_max_timeout_seconds', value: '180' },
+      { key: 'shell_default_timeout_seconds', value: '60' },
+      { key: 'shell_max_timeout_seconds', value: '300' },
     ];
 
     for (const { key, value } of testCases) {
@@ -156,10 +156,10 @@ describe('setCommand runtime integration', () => {
 
   it('validates task timeout settings with -1 for unlimited', async () => {
     const testCases = [
-      { key: 'task_default_timeout_ms', value: '-1' },
-      { key: 'task_max_timeout_ms', value: '-1' },
-      { key: 'shell_default_timeout_ms', value: '-1' },
-      { key: 'shell_max_timeout_ms', value: '-1' },
+      { key: 'task_default_timeout_seconds', value: '-1' },
+      { key: 'task_max_timeout_seconds', value: '-1' },
+      { key: 'shell_default_timeout_seconds', value: '-1' },
+      { key: 'shell_max_timeout_seconds', value: '-1' },
     ];
 
     for (const { key, value } of testCases) {
@@ -176,28 +176,28 @@ describe('setCommand runtime integration', () => {
   it('rejects invalid timeout settings', async () => {
     const invalidCases = [
       {
-        key: 'task_default_timeout_ms',
+        key: 'task_default_timeout_seconds',
         value: '-5',
         expectedError:
-          'must be a positive integer in milliseconds or -1 for unlimited',
+          'must be a positive number in seconds or -1 for unlimited',
       },
       {
-        key: 'task_max_timeout_ms',
+        key: 'task_max_timeout_seconds',
         value: '0',
         expectedError:
-          'must be a positive integer in milliseconds or -1 for unlimited',
+          'must be a positive number in seconds or -1 for unlimited',
       },
       {
-        key: 'shell_default_timeout_ms',
+        key: 'shell_default_timeout_seconds',
         value: 'not-a-number',
         expectedError:
-          'must be a positive integer in milliseconds or -1 for unlimited',
+          'must be a positive number in seconds or -1 for unlimited',
       },
       {
-        key: 'shell_max_timeout_ms',
-        value: '1.5',
+        key: 'shell_max_timeout_seconds',
+        value: '-100',
         expectedError:
-          'must be a positive integer in milliseconds or -1 for unlimited',
+          'must be a positive number in seconds or -1 for unlimited',
       },
     ];
 

--- a/packages/core/src/tools/task.test.ts
+++ b/packages/core/src/tools/task.test.ts
@@ -353,7 +353,7 @@ describe('TaskTool', () => {
     expect(result.returnDisplay).toMatch(/abort/i);
   });
 
-  describe('timeout_ms handling', () => {
+  describe('timeout_seconds handling', () => {
     beforeEach(() => {
       vi.useFakeTimers();
     });
@@ -362,7 +362,7 @@ describe('TaskTool', () => {
       vi.useRealTimers();
     });
 
-    it('uses default timeout when timeout_ms is omitted', async () => {
+    it('uses default timeout when timeout_seconds is omitted', async () => {
       const dispose = vi.fn().mockResolvedValue(undefined);
       const scope = {
         output: {
@@ -386,8 +386,8 @@ describe('TaskTool', () => {
       const configWithSettings = {
         ...config,
         getEphemeralSettings: () => ({
-          task_default_timeout_ms: 60000,
-          task_max_timeout_ms: 300000,
+          task_default_timeout_seconds: 60,
+          task_max_timeout_seconds: 300,
         }),
       } as unknown as Config;
       const tool = new TaskTool(configWithSettings, {
@@ -418,7 +418,7 @@ describe('TaskTool', () => {
       await resultPromise;
     });
 
-    it('clamps timeout_ms to max setting', async () => {
+    it('clamps timeout_seconds to max setting', async () => {
       const dispose = vi.fn().mockResolvedValue(undefined);
       const scope = {
         output: {
@@ -442,8 +442,8 @@ describe('TaskTool', () => {
       const configWithSettings = {
         ...config,
         getEphemeralSettings: () => ({
-          task_default_timeout_ms: 60000,
-          task_max_timeout_ms: 120000,
+          task_default_timeout_seconds: 60,
+          task_max_timeout_seconds: 120,
         }),
       } as unknown as Config;
 
@@ -454,7 +454,7 @@ describe('TaskTool', () => {
       const invocation = tool.build({
         subagent_name: 'helper',
         goal_prompt: 'Ship it',
-        timeout_ms: 999999,
+        timeout_seconds: 999999,
       });
 
       const resultPromise = invocation.execute(
@@ -476,7 +476,7 @@ describe('TaskTool', () => {
       await resultPromise;
     });
 
-    it('skips timeout when timeout_ms is -1', async () => {
+    it('skips timeout when timeout_seconds is -1', async () => {
       const dispose = vi.fn().mockResolvedValue(undefined);
       const scope = {
         output: {
@@ -500,8 +500,8 @@ describe('TaskTool', () => {
       const configWithSettings = {
         ...config,
         getEphemeralSettings: () => ({
-          task_default_timeout_ms: 60000,
-          task_max_timeout_ms: 300000,
+          task_default_timeout_seconds: 60,
+          task_max_timeout_seconds: 300,
         }),
       } as unknown as Config;
       const tool = new TaskTool(configWithSettings, {
@@ -511,7 +511,7 @@ describe('TaskTool', () => {
       const invocation = tool.build({
         subagent_name: 'helper',
         goal_prompt: 'Ship it',
-        timeout_ms: -1,
+        timeout_seconds: -1,
       });
 
       const resultPromise = invocation.execute(
@@ -566,8 +566,8 @@ describe('TaskTool', () => {
       const configWithSettings = {
         ...config,
         getEphemeralSettings: () => ({
-          task_default_timeout_ms: 60000,
-          task_max_timeout_ms: 300000,
+          task_default_timeout_seconds: 60,
+          task_max_timeout_seconds: 300,
         }),
       } as unknown as Config;
       const tool = new TaskTool(configWithSettings, {
@@ -578,7 +578,7 @@ describe('TaskTool', () => {
       const invocation = tool.build({
         subagent_name: 'helper',
         goal_prompt: 'Ship it',
-        timeout_ms: 50,
+        timeout_seconds: 0.05, // 50ms
       });
 
       const resultPromise = invocation.execute(
@@ -631,8 +631,8 @@ describe('TaskTool', () => {
       const configWithSettings = {
         ...config,
         getEphemeralSettings: () => ({
-          task_default_timeout_ms: 60000,
-          task_max_timeout_ms: 300000,
+          task_default_timeout_seconds: 60,
+          task_max_timeout_seconds: 300,
         }),
       } as unknown as Config;
       const tool = new TaskTool(configWithSettings, {
@@ -645,7 +645,7 @@ describe('TaskTool', () => {
       const invocation = tool.build({
         subagent_name: 'helper',
         goal_prompt: 'Ship it',
-        timeout_ms: 1000,
+        timeout_seconds: 1,
       });
 
       const result = await invocation.execute(


### PR DESCRIPTION
## Summary

This PR addresses issue #1028 by changing the timeout parameters and ephemeral settings for shell and task tools from milliseconds to seconds. This prevents LLMs from setting timeout values too low due to misunderstanding the unit.

## Changes

### Parameter Renaming
- `timeout_ms` → `timeout_seconds` in both shell and task tool parameters
- Ephemeral settings renamed:
  - `shell_default_timeout_ms` → `shell_default_timeout_seconds`
  - `shell_max_timeout_ms` → `shell_max_timeout_seconds`
  - `task_default_timeout_ms` → `task_default_timeout_seconds`
  - `task_max_timeout_ms` → `task_max_timeout_seconds`

### Default Values (now in seconds)
- Shell: default 120s, max 600s
- Task: default 60s, max 300s

### Implementation Details
- Seconds are converted to milliseconds internally for `setTimeout`
- Fractional seconds are supported (e.g., `0.5` for 500ms)
- Timeout error messages now reference `timeout_seconds`
- Ephemeral settings validation updated to allow fractional seconds

### Approval Time Not Counted in Timeout
The shell tool timeout does **not** include user approval time. This is because:
1. The scheduler calls `shouldConfirmExecute()` first to determine if confirmation is needed
2. User approval happens outside the tool invocation
3. Only after approval does the scheduler call `execute()`
4. The timeout timer is created inside `execute()`, so it only counts execution time

A test was added to verify this behavior.

## Testing
- All existing tests updated to use new `_seconds` naming
- New test added to verify approval time is not counted in timeout
- All tests pass: `npm run test`, `npm run typecheck`, `npm run lint`

closes #1028

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Transitioned timeout configuration from milliseconds to seconds across shell and task tools. Setting names updated (e.g., `task_default_timeout_ms` → `task_default_timeout_seconds`) with corresponding defaults adjusted. Help text and validation error messages now reference seconds instead of milliseconds.

* **Tests**
  * Updated test suite to validate new seconds-based timeout configuration and behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->