### PR TITLE
feat(subagent): apply emoji filtering to subagent output based on profile settings

### DIFF
--- a/packages/core/src/filters/EmojiFilter.subagent.test.ts
+++ b/packages/core/src/filters/EmojiFilter.subagent.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Tests for EmojiFilter integration with SubAgentScope
+ * @plan PLAN-ISSUE-623
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  EmojiFilter,
+  type EmojiFilterMode,
+  getMostRestrictiveFilter,
+} from './EmojiFilter';
+
+describe('EmojiFilter for Subagent Output', () => {
+  describe('getMostRestrictiveFilter', () => {
+    it('should return error when comparing error vs allowed', () => {
+      expect(getMostRestrictiveFilter('error', 'allowed')).toBe('error');
+      expect(getMostRestrictiveFilter('allowed', 'error')).toBe('error');
+    });
+
+    it('should return error when comparing error vs warn', () => {
+      expect(getMostRestrictiveFilter('error', 'warn')).toBe('error');
+      expect(getMostRestrictiveFilter('warn', 'error')).toBe('error');
+    });
+
+    it('should return error when comparing error vs auto', () => {
+      expect(getMostRestrictiveFilter('error', 'auto')).toBe('error');
+      expect(getMostRestrictiveFilter('auto', 'error')).toBe('error');
+    });
+
+    it('should return warn when comparing warn vs allowed', () => {
+      expect(getMostRestrictiveFilter('warn', 'allowed')).toBe('warn');
+      expect(getMostRestrictiveFilter('allowed', 'warn')).toBe('warn');
+    });
+
+    it('should return warn when comparing warn vs auto', () => {
+      expect(getMostRestrictiveFilter('warn', 'auto')).toBe('warn');
+      expect(getMostRestrictiveFilter('auto', 'warn')).toBe('warn');
+    });
+
+    it('should return auto when comparing auto vs allowed', () => {
+      expect(getMostRestrictiveFilter('auto', 'allowed')).toBe('auto');
+      expect(getMostRestrictiveFilter('allowed', 'auto')).toBe('auto');
+    });
+
+    it('should return the same mode when both are equal', () => {
+      const modes: EmojiFilterMode[] = ['error', 'warn', 'auto', 'allowed'];
+      for (const mode of modes) {
+        expect(getMostRestrictiveFilter(mode, mode)).toBe(mode);
+      }
+    });
+  });
+
+  describe('Subagent text filtering', () => {
+    const rocketEmoji = String.fromCodePoint(0x1f680);
+    const textWithEmoji = `Hello ${rocketEmoji} World`;
+
+    it('should filter emojis from subagent text response in warn mode', () => {
+      const filter = new EmojiFilter({ mode: 'warn' });
+      const result = filter.filterText(textWithEmoji);
+      expect(result.emojiDetected).toBe(true);
+      expect(result.filtered).toBe('Hello  World');
+      expect(result.systemFeedback).toBeDefined();
+    });
+
+    it('should filter emojis from subagent text response in auto mode without feedback', () => {
+      const filter = new EmojiFilter({ mode: 'auto' });
+      const result = filter.filterText(textWithEmoji);
+      expect(result.emojiDetected).toBe(true);
+      expect(result.filtered).toBe('Hello  World');
+      expect(result.systemFeedback).toBeUndefined();
+    });
+
+    it('should block content in error mode', () => {
+      const filter = new EmojiFilter({ mode: 'error' });
+      const result = filter.filterText(textWithEmoji);
+      expect(result.emojiDetected).toBe(true);
+      expect(result.blocked).toBe(true);
+      expect(result.filtered).toBeNull();
+    });
+
+    it('should pass through content in allowed mode', () => {
+      const filter = new EmojiFilter({ mode: 'allowed' });
+      const result = filter.filterText(textWithEmoji);
+      expect(result.emojiDetected).toBe(false);
+      expect(result.filtered).toBe(textWithEmoji);
+      expect(result.blocked).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/filters/EmojiFilter.ts
+++ b/packages/core/src/filters/EmojiFilter.ts
@@ -39,6 +39,24 @@ export interface FilterResult {
 type CompiledRegexArray = RegExp[];
 
 /**
+ * Gets the most restrictive filter mode from two modes
+ * Hierarchy: error > warn > auto > allowed
+ */
+export function getMostRestrictiveFilter(
+  mode1: EmojiFilterMode,
+  mode2: EmojiFilterMode,
+): EmojiFilterMode {
+  const priority: Record<EmojiFilterMode, number> = {
+    allowed: 0,
+    auto: 1,
+    warn: 2,
+    error: 3,
+  };
+
+  return priority[mode1] >= priority[mode2] ? mode1 : mode2;
+}
+
+/**
  * EmojiFilter class for filtering emojis from various content types
  * @pseudocode lines 01-186
  */

--- a/packages/core/src/runtime/AgentRuntimeContext.ts
+++ b/packages/core/src/runtime/AgentRuntimeContext.ts
@@ -32,6 +32,8 @@ export interface ReadonlySettingsSnapshot {
     allowed?: string[];
     disabled?: string[];
   };
+  /** Emoji filter mode for subagent output */
+  emojifilter?: 'allowed' | 'auto' | 'warn' | 'error';
   /** @plan PLAN-20251202-THINKING.P03b @requirement REQ-THINK-006.1 */
   'reasoning.enabled'?: boolean;
   /** @plan PLAN-20251202-THINKING.P03b @requirement REQ-THINK-006.2 */


### PR DESCRIPTION
## Summary

This PR implements emoji filtering for subagent output based on profile settings, addressing the issue where subagents were not respecting the `emojifilter` configuration from their profiles.

## Problem

Previously, subagents had the emoji filter mode hardcoded to `'auto'` in `buildEphemeralSettings()`, ignoring any `emojifilter` setting configured in the profile. This meant that even if a profile specified `error` or `warn` mode, subagents would always use `auto` mode for emoji filtering.

## Solution

Implemented a dual-layer filtering approach as recommended in the issue analysis:

### Changes Made

1. **`packages/core/src/runtime/AgentRuntimeContext.ts`**
   - Added `emojifilter` property to `ReadonlySettingsSnapshot` interface with proper typing

2. **`packages/core/src/filters/EmojiFilter.ts`**
   - Added `getMostRestrictiveFilter()` helper function for comparing filter modes
   - Filter mode hierarchy: `error` > `warn` > `auto` > `allowed`

3. **`packages/core/src/core/subagent.ts`**
   - Added private `emojiFilter` field to `SubAgentScope` class
   - Created `createEmojiFilter()` method to instantiate filter based on settings
   - Updated `buildEphemeralSettings()` to read `emojifilter` from settings snapshot
   - Applied emoji filtering in `runInteractive()`:
     - Filter text before calling `onMessage` callback
     - Filter `final_message` before setting in output
     - Handle blocked content in error mode by terminating
     - Include system feedback in warn mode
   - Applied emoji filtering in `runNonInteractive()`:
     - Same filtering logic as interactive mode

4. **`packages/core/src/filters/EmojiFilter.subagent.test.ts`** (new file)
   - Added tests for `getMostRestrictiveFilter()` helper
   - Added tests for subagent text filtering behavior in all modes

### Filter Mode Behavior

| Mode | Behavior |
|------|----------|
| `allowed` | Emojis pass through unchanged |
| `auto` | Emojis silently filtered out |
| `warn` | Emojis filtered + system feedback message |
| `error` | Content blocked, subagent terminates with error |

## Testing

- [x] Unit tests pass (`npm run test`)
- [x] TypeScript compilation passes (`npm run typecheck`)
- [x] Linting passes (`npm run lint`)
- [x] Code formatted (`npm run format`)
- [x] Build succeeds (`npm run build`)
- [x] Functional test: `node scripts/start.js --profile-load synthetic "write a haiku"`

## Related Issues

fixes #623

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Subagent messages now support emoji filtering with configurable modes (allowed, auto, warn, error)
  * Filtered content is processed before display; blocked content triggers error handling with optional system feedback

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->