### PR TITLE
fix(debug): add factory pattern to DebugLogger to prevent memory leaks

### DIFF
--- a/packages/core/src/debug/ConfigurationManager.test.ts
+++ b/packages/core/src/debug/ConfigurationManager.test.ts
@@ -210,6 +210,16 @@ describe('ConfigurationManager', () => {
       const config = manager.getEffectiveConfig();
       expect(config.enabled).toBe(true);
     });
+
+    it('should clear ephemeral config', () => {
+      const manager = ConfigurationManager.getInstance();
+      manager.setEphemeralConfig({ enabled: true });
+      expect(manager.getEffectiveConfig().enabled).toBe(true);
+
+      manager.clearEphemeralConfig();
+      // Should revert to default (or lower priority config)
+      expect(manager.getEffectiveConfig().enabled).toBe(false);
+    });
   });
 
   describe('Configuration Merging', () => {

--- a/packages/core/src/debug/ConfigurationManager.ts
+++ b/packages/core/src/debug/ConfigurationManager.ts
@@ -180,6 +180,18 @@ export class ConfigurationManager {
     this.mergeConfigurations();
   }
 
+  clearEphemeralConfig(): void {
+    this.ephemeralConfig = null;
+    this.mergeConfigurations();
+  }
+
+  /**
+   * Reset the singleton instance (for testing)
+   */
+  static resetForTesting(): void {
+    ConfigurationManager.instance = undefined;
+  }
+
   // Line 123-150: Persist ephemeral to user config
   persistEphemeralConfig(): void {
     if (!this.ephemeralConfig) {


### PR DESCRIPTION
## Summary

This PR fixes a memory leak in the DebugLogger class where every instance subscribed to ConfigurationManager but never properly cleaned up. The root cause was that `dispose()` used `this.onConfigChange` which created a new bound reference each time, rather than storing and reusing the original subscription callback.

## Problem Analysis

As identified in issue #228, the DebugLogger had three compounding problems:

1. **Unconditional Subscription**: Every `new DebugLogger(namespace)` subscribed to ConfigurationManager's listener set
2. **Broken Unsubscribe**: The `dispose()` method couldn't unsubscribe because it created a new function reference instead of using the original bound callback
3. **No Singleton Pattern**: Unlike ConfigurationManager and FileOutput, DebugLogger created new instances for each namespace every time

This caused:
- ~1MB memory leak per 1000 DebugLogger instances
- `MaxListenersExceededWarning` in tests (35+ tests creating 39+ instances)
- Production memory accumulation in long sessions (provider methods like `getLogger()` create new instances on every call)

## Solution

### 1. Factory Pattern with Singleton-per-Namespace
```typescript
static getLogger(namespace: string): DebugLogger {
  let logger = DebugLogger.instances.get(namespace);
  if (!logger) {
    logger = new DebugLogger(namespace);
    DebugLogger.instances.set(namespace, logger);
  }
  return logger;
}
```

### 2. Proper Bound Callback Storage
```typescript
// In constructor - store the bound reference
this.boundOnConfigChange = () => this.onConfigChange();
this._configManager.subscribe(this.boundOnConfigChange);

// In dispose - use the same reference
this._configManager.unsubscribe(this.boundOnConfigChange);
```

### 3. Test Cleanup
Added `afterEach(() => DebugLogger.disposeAll())` to all test suites to prevent subscription accumulation across tests.

## Changes

- **DebugLogger.ts**:
  - Add `static instances: Map<string, DebugLogger>` for singleton-per-namespace registry
  - Add `static getLogger(namespace)` factory method
  - Add `static disposeAll()` for test/shutdown cleanup
  - Add `static resetForTesting()` for test isolation
  - Store `boundOnConfigChange` in constructor for proper unsubscribe
  - Fix `dispose()` to unsubscribe with correct reference and remove from registry

- **DebugLogger.test.ts**:
  - Add `afterEach` cleanup to main describe block
  - Add new "DebugLogger Factory" test suite with 6 tests covering:
    - Same instance returned for same namespace
    - Different instances for different namespaces
    - Re-creation after disposeAll
    - No subscription accumulation
    - Individual dispose removes from registry
    - Subscription removal on dispose

- **ConfigurationManager.ts**:
  - Add `clearEphemeralConfig()` for test cleanup
  - Add `static resetForTesting()` for test isolation

- **ConfigurationManager.test.ts**:
  - Add test for `clearEphemeralConfig()`

## Backward Compatibility

The `new DebugLogger(namespace)` constructor remains public for backward compatibility. Production code should migrate to `DebugLogger.getLogger(namespace)` over time to benefit from the singleton pattern and prevent memory leaks.

## Testing

All tests pass:
- `npm run test` ✅
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run format` ✅
- `npm run build` ✅

closes #228

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced test coverage for ephemeral configuration management and logger factory pattern, including lifecycle and instance management scenarios.

* **New Features**
  * Added ability to clear ephemeral configurations and reset to default state.
  * Introduced improved logger lifecycle management with factory pattern and instance registry.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->