### PR TITLE
feat(gemini): add gemini-3-flash-preview to oauth models

### DIFF
--- a/packages/core/src/providers/gemini/GeminiProvider.test.ts
+++ b/packages/core/src/providers/gemini/GeminiProvider.test.ts
@@ -382,6 +382,31 @@ describe('GeminiProvider', () => {
     });
   });
 
+  it('should include gemini-3-flash-preview in OAuth model list', async () => {
+    const provider = new GeminiProvider();
+
+    vi.spyOn(
+      provider as unknown as {
+        determineBestAuth: () => Promise<{ authMode: string; token: string }>;
+      },
+      'determineBestAuth',
+    ).mockResolvedValue({
+      authMode: 'oauth',
+      token: 'test-oauth-token',
+    });
+
+    const models = await provider.getModels();
+    const modelIds = models.map((m) => m.id);
+
+    expect(modelIds).toContain('gemini-3-flash-preview');
+
+    const flashPreview = models.find((m) => m.id === 'gemini-3-flash-preview');
+    expect(flashPreview).toBeDefined();
+    expect(flashPreview?.name).toBe('Gemini 3 Flash Preview');
+    expect(flashPreview?.provider).toBe('gemini');
+    expect(flashPreview?.supportedToolFormats).toEqual([]);
+  });
+
   describe('GeminiProvider Authentication', () => {
     it('should check AuthResolver before falling back to Vertex AI', async () => {
       // Mock authResolver to return a test key

--- a/packages/core/src/providers/gemini/GeminiProvider.ts
+++ b/packages/core/src/providers/gemini/GeminiProvider.ts
@@ -494,6 +494,12 @@ export class GeminiProvider extends BaseProvider {
           provider: this.name,
           supportedToolFormats: [],
         },
+        {
+          id: 'gemini-3-flash-preview',
+          name: 'Gemini 3 Flash Preview',
+          provider: this.name,
+          supportedToolFormats: [],
+        },
       ];
     }
 


### PR DESCRIPTION
## Summary
- add gemini-3-flash-preview to Gemini OAuth model list
- add test coverage for the OAuth model list

## Testing
- npm run test
- npm run lint
- npm run format
- npm run typecheck (fails: pre-existing diffOptions.ts type errors)
- npm run build (fails: pre-existing diffOptions.ts type errors)
- node scripts/start.js --profile-load synthetic "write me a haiku"

Fixes #1163