### PR TITLE
fix(anthropic): add schema-aware parameter coercion for LLM type errors

### DIFF
--- a/packages/core/src/utils/parameterCoercion.test.ts
+++ b/packages/core/src/utils/parameterCoercion.test.ts
@@ -304,6 +304,36 @@ describe('coerceParametersToSchema', () => {
       expect(result).toEqual({ offset: 50, limit: 100 });
     });
 
+    it('should not coerce float string to integer when schema expects integer', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          count: { type: 'integer' },
+        },
+      };
+      const params = { count: '1.5' };
+
+      const result = coerceParametersToSchema(params, schema);
+
+      // Should NOT coerce because 1.5 is not an integer
+      expect(result).toEqual({ count: '1.5' });
+    });
+
+    it('should coerce whole number float string to integer when schema expects integer', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          count: { type: 'integer' },
+        },
+      };
+      const params = { count: '10.0' };
+
+      const result = coerceParametersToSchema(params, schema);
+
+      // Should coerce because 10.0 is effectively an integer
+      expect(result).toEqual({ count: 10 });
+    });
+
     it('should handle complex nested JSON string arrays', () => {
       const schema = {
         type: 'object',

--- a/packages/core/src/utils/parameterCoercion.ts
+++ b/packages/core/src/utils/parameterCoercion.ts
@@ -62,9 +62,14 @@ function coerceValue(value: unknown, propertySchema: PropertySchema): unknown {
     const trimmed = value.trim();
     if (/^-?(?:\d+|\d*\.\d+)(?:[eE][+-]?\d+)?$/.test(trimmed)) {
       const num = Number(trimmed);
-      if (Number.isFinite(num)) {
-        return num;
+      if (!Number.isFinite(num)) {
+        return value;
       }
+      // For integer type, only coerce if the value is actually an integer
+      if (expectedType === 'integer' && !Number.isInteger(num)) {
+        return value;
+      }
+      return num;
     }
     return value;
   }


### PR DESCRIPTION
## Summary

This PR addresses a persistent issue where Claude Opus intermittently returns tool parameters with incorrect types, causing validation failures and tool execution errors.

## The Problem

Claude Opus sometimes returns:
- **Numbers as strings**: `"50"` instead of `50`
- **Booleans as strings**: `"true"` instead of `true`
- **Arrays as JSON strings**: `"[{...}]"` instead of `[{...}]`

This manifested as errors like:
- `params/offset must be number`
- `params/start_line must be number`
- `rawTodos.map is not a function` (TodoWrite receiving string instead of array)

## The Solution

Introduced a **schema-aware parameter coercion** utility that transforms LLM-returned parameters to match their expected schema types. This approach:

1. **Coerces types intelligently** based on the tool's JSON schema
2. **Handles all common LLM type mistakes**:
   - String → Number (`"50"` → `50`)
   - String → Boolean (`"true"` → `true`)
   - JSON String → Array (`"[{...}]"` → `[{...}]`)
   - JSON String → Object (`"{...}"` → `{...}`)
   - Single value → Array when schema expects array
3. **Normalizes Gemini Type enums** (`ARRAY` → `array`, `NUMBER` → `number`) for consistent matching
4. **Recursively processes** nested objects and array items

## Implementation Details

### New Files
- `packages/core/src/utils/parameterCoercion.ts` - Core coercion utility
- `packages/core/src/utils/parameterCoercion.test.ts` - Comprehensive test suite (33 tests)

### Modified Files
- `packages/core/src/providers/anthropic/AnthropicProvider.ts` - Integration at both streaming and non-streaming tool call processing paths

## Why This Approach?

We initially explored Anthropic's `strict: true` structured outputs feature, but it has significant limitations:
- Maximum 20 strict tools allowed
- Maximum 24 optional parameters across all strict tools
- Requires `additionalProperties: false` on all objects
- No support for `minimum`, `maximum`, `minLength`, `maxLength` constraints

Schema-aware coercion provides a robust client-side solution that works with all tools without API limitations.

## Testing

- ✅ 33 new unit tests covering all coercion scenarios
- ✅ Full test suite passes (3000+ tests)
- ✅ TypeScript compilation succeeds
- ✅ Linting passes
- ✅ Manual testing with Claude Max confirms fix

closes #1146