### PR TITLE
Retry OpenAI timeouts like 429s

### DIFF
--- a/packages/core/src/providers/openai/OpenAIProvider.retry.test.ts
+++ b/packages/core/src/providers/openai/OpenAIProvider.retry.test.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * @plan PLAN-20250109issue1007
+ * Issue #1007: Request timeouts should trigger retry like 429
+ */
+
+import { describe, it, expect } from 'vitest';
+import { OpenAIProvider } from './OpenAIProvider.js';
+
+describe('OpenAIProvider - shouldRetryResponse (Issue #1007)', () => {
+  it('retries on 429 rate limit errors', () => {
+    const provider = new OpenAIProvider('test-key');
+    const error = new Error('Rate limit exceeded');
+    (error as { status: number }).status = 429;
+    expect(provider.shouldRetryResponse(error)).toBe(true);
+  });
+
+  it('retries on network timeout errors', () => {
+    const provider = new OpenAIProvider('test-key');
+    const error = new Error('Request timeout');
+    (error as { code: string }).code = 'ETIMEDOUT';
+    expect(provider.shouldRetryResponse(error)).toBe(true);
+  });
+
+  it('does not retry on status 200 streaming sentinel', () => {
+    const provider = new OpenAIProvider('test-key');
+    const error = { status: 200 };
+    expect(provider.shouldRetryResponse(error)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary\n- treat OpenAI transient network timeouts as retryable alongside 429/5xx\n- add focused retry predicate tests for timeout handling\n\n## Testing\n- npm run format\n- npm run lint\n- npm run typecheck\n- npm run test\n- npm run build\n- node scripts/start.js --profile-load synthetic --prompt "write me a haiku"\n\ncloses #1007

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for OpenAI provider retry behavior, covering rate limit errors, network timeouts, and streaming responses.

* **Bug Fixes**
  * Enhanced error handling to retry on network transient errors in addition to standard HTTP status codes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->