### PR TITLE
fix: address CodeRabbit feedback and OAuth onboarding issues

### DIFF
--- a/packages/cli/src/ui/components/WelcomeOnboarding/AuthenticationStep.tsx
+++ b/packages/cli/src/ui/components/WelcomeOnboarding/AuthenticationStep.tsx
@@ -35,7 +35,6 @@ export const AuthenticationStep: React.FC<AuthenticationStepProps> = ({
 }) => {
   const [apiKey, setApiKey] = useState('');
   const [isAuthenticating, setIsAuthenticating] = useState(false);
-  const [authStarted, setAuthStarted] = useState(false);
 
   const providerDisplay = provider.charAt(0).toUpperCase() + provider.slice(1);
 
@@ -89,10 +88,13 @@ export const AuthenticationStep: React.FC<AuthenticationStepProps> = ({
     { isActive: isFocused },
   );
 
-  // Start OAuth flow automatically
+  // Start OAuth flow automatically - use ref to prevent double-execution
+  // React Strict Mode or dependency changes can cause this effect to re-run
+  const authStartedRef = React.useRef(false);
+
   useEffect(() => {
-    if (method === 'oauth' && !authStarted) {
-      setAuthStarted(true);
+    if (method === 'oauth' && !authStartedRef.current) {
+      authStartedRef.current = true;
       setIsAuthenticating(true);
       triggerAuth(provider, 'oauth')
         .then(() => {
@@ -103,7 +105,7 @@ export const AuthenticationStep: React.FC<AuthenticationStepProps> = ({
           onError(error instanceof Error ? error.message : String(error));
         });
     }
-  }, [method, provider, triggerAuth, onComplete, onError, authStarted]);
+  }, [method, provider, triggerAuth, onComplete, onError]);
 
   if (method === 'oauth') {
     return (


### PR DESCRIPTION
## Summary

This PR addresses CodeRabbit feedback from PR #1200 and fixes OAuth onboarding issues (#1202) for the v0.8.1 release.

## Changes

### 1. useWelcomeOnboarding.ts - setActiveModel error handling (CodeRabbit)

- Added try/catch around `runtime.setActiveModel()` in `selectModel`
- Surfaces error to UI via `state.error` so user gets feedback
- Keeps user on model step if setting model fails (instead of silently stalling)

### 2. useWelcomeOnboarding.ts - Double OAuth trigger fix (Issue #1202)

- Pass `autoOAuth: false` to `switchActiveProvider()` to prevent triggering a second OAuth flow after explicit authentication
- This was causing two browser tabs to open and two OAuth URLs to be displayed

### 3. anthropic-oauth-provider.ts - Paste box fallthrough fix (Issue #1202)

- In interactive mode with local callback server, throw error on callback failure instead of falling through to paste box flow
- Paste box (`__oauth_needs_code`) now only shown in non-interactive (headless) environments
- Reorganized URL construction for clarity between interactive and device-code flows

### 4. scripts/preinstall.cjs - npm prefix-aware path resolution (CodeRabbit)

- Added `npm_config_prefix` detection for correct path resolution during npm global installs
- Computes correct `node_modules` path based on prefix:
  - Unix: `prefix/lib/node_modules`
  - Windows: `prefix/node_modules`
- Falls back to `__dirname`-based logic if prefix unavailable
- **This fixes ongoing mac upgrade issues** where users had to manually delete directories

## Verification

- npm run test - passed
- npm run lint - passed
- npm run format - passed
- npm run build - passed
- `node scripts/start.js --profile-load synthetic "write me a haiku"` - works

## Testing

OAuth onboarding should be tested manually:
1. Remove existing Anthropic OAuth token: `rm ~/.llxprt/oauth/anthropic.json`
2. Run welcome onboarding and select Anthropic with OAuth
3. Verify:
   - Only ONE browser tab opens
   - Only ONE OAuth URL is displayed
   - NO paste box appears after browser auth completes

Fixes #1202
Addresses CodeRabbit feedback from #1200