### PR TITLE
docs: add Multi-Account Failover section to OAuth docs

### DIFF
--- a/docs/cli/authentication.md
+++ b/docs/cli/authentication.md
@@ -196,6 +196,8 @@ LLxprt Code supports authentication with multiple AI providers beyond Google. Us
 
 OAuth buckets let you manage multiple authentication contexts per provider. This is useful when you have multiple accounts or API credentials for the same provider.
 
+> **Why use multiple buckets?** When you hit rate limits (429 errors) or quota limits (402 errors) on one account, llxprt-code can automatically fail over to another bucket. This is especially valuable for teams sharing multiple Claude Pro accounts or developers who want personal accounts as backup. For complete setup instructions and example scenarios, see the [Multi-Account Failover Guide](../oauth-setup.md#multi-account-failover).
+
 **Creating buckets:**
 
 ```bash

--- a/docs/cli/profiles.md
+++ b/docs/cli/profiles.md
@@ -58,6 +58,8 @@ Save a profile with multiple OAuth buckets for automatic failover when rate limi
 - On 402 (quota/payment): advance to next bucket immediately
 - On 401 (auth failure): attempt token refresh, retry once, then advance
 
+> **Need to create buckets first?** See the [OAuth Setup Guide](../oauth-setup.md#multi-account-failover) for step-by-step bucket creation instructions and practical failover scenarios (team accounts, personal+work, multi-provider).
+
 ### OpenAI-Compatible Endpoints
 
 Profiles work with any OpenAI-compatible endpoint. Here's an example using Synthetic with Kimi K2:


### PR DESCRIPTION
## Summary

Add comprehensive documentation for OAuth multi-bucket failover feature, addressing the documentation gap identified in issue #1094.

## Changes

### docs/oauth-setup.md
- Added new **Multi-Account Failover** section with:
  - Use case explanation (rate limit avoidance across multiple accounts)
  - Step-by-step setup guide:
    1. Create multiple OAuth buckets
    2. Verify bucket authentication
    3. Create profile with failover buckets
    4. Load and use the profile
  - Failover trigger table explaining 429, 402, and 401 error handling
  - Three practical example scenarios:
    1. Team with multiple Claude Pro accounts
    2. Personal + work account failover  
    3. Multi-provider failover (Anthropic -> OpenAI -> Gemini)
  - Monitoring bucket usage with \`/stats buckets\`
  - Best practices for bucket management
  - Troubleshooting guide for common failover issues

### docs/cli/authentication.md
- Added cross-reference callout in OAuth Buckets section explaining why multiple buckets are useful
- Links to oauth-setup.md for complete failover documentation

### docs/cli/profiles.md
- Added cross-reference callout in Multi-Bucket Profiles section
- Links to oauth-setup.md for bucket creation instructions and scenarios

## Testing

- Ran \`npm run lint\` - passed
- Ran \`npm run format\` - passed

Fixes #1094

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced OAuth authentication documentation with clearer explanations of multi-bucket configurations and automatic failover behavior.
  * Added comprehensive Multi-Account Failover guide covering setup steps, failover triggers, multi-provider chaining, and troubleshooting.
  * Improved profiles documentation with setup references for OAuth bucket creation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->