### PR TITLE
fix(onboarding): fix multiple onboarding issues #1181-#1185

### DIFF
--- a/packages/cli/src/ui/components/WelcomeOnboarding/AuthMethodStep.tsx
+++ b/packages/cli/src/ui/components/WelcomeOnboarding/AuthMethodStep.tsx
@@ -13,7 +13,13 @@ import {
 } from '../shared/RadioButtonSelect.js';
 
 // Providers that support OAuth
-const OAUTH_PROVIDERS = new Set(['anthropic', 'openai', 'gemini', 'qwen']);
+const OAUTH_PROVIDERS = new Set([
+  'anthropic',
+  'openai',
+  'gemini',
+  'qwen',
+  'codex',
+]);
 
 const API_KEY_URLS: Record<string, string> = {
   anthropic: 'console.anthropic.com/settings/keys',

--- a/packages/cli/src/ui/components/WelcomeOnboarding/ProviderSelectStep.tsx
+++ b/packages/cli/src/ui/components/WelcomeOnboarding/ProviderSelectStep.tsx
@@ -13,14 +13,31 @@ import {
 } from '../shared/RadioButtonSelect.js';
 
 const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
-  anthropic: 'Anthropic (Claude)',
-  openai: 'OpenAI (GPT-4, etc.)',
   gemini: 'Google Gemini',
-  deepseek: 'DeepSeek',
+  codex: 'OpenAI Codex (ChatGPT Backend)',
+  anthropic: 'Anthropic (Claude)',
   qwen: 'Qwen',
+  synthetic: 'Synthetic (Testing)',
+  zai: 'Zai',
+  openai: 'OpenAI (GPT-4, etc.)',
   'openai-responses': 'OpenAI Responses API',
   openaivercel: 'OpenAI (Vercel AI SDK)',
+  deepseek: 'DeepSeek',
 };
+
+// Preferred order for provider display
+const PROVIDER_ORDER: string[] = [
+  'gemini',
+  'codex',
+  'anthropic',
+  'qwen',
+  'synthetic',
+  'zai',
+  'openai',
+  'openai-responses',
+  'openaivercel',
+  'deepseek',
+];
 
 interface ProviderSelectStepProps {
   providers: string[];
@@ -36,7 +53,17 @@ export const ProviderSelectStep: React.FC<ProviderSelectStepProps> = ({
   isFocused = true,
 }) => {
   const options: Array<RadioSelectItem<string>> = useMemo(() => {
-    const providerOptions = providers.map((provider) => ({
+    // Sort providers by preferred order
+    const sortedProviders = [...providers].sort((a, b) => {
+      const aIndex = PROVIDER_ORDER.indexOf(a);
+      const bIndex = PROVIDER_ORDER.indexOf(b);
+      // Providers not in the list go to the end
+      const aOrder = aIndex === -1 ? PROVIDER_ORDER.length : aIndex;
+      const bOrder = bIndex === -1 ? PROVIDER_ORDER.length : bIndex;
+      return aOrder - bOrder;
+    });
+
+    const providerOptions = sortedProviders.map((provider) => ({
       label: PROVIDER_DISPLAY_NAMES[provider] || provider,
       value: provider,
       key: provider,

--- a/packages/core/src/providers/gemini/GeminiProvider.ts
+++ b/packages/core/src/providers/gemini/GeminiProvider.ts
@@ -464,43 +464,55 @@ export class GeminiProvider extends BaseProvider {
    * Determine auth mode per call instead of using cached state
    */
   async getModels(): Promise<IModel[]> {
-    // Determine auth mode for this call
-    const { authMode } = await this.determineBestAuth();
+    // Full model list including OAuth-only models (gemini-3-*-preview)
+    // Used as fallback when no auth yet, and for OAuth mode
+    const oauthModels: IModel[] = [
+      {
+        id: 'gemini-2.5-pro',
+        name: 'Gemini 2.5 Pro',
+        provider: this.name,
+        supportedToolFormats: [],
+      },
+      {
+        id: 'gemini-2.5-flash',
+        name: 'Gemini 2.5 Flash',
+        provider: this.name,
+        supportedToolFormats: [],
+      },
+      {
+        id: 'gemini-2.5-flash-lite',
+        name: 'Gemini 2.5 Flash Lite',
+        provider: this.name,
+        supportedToolFormats: [],
+      },
+      {
+        id: 'gemini-3-pro-preview',
+        name: 'Gemini 3 Pro Preview',
+        provider: this.name,
+        supportedToolFormats: [],
+      },
+      {
+        id: 'gemini-3-flash-preview',
+        name: 'Gemini 3 Flash Preview',
+        provider: this.name,
+        supportedToolFormats: [],
+      },
+    ];
 
-    // For OAuth mode, return fixed list of models
+    // Determine auth mode for this call (graceful when no auth yet)
+    let authMode: GeminiAuthMode;
+    try {
+      const result = await this.determineBestAuth();
+      authMode = result.authMode;
+    } catch (_e) {
+      // No auth configured yet (pre-onboarding) - return full model list
+      // including OAuth models so user can see all options when selecting
+      return oauthModels;
+    }
+
+    // For OAuth mode, return fixed list of models (including 3-*-preview)
     if (authMode === 'oauth') {
-      return [
-        {
-          id: 'gemini-2.5-pro',
-          name: 'Gemini 2.5 Pro',
-          provider: this.name,
-          supportedToolFormats: [],
-        },
-        {
-          id: 'gemini-2.5-flash',
-          name: 'Gemini 2.5 Flash',
-          provider: this.name,
-          supportedToolFormats: [],
-        },
-        {
-          id: 'gemini-2.5-flash-lite',
-          name: 'Gemini 2.5 Flash Lite',
-          provider: this.name,
-          supportedToolFormats: [],
-        },
-        {
-          id: 'gemini-3-pro-preview',
-          name: 'Gemini 3 Pro Preview',
-          provider: this.name,
-          supportedToolFormats: [],
-        },
-        {
-          id: 'gemini-3-flash-preview',
-          name: 'Gemini 3 Flash Preview',
-          provider: this.name,
-          supportedToolFormats: [],
-        },
-      ];
+      return oauthModels;
     }
 
     // For API key modes (gemini-api-key or vertex-ai), try to fetch real models
@@ -545,27 +557,8 @@ export class GeminiProvider extends BaseProvider {
       }
     }
 
-    // Return default models as fallback
-    return [
-      {
-        id: 'gemini-2.5-pro',
-        name: 'Gemini 2.5 Pro',
-        provider: this.name,
-        supportedToolFormats: [],
-      },
-      {
-        id: 'gemini-2.5-flash',
-        name: 'Gemini 2.5 Flash',
-        provider: this.name,
-        supportedToolFormats: [],
-      },
-      {
-        id: 'gemini-2.5-flash-exp',
-        name: 'Gemini 2.5 Flash Experimental',
-        provider: this.name,
-        supportedToolFormats: [],
-      },
-    ];
+    // Return default models as fallback (use same list as OAuth for consistency)
+    return oauthModels;
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes critical onboarding issues that prevent new users from successfully completing initial setup.

## Issues Fixed

### #1181 - Onboarding setup with Anthropic (double OAuth, invalid model ID)
- **Root cause 1**: Model ID mapping used display name instead of API identifier
- **Fix**: Changed \`useWelcomeOnboarding.ts\` to use \`m.id\` for the model ID field
- **Root cause 2**: Double OAuth trigger - \`switchActiveProvider()\` was called before \`authenticate()\`
- **Fix**: Reordered \`triggerAuth()\` to call \`authenticate()\` BEFORE \`switchActiveProvider()\`
- **Root cause 3**: Selected model was not persisted to runtime - \`setActiveModel()\` was never called
- **Fix**: Now call \`runtime.setActiveModel(modelId)\` in \`selectModel\` callback

### #1182 - Codex in onboarding has "API key" as the only option
- **Root cause**: Codex provider was missing from \`OAUTH_PROVIDERS\` set
- **Fix**: Added \`codex\` to \`OAUTH_PROVIDERS\` in \`AuthMethodStep.tsx\` and added display name in \`ProviderSelectStep.tsx\`

### #1183 - OpenAIResponses model list outdated
- **Root cause**: \`RESPONSES_API_MODELS\` list was missing newer codex models
- **Fix**: Added \`gpt-5.2-codex\`, \`gpt-5.1-codex-max\`, \`gpt-5.1-codex\`, \`gpt-5.1-codex-mini\`, \`gpt-5.2\`, and \`gpt-5.1\` to the model list

### #1184 - Onboarding with Gemini fails (model list doesn't load)
- **Root cause**: \`GeminiProvider.getModels()\` called \`determineBestAuth()\` which throws when no auth is configured
- **Fix 1**: Wrapped \`determineBestAuth()\` call in try/catch and return full OAuth model list when no auth configured
- **Fix 2**: Reordered onboarding flow to provider -> auth_method -> model
- **Fix 3**: After auth completes, models are refreshed with proper auth context
- **Bonus**: Gemini fallback now includes gemini-3-pro-preview and gemini-3-flash-preview

### #1185 - Primary Onboarding Problems Issue
- Parent issue for the above; all sub-issues are addressed by this PR

## Additional Improvements

### Provider Order
Providers are now displayed in preferred order: Gemini, Codex, Anthropic, Qwen, Synthetic, Zai, then others.

## New Onboarding Flow

\`\`\`
provider -> auth_method -> [authenticate] -> model -> completion
\`\`\`

This ensures:
1. User selects provider first
2. User chooses auth method (OAuth or API key)
3. Authentication happens BEFORE model list loads
4. Model list refreshes with proper auth context (full model list available)
5. User selects model AND it is persisted to runtime state
6. Profile snapshot captures the correct model

## Key Bug Fix: Model Selection Not Persisted

The root cause of the "selected gemini-3-pro-preview but got gemini-2.5-pro" bug was that \`selectModel()\` only updated React state but never called \`runtime.setActiveModel()\`. When \`saveProfileSnapshot()\` was called, it captured the default model from the runtime instead of the user's selection.

**Before**: \`selectModel\` only set \`state.selectedModel\`
**After**: \`selectModel\` also calls \`await runtime.setActiveModel(modelId)\`

## Verification

- npm run lint - PASSED
- npm run typecheck - PASSED
- npm run format - PASSED
- npm run build - PASSED
- npm run test - PASSED (3000+ tests)
- node scripts/start.js --profile-load synthetic "write me a haiku" - PASSED

## Files Changed

- \`packages/cli/src/ui/hooks/useWelcomeOnboarding.ts\` - Reordered flow, fixed model ID mapping, fixed double OAuth, **added runtime.setActiveModel() call**
- \`packages/cli/src/ui/components/WelcomeOnboarding/AuthMethodStep.tsx\` - Add codex to OAuth providers
- \`packages/cli/src/ui/components/WelcomeOnboarding/ProviderSelectStep.tsx\` - Add codex display name, **add provider ordering**
- \`packages/core/src/providers/openai/RESPONSES_API_MODELS.ts\` - Add newer codex models
- \`packages/core/src/providers/gemini/GeminiProvider.ts\` - Graceful fallback with full OAuth model list

Fixes #1181, fixes #1182, fixes #1183, fixes #1184, fixes #1185