### PR TITLE
fix: prevent ENOTEMPTY errors and set executable permissions on CLI entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "auth": "npm run auth:npm && npm run auth:docker",
     "generate": "node scripts/generate-git-commit-info.js && node scripts/generate_prompt_manifest.js",
     "build": "node scripts/build.js",
+    "preinstall": "node scripts/preinstall.cjs",
     "postinstall": "node scripts/postinstall.cjs",
     "build-and-start": "npm run build && npm run start",
     "build:vscode": "node scripts/build_vscode_companion.js",
@@ -75,6 +76,7 @@
   },
   "files": [
     "bundle/",
+    "scripts/preinstall.cjs",
     "scripts/postinstall.cjs",
     "README.md",
     "LICENSE"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
     "llxprt": "dist/index.js"
   },
   "scripts": {
-    "build": "node ../../scripts/build_package.js",
+    "build": "node ../../scripts/build_package.js && chmod 755 dist/index.js",
     "start": "node dist/index.js",
     "debug": "node --inspect-brk dist/index.js",
     "lint": "eslint . --ext .ts,.tsx",

--- a/scripts/preinstall.cjs
+++ b/scripts/preinstall.cjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+/**
+ * Preinstall script to clean up leftover temp directories from failed npm installs.
+ * This prevents ENOTEMPTY errors during npm global upgrades.
+ *
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* eslint-env node */
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Attempts to clean up leftover .llxprt-code-* temp directories that cause
+ * ENOTEMPTY errors during npm global package upgrades.
+ *
+ * These temp directories are created by npm during atomic rename operations
+ * and can be left behind if the install fails or is interrupted.
+ */
+function cleanupTempDirectories() {
+  // Only run cleanup for global installs
+  if (process.env.npm_config_global !== 'true') {
+    return;
+  }
+
+  try {
+    // Get the path where this package is being installed
+    // For global installs, this will be something like /opt/homebrew/lib/node_modules/@vybestack/llxprt-code
+    const scriptDir = __dirname;
+    const packageDir = path.dirname(scriptDir);
+
+    // The temp directories are created in the parent of node_modules/@vybestack
+    // e.g., /opt/homebrew/lib/node_modules/@vybestack/.llxprt-code-ofqtIqCy
+    const nodeModulesDir = path.dirname(path.dirname(packageDir));
+
+    if (!nodeModulesDir || !fs.existsSync(nodeModulesDir)) {
+      return;
+    }
+
+    // Look for @vybestack directory (parent of this package)
+    const vybestackDir = path.dirname(packageDir);
+    if (!fs.existsSync(vybestackDir)) {
+      return;
+    }
+
+    const entries = fs.readdirSync(vybestackDir);
+    let cleanedCount = 0;
+
+    for (const entry of entries) {
+      // Match temp directories like .llxprt-code-ofqtIqCy
+      if (entry.startsWith('.llxprt-code-')) {
+        const tempPath = path.join(vybestackDir, entry);
+        try {
+          fs.rmSync(tempPath, { recursive: true, force: true });
+          console.log(`Cleaned up leftover temp directory: ${entry}`);
+          cleanedCount++;
+        } catch (rmError) {
+          // Ignore errors - best effort cleanup
+          console.warn(
+            `Warning: Could not remove ${entry}: ${rmError.message}`,
+          );
+        }
+      }
+    }
+
+    if (cleanedCount > 0) {
+      console.log(
+        `Cleaned up ${cleanedCount} leftover temp director${cleanedCount === 1 ? 'y' : 'ies'} from previous failed install.`,
+      );
+    }
+  } catch {
+    // Silently ignore errors - this is best-effort cleanup
+    // We don't want to fail the install if cleanup fails
+  }
+}
+
+cleanupTempDirectories();


### PR DESCRIPTION
## Summary

Fixes #1162 - Addresses the ENOTEMPTY errors and permission issues that occur during npm global installs/upgrades.

## Problem

When users run \`npm i -g @vybestack/llxprt-code@nightly\` (or any version), they encounter two issues:

1. **ENOTEMPTY error**: npm attempts to atomically rename the package directory but fails because leftover \`.llxprt-code-*\` temp directories exist from previous failed installs
2. **Permission denied**: After manual cleanup, the CLI fails to run because \`dist/index.js\` lacks execute permissions (644 instead of 755)

## Root Cause Analysis

1. **ENOTEMPTY**: npm creates temp directories during atomic rename operations. If an install fails or is interrupted, these directories are left behind and cause subsequent installs to fail.

2. **Permissions**: The CLI workspace publishes \`dist/index.js\` as the bin entry point, but unlike the root package's \`bundle/llxprt.js\` (which gets chmod 755 via esbuild.config.js), the CLI's dist/index.js had no chmod applied. npm tarballs preserve file modes, so the 644 permissions were being shipped.

For reference, Google's \`@google/gemini-cli\` package correctly ships \`dist/index.js\` with 755 permissions in their tarball.

## Solution

### 1. Add chmod to CLI build script
- Modified \`packages/cli/package.json\` build script to run \`chmod 755 dist/index.js\` after TypeScript compilation
- Ensures the bin entry point has executable permissions in the published npm package

### 2. Add preinstall cleanup script
- Created \`scripts/preinstall.cjs\` that runs before npm install
- Detects and cleans up leftover \`.llxprt-code-*\` temp directories in the @vybestack scope directory
- Only runs for global installs (checks \`npm_config_global\`)
- Best-effort cleanup - silently ignores errors to not break installs

## Files Changed

- \`package.json\` - Added preinstall script hook and included preinstall.cjs in files array
- \`packages/cli/package.json\` - Added chmod 755 to build script
- \`scripts/preinstall.cjs\` - New script for temp directory cleanup

## Testing

All verification passed:
- \`npm run lint\` ✓
- \`npm run typecheck\` ✓
- \`npm run format\` ✓
- \`npm run build\` ✓
- \`npm run test\` ✓
- Manual haiku test with synthetic profile ✓
- Verified \`packages/cli/dist/index.js\` now has 755 permissions after build

## Backward Compatibility

Fully backward compatible:
- preinstall script only affects global installs and is best-effort
- chmod change only affects new publishes, existing installs unaffected
- No changes to user-facing behavior except fixes for the reported issues

closes #1162