### PR TITLE
fix: handle 403 OAuth token revoked errors with refresh retry and bucket failover

### DIFF
--- a/packages/cli/src/runtime/__tests__/profileApplication.bucket-failover.spec.ts
+++ b/packages/cli/src/runtime/__tests__/profileApplication.bucket-failover.spec.ts
@@ -102,6 +102,29 @@ describe('shouldFailover - failover triggers', () => {
     );
     expect(shouldFailover(error)).toBe(true);
   });
+  it('should return true for 401 unauthorized errors (status code)', () => {
+    const error = new Error('Request failed with status code 401');
+    expect(shouldFailover(error)).toBe(true);
+  });
+
+  it('should return true for 403 permission errors (status code)', () => {
+    const error = new Error('Request failed with status code 403');
+    expect(shouldFailover(error)).toBe(true);
+  });
+
+  it('should return true for OAuth token revoked errors', () => {
+    const error = new Error(
+      'OAuth token has been revoked. Please obtain a new token.',
+    );
+    expect(shouldFailover(error)).toBe(true);
+  });
+
+  it('should return true for permission_error type in error message', () => {
+    const error = new Error(
+      '{"type":"error","error":{"type":"permission_error","message":"Token revoked"}}',
+    );
+    expect(shouldFailover(error)).toBe(true);
+  });
 });
 
 describe('executeWithBucketFailover - failover execution', () => {

--- a/packages/cli/src/runtime/bucketFailover.ts
+++ b/packages/cli/src/runtime/bucketFailover.ts
@@ -25,12 +25,22 @@
 export function shouldFailover(error: Error): boolean {
   const message = error.message.toLowerCase();
 
+  // Check for status code on error object (common pattern)
+  const errorStatus = (error as { status?: number }).status;
+  if (errorStatus === 401 || errorStatus === 403) {
+    return true;
+  }
+
   return (
     message.includes('429') ||
+    message.includes('401') ||
+    message.includes('403') ||
     message.includes('rate limit') ||
     message.includes('quota') ||
     message.includes('402') ||
     message.includes('payment') ||
+    message.includes('revoked') ||
+    message.includes('permission_error') ||
     (message.includes('token') && message.includes('expired'))
   );
 }

--- a/packages/core/src/core/bucketFailoverIntegration.ts
+++ b/packages/core/src/core/bucketFailoverIntegration.ts
@@ -29,12 +29,22 @@ import { DebugLogger } from '../debug/index.js';
 function shouldFailover(error: Error): boolean {
   const message = error.message.toLowerCase();
 
+  // Check for status code on error object (common pattern)
+  const errorStatus = (error as { status?: number }).status;
+  if (errorStatus === 401 || errorStatus === 403) {
+    return true;
+  }
+
   return (
     message.includes('429') ||
+    message.includes('401') ||
+    message.includes('403') ||
     message.includes('rate limit') ||
     message.includes('quota') ||
     message.includes('402') ||
     message.includes('payment') ||
+    message.includes('revoked') ||
+    message.includes('permission_error') ||
     (message.includes('token') && message.includes('expired'))
   );
 }


### PR DESCRIPTION
## Summary

Fixes #1123

When Anthropic returns a 403 `permission_error` with message "OAuth token has been revoked...", the system now properly handles this as an auth error, triggering:

1. **Refresh Retry**: One retry attempt to allow OAuth token refresh (same behavior as 401)
2. **Bucket Failover**: If refresh fails, failover to the next OAuth bucket in the profile

## Problem

Previously, 403 permission errors were not recognized as auth-related:
- `retry.ts` only treated 401 as an auth error for refresh retry
- `shouldFailover()` functions did not detect "revoked" tokens or 403 status codes

This meant revoked OAuth tokens would cause immediate failure without attempting refresh or bucket failover.

## Solution

### Core Changes

1. **packages/core/src/utils/retry.ts**:
   - Renamed `is401` to `isAuthError` to include both 401 and 403 status codes
   - Renamed `consecutive401s` to `consecutiveAuthErrors` for clarity
   - Updated debug logging to mention "401/403" instead of just "401"
   - Now triggers refresh retry on first 403, then bucket failover on second consecutive 403

2. **packages/cli/src/runtime/bucketFailover.ts**:
   - Enhanced `shouldFailover()` to detect:
     - Error status codes 401 or 403
     - "401", "403", "revoked", or "permission_error" in error messages
   - Preserved all existing triggers (429, rate limit, quota, 402, payment, token+expired)

3. **packages/core/src/core/bucketFailoverIntegration.ts**:
   - Applied same `shouldFailover()` enhancements for consistency

### Tests Added (TDD approach)

- **retry.test.ts**: Test for 403 OAuth token revoked with retry and failover behavior
- **bucketFailoverIntegration.spec.ts**: Tests for 403 status and "revoked" message handling
- **profileApplication.bucket-failover.spec.ts**: Tests for 401/403/revoked failover triggers

## Verification

All checks pass:
- npm run test (3009 tests passing)
- npm run lint (no errors)
- npm run typecheck (no errors)
- npm run format (formatted)
- npm run build (successful)
- Smoke test with haiku prompt (working)

## Behavior Change

Before:
- 403 "OAuth token has been revoked" -> Immediate failure

After:
- 403 "OAuth token has been revoked" -> Retry once for refresh -> Failover to next bucket -> Success (or fail if no more buckets)

This matches the existing behavior for 401 Unauthorized errors and aligns with the user expectation that revoked tokens should be treated as expired tokens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved failover behavior to handle HTTP 401 (Unauthorized) and 403 (Forbidden) errors
  * Added support for graceful bucket failover when OAuth tokens are revoked or permissions are denied

* **Tests**
  * Added comprehensive test coverage for authentication error scenarios and token revocation handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->