### PR TITLE
fix: prevent OpenAI tool output double-wrapping for error objects

### DIFF
--- a/docs/tool-output-format.md
+++ b/docs/tool-output-format.md
@@ -27,3 +27,4 @@ Notes:
 - `output` is intended to be raw multi-line text (for example, code or logs).
 - If there is no error, `error` is an empty string.
 - When output is missing, it is replaced with `[no tool result]`.
+- Some tools return structured (JSON-like) results. For OpenAI providers we prefer a human-readable multi-line rendering (e.g. `error` text, `stdout`/`stderr`) to avoid an extra JSON wrapper like `{"error":"..."}` and preserve real newlines.

--- a/packages/core/src/providers/openai/OpenAIProvider.ts
+++ b/packages/core/src/providers/openai/OpenAIProvider.ts
@@ -1117,7 +1117,7 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
     block: ToolResponseBlock,
     config?: Config,
   ): string {
-    const payload = buildToolResponsePayload(block, config);
+    const payload = buildToolResponsePayload(block, config, true);
     return ensureJsonSafe(
       formatToolResponseText({
         status: payload.status,

--- a/packages/core/src/providers/openai/buildResponsesRequest.stripToolCalls.test.ts
+++ b/packages/core/src/providers/openai/buildResponsesRequest.stripToolCalls.test.ts
@@ -73,6 +73,56 @@ describe('buildResponsesRequest - tool_calls stripping', () => {
     });
   });
 
+  it('does not double-wrap tool errors when result is {error: string}', () => {
+    const messages: IContent[] = [
+      {
+        speaker: 'tool',
+        blocks: [
+          {
+            type: 'tool_response',
+            callId: 'call_doublewrap',
+            toolName: 'replace',
+            result: {
+              error: `Failed to edit file
+
+Diff: ...`,
+            },
+          },
+        ],
+      },
+    ];
+
+    const request = buildResponsesRequest({
+      model: 'o3',
+      messages,
+    });
+
+    expect(request.input?.length).toBe(1);
+    expect(request.input?.[0]).toEqual({
+      type: 'function_call_output',
+      call_id: 'call_doublewrap',
+      output: `status:
+success
+
+toolName:
+replace
+
+error:
+
+
+output:
+Failed to edit file
+
+Diff: ...`,
+    });
+
+    const output = (request.input?.[0] as { output?: string }).output ?? '';
+    expect(output).toContain(`output:
+Failed to edit file`);
+    expect(output).not.toContain(`output:
+{"error":`);
+  });
+
   it('should handle messages without tool_calls', () => {
     const messages: IContent[] = [
       {

--- a/packages/core/src/providers/openai/buildResponsesRequest.ts
+++ b/packages/core/src/providers/openai/buildResponsesRequest.ts
@@ -243,7 +243,11 @@ export function buildResponsesRequest(
             if (block.type === 'tool_response') {
               const toolResponseBlock = block as ToolResponseBlock;
 
-              const payload = buildToolResponsePayload(toolResponseBlock);
+              const payload = buildToolResponsePayload(
+                toolResponseBlock,
+                undefined,
+                true,
+              );
               let sanitizedContent = formatToolResponseText({
                 status: payload.status,
                 toolName: payload.toolName ?? toolResponseBlock.toolName,

--- a/packages/core/src/providers/utils/toolResponsePayload.test.ts
+++ b/packages/core/src/providers/utils/toolResponsePayload.test.ts
@@ -113,6 +113,34 @@ describe('toolResponsePayload', () => {
     });
   });
 
+  describe('humanizeJson', () => {
+    it('should render stdout/stderr/exitCode as multi-line blocks with stable spacing', () => {
+      const block: ToolResponseBlock = {
+        type: 'tool_response',
+        toolUseId: 'test-id',
+        toolName: 'test_tool',
+        result: {
+          exitCode: 2,
+          stdout: `hello
+world`,
+          stderr: `warn`,
+        },
+      };
+
+      const payload = buildToolResponsePayload(block, undefined, true);
+
+      expect(payload.result).toBe(`exitCode:
+2
+
+stdout:
+hello
+world
+
+stderr:
+warn`);
+    });
+  });
+
   describe('edge cases', () => {
     it('should handle empty results', () => {
       const block: ToolResponseBlock = {

--- a/packages/core/src/providers/utils/toolResponsePayload.ts
+++ b/packages/core/src/providers/utils/toolResponsePayload.ts
@@ -50,10 +50,92 @@ export interface ToolResponsePayload {
 
 export const EMPTY_TOOL_RESULT_PLACEHOLDER = '[no tool result]';
 
-function coerceToString(value: unknown): string {
+export function humanizeJsonForDisplay(value: unknown): string | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const obj = value as Record<string, unknown>;
+
+  // Prefer common text fields to avoid JSON-stringifying multi-line output.
+  for (const key of [
+    'error',
+    'error_text',
+    'message',
+    'llmContent',
+    'returnDisplay',
+  ]) {
+    const v = obj[key];
+    if (typeof v === 'string' && v.trim()) {
+      return v;
+    }
+  }
+
+  // Common shell-like result shape.
+  const stdout = obj.stdout;
+  const stderr = obj.stderr;
+  const exitCode = obj.exitCode;
+  const hasStdout = typeof stdout === 'string' && stdout.trim();
+  const hasStderr = typeof stderr === 'string' && stderr.trim();
+  const hasExitCode = typeof exitCode === 'number';
+
+  if (hasStdout || hasStderr || hasExitCode) {
+    const out: string[] = [];
+
+    if (hasExitCode) {
+      out.push('exitCode:');
+      out.push(String(exitCode));
+      out.push('');
+    }
+
+    if (hasStdout) {
+      out.push('stdout:');
+      out.push(
+        String(stdout)
+          .replace(/[\r\n]+$/, '')
+          .trimEnd(),
+      );
+      out.push('');
+    }
+
+    if (hasStderr) {
+      out.push('stderr:');
+      out.push(
+        String(stderr)
+          .replace(/[\r\n]+$/, '')
+          .trimEnd(),
+      );
+      out.push('');
+    }
+
+    return out.join('\n').trimEnd();
+  }
+
+  return undefined;
+}
+
+function coerceToString(value: unknown, humanizeJson?: boolean): string {
   if (typeof value === 'string') {
     return value;
   }
+
+  // Default behavior is JSON.stringify for non-strings. For OpenAI tool output we may prefer
+  // a human-readable multi-line rendering to preserve newlines.
+  if (humanizeJson) {
+    const human = humanizeJsonForDisplay(value);
+    if (typeof human === 'string' && human.trim()) {
+      return human;
+    }
+    // Fallback: pretty JSON (multi-line) instead of a single-line blob.
+    if (value && typeof value === 'object') {
+      try {
+        return JSON.stringify(value, null, 2);
+      } catch {
+        // no-op
+      }
+    }
+  }
+
   try {
     return JSON.stringify(value);
   } catch {
@@ -76,7 +158,10 @@ function formatToolResultValue(text: string): {
   return { value: text, originalLength: text.length };
 }
 
-function formatToolResult(result: unknown): {
+function formatToolResult(
+  result: unknown,
+  humanizeJson?: boolean,
+): {
   value?: string;
   originalLength?: number;
   raw?: string;
@@ -97,7 +182,7 @@ function formatToolResult(result: unknown): {
     }
   }
 
-  const coerced = coerceToString(result);
+  const coerced = coerceToString(result, humanizeJson);
   return { value: coerced, raw: coerced };
 }
 
@@ -148,6 +233,7 @@ function limitToolPayload(
 export function buildToolResponsePayload(
   block: ToolResponseBlock,
   config?: Config,
+  humanizeJson?: boolean,
 ): ToolResponsePayload {
   const payload: ToolResponsePayload = {
     status: block.error ? 'error' : 'success',
@@ -155,7 +241,7 @@ export function buildToolResponsePayload(
     result: EMPTY_TOOL_RESULT_PLACEHOLDER,
   };
 
-  const formatted = formatToolResult(block.result);
+  const formatted = formatToolResult(block.result, humanizeJson);
   const serializedResult =
     config && formatted.raw ? formatted.raw : formatted.value;
   if (serializedResult) {
@@ -171,7 +257,7 @@ export function buildToolResponsePayload(
   }
 
   if (block.error) {
-    payload.error = coerceToString(block.error);
+    payload.error = coerceToString(block.error, humanizeJson);
   }
 
   return payload;


### PR DESCRIPTION
## Proposed change

Improves OpenAI tool output rendering when a tool returns a JSON-like result object (e.g. `{ error: string }`, `{ stdout, stderr, exitCode }`).

Instead of embedding a JSON string inside the `output:` section (double-wrapping), the OpenAI provider now prefers a human-readable multi-line rendering that:

- preserves real newlines;
- avoids unreadable blobs like  
  `output:\n{"error":"..."}`.

## Implementation details

- Extends `buildToolResponsePayload()` with an optional **humanize JSON** mode for OpenAI tool outputs.
- Adds `humanizeJsonForDisplay()` to detect common result shapes and render them as readable multi-line text:
  - prefers text fields like `error`, `message`, etc.
  - renders `exitCode`, `stdout`, `stderr` as stable multi-line blocks
  - falls back to pretty-printed JSON for other objects
- Updates OpenAI tool output formatting paths to enable this mode:
  - `OpenAIProvider.formatToolMessage()`
  - Responses API `buildResponsesRequest()` for `function_call_output`
- Adds tests to ensure:
  - `{ error: "multiline..." }` does not become `output:\n{"error": ...}`
  - `stdout` / `stderr` / `exitCode` are rendered as multi-line blocks with stable spacing
- Updates documentation note in `docs/tool-output-format.md` clarifying preference for human-readable rendering for structured results

## Notes

- Scope is intentionally limited to OpenAI tool output formatting; other providers keep existing behavior.
- Tool outputs remain plain multi-line text; this change only affects how non-string results are converted into that text to avoid reintroducing escaping.
- Preserves real newlines for error text, logs, and diffs.

## Related issue

Fixes #1171 — OpenAI tool outputs were still getting JSON-wrapped when the tool result was an object,  
reintroducing over-escaping and reducing readability even after #1002.