### PR TITLE
Fix diff advisory in UI lockfiles

### DIFF
--- a/packages/ui/bun.lock
+++ b/packages/ui/bun.lock
@@ -310,7 +310,7 @@
 
     "@vitest/utils": ["@vitest/utils@4.0.16", "", { "dependencies": { "@vitest/pretty-format": "4.0.16", "tinyrainbow": "^3.0.3" } }, "sha512-h8z9yYhV3e1LEfaQ3zdypIrnAg/9hguReGZoS7Gl0aBG5xgA410zBqECqmaF/+RkTggRsfnzc1XaAHA6bmUufA=="],
 
-    "@vybestack/opentui-core": ["@vybestack/opentui-core@0.1.62", "", { "dependencies": { "bun-ffi-structs": "0.1.2", "diff": "8.0.2", "sharp": "0.33.5", "yoga-layout": "3.2.1" }, "optionalDependencies": { "@dimforge/rapier2d-simd-compat": "^0.17.3", "@vybestack/opentui-core-darwin-arm64": "0.1.62", "@vybestack/opentui-core-darwin-x64": "0.1.62", "@vybestack/opentui-core-linux-arm64": "0.1.62", "@vybestack/opentui-core-linux-x64": "0.1.62", "@vybestack/opentui-core-win32-arm64": "0.1.62", "@vybestack/opentui-core-win32-x64": "0.1.62", "bun-webgpu": "0.1.4", "planck": "^1.4.2", "three": "0.177.0" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-7bV642znET0E7HS+aaNKFaMRWXYkQGVZbXgE1IWdgQMHCjO/McZ5Z6EFREhnVY7BfnsEoQnS8cwP6DO9vNAhPw=="],
+    "@vybestack/opentui-core": ["@vybestack/opentui-core@0.1.62", "", { "dependencies": { "bun-ffi-structs": "0.1.2", "diff": "8.0.3", "sharp": "0.33.5", "yoga-layout": "3.2.1" }, "optionalDependencies": { "@dimforge/rapier2d-simd-compat": "^0.17.3", "@vybestack/opentui-core-darwin-arm64": "0.1.62", "@vybestack/opentui-core-darwin-x64": "0.1.62", "@vybestack/opentui-core-linux-arm64": "0.1.62", "@vybestack/opentui-core-linux-x64": "0.1.62", "@vybestack/opentui-core-win32-arm64": "0.1.62", "@vybestack/opentui-core-win32-x64": "0.1.62", "bun-webgpu": "0.1.4", "planck": "^1.4.2", "three": "0.177.0" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-7bV642znET0E7HS+aaNKFaMRWXYkQGVZbXgE1IWdgQMHCjO/McZ5Z6EFREhnVY7BfnsEoQnS8cwP6DO9vNAhPw=="],
 
     "@vybestack/opentui-core-darwin-arm64": ["@vybestack/opentui-core-darwin-arm64@0.1.62", "", { "os": "darwin", "cpu": "arm64" }, "sha512-1FuxAD0ya4zB1DMTycy9CQHex4EgEx7tDtGbGKNqPGP+g4s4b04HEq0pdWXJIp0a25XtWvQ3x+9MAczzUhTEQA=="],
 
@@ -438,7 +438,7 @@
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
-    "diff": ["diff@8.0.2", "", {}, "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg=="],
+    "diff": ["diff@8.0.3", "", {}, "sha512-8kxCs9zZ1KAJXA4ogRzWllaBP3KUnp4+BKs+T844p7OEmFayGc6K8SSXepXsg8w7xDzs/a1rq9iLwr6voNNCVQ=="],
 
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
 

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -2846,9 +2846,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.2.tgz",
-      "integrity": "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+      "integrity": "sha512-8kxCs9zZ1KAJXA4ogRzWllaBP3KUnp4+BKs+T844p7OEmFayGc6K8SSXepXsg8w7xDzs/a1rq9iLwr6voNNCVQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -5538,7 +5538,7 @@
       "license": "MIT",
       "dependencies": {
         "bun-ffi-structs": "0.1.2",
-        "diff": "8.0.2",
+        "diff": "8.0.3",
         "jimp": "1.6.0",
         "sharp": "0.33.5",
         "yoga-layout": "3.2.1"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -34,6 +34,9 @@
     "node": ">=20",
     "bun": ">=1.2.0"
   },
+  "overrides": {
+    "diff": "8.0.3"
+  },
   "dependencies": {
     "@vybestack/opentui-core": "^0.1.62",
     "@vybestack/opentui-react": "^0.1.62",


### PR DESCRIPTION
## Summary
- Update UI workspace overrides to force diff 8.0.3
- Refresh UI npm and bun lockfiles for the patched diff version

## Verification
- npm run format
- npm run build
- npm run test
- npm run typecheck
- npm run lint
- node scripts/start.js --profile-load synthetic "write me a haiku"

## Security context
- Addresses https://github.com/vybestack/llxprt-code/security/dependabot/28 by ensuring the UI workspace uses diff 8.0.3 in its lockfiles and transitive references
