### PR TITLE
fix(oauth): prevent spurious paste box in non-headless Anthropic OAuth

### DIFF
--- a/packages/cli/src/ui/hooks/useWelcomeOnboarding.ts
+++ b/packages/cli/src/ui/hooks/useWelcomeOnboarding.ts
@@ -331,7 +331,11 @@ export const useWelcomeOnboarding = (
       }
 
       // Now switch to the provider AFTER auth is complete
-      const switchResult = await runtime.switchActiveProvider(provider);
+      // IMPORTANT: Pass autoOAuth: false to prevent switchActiveProvider from triggering
+      // a second OAuth flow - we already authenticated above
+      const switchResult = await runtime.switchActiveProvider(provider, {
+        autoOAuth: false,
+      });
       debug.log(
         `[triggerAuth] After switchActiveProvider - changed: ${switchResult.changed}, now active: ${providerManager?.getActiveProviderName()}`,
       );


### PR DESCRIPTION
## Summary

Fixes #1202 - During onboarding OAuth with Anthropic, users in non-headless environments were seeing:
1. Two authentication links being printed (two browser tabs opening)
2. A paste box appearing even after the user successfully authenticated via browser

## Root Causes

### Issue 1: Paste box fallthrough in anthropic-oauth-provider.ts

The original code would:
1. Set up the local callback server for browser auth
2. Open browser and wait for callback
3. If `waitForCallback()` failed (e.g., timeout, error), it would **silently fall through** to the paste box flow instead of reporting the error

This meant that even if the browser auth succeeded but the callback had a race condition or timing issue, the user would see the paste box.

### Issue 2: Double OAuth trigger in useWelcomeOnboarding.ts

The onboarding flow was:
1. `oauthManager.authenticate(provider)` - triggers OAuth (first browser tab)
2. `runtime.switchActiveProvider(provider)` - by default triggers autoOAuth, which would call `oauthManager.authenticate()` AGAIN (second browser tab)

## Solution

### Fix 1: anthropic-oauth-provider.ts
- In interactive mode with local callback server: if the callback succeeds, return immediately
- If the callback fails, **throw an error** rather than falling through to the paste box flow
- The paste box (`__oauth_needs_code`) should ONLY be shown in non-interactive (headless) environments
- Reorganized URL construction to be clearer about which URL is used in which mode

### Fix 2: useWelcomeOnboarding.ts
- Pass `autoOAuth: false` to `switchActiveProvider()` to prevent it from triggering a second OAuth flow
- We already authenticated explicitly in the step before, so autoOAuth is not needed

## Verification

- npm run test - passed
- npm run lint - passed  
- npm run format - passed
- npm run build - passed
- `node scripts/start.js --profile-load synthetic "write me a haiku"` - works

## Testing

This fix should be tested manually by:
1. Removing existing Anthropic OAuth token (`rm ~/.llxprt/oauth/anthropic.json`)
2. Running welcome onboarding and selecting Anthropic with OAuth
3. Completing browser authentication
4. Verifying:
   - Only ONE browser tab opens
   - Only ONE OAuth URL is displayed
   - NO paste box appears after browser auth completes

Fixes #1202