### PR TITLE
fix(ci): use --prompt flag for llxprt non-interactive mode

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -409,7 +409,7 @@ jobs:
           initial_prompt="You are reviewing PR #${PR_NUMBER}. Start by reading review/instructions.md for your mission and review/context.md for PR details. Use file tools to explore the changes incrementally. Write your final verdict to review/verdict.md."
 
           set +e
-          # Agentic mode: pass instruction as positional argument, agent explores files with tools
+          # Agentic mode: use --prompt flag to pass initial instruction
           # Use --baseurl CLI flag instead of --set base-url to ensure proper timing
           llxprt \
             --provider "${LLXPRT_DEFAULT_PROVIDER}" \
@@ -421,7 +421,7 @@ jobs:
             --set modelparam.max_tokens=16000 \
             --set context-limit="${context_limit}" \
             --set shell-replacement=false \
-            "${initial_prompt}" 2>&1 | tee "${llxprt_log}"
+            --prompt "${initial_prompt}" 2>&1 | tee "${llxprt_log}"
           llxprt_status=${PIPESTATUS[0]}
           set -e
 


### PR DESCRIPTION
## TLDR

Fixes the PR review workflow by adding the `--prompt` flag to pass the initial instruction to llxprt in non-interactive mode. Without this flag, llxprt expects stdin input and fails with "No input provided via stdin".

Fixes #1220

## Dive Deeper

### The Problem

After the recent refactor to agentic workflow mode (PR #1219), the PR reviewer was failing with:

```
No input provided via stdin. Input can be provided by piping data into gemini or using the --prompt option.
```

The workflow was passing the initial prompt as a positional argument:
```bash
llxprt ... "${initial_prompt}"
```

However, llxprt in non-interactive (yolo) mode requires either:
1. Input piped via stdin, OR
2. The `--prompt` flag to specify the initial prompt

### The Fix

Changed from positional argument to explicit `--prompt` flag:

```diff
-            "${initial_prompt}" 2>&1 | tee "${llxprt_log}"
+            --prompt "${initial_prompt}" 2>&1 | tee "${llxprt_log}"
```

This is the correct way to pass an initial prompt in non-interactive mode, ensuring the agent receives its instructions and can begin the agentic exploration workflow.

## Reviewer Test Plan

1. **Verify workflow syntax**: Run `actionlint .github/workflows/pr-review.yml` - should pass
2. **Test on a real PR**: The reviewer should now:
   - Start successfully without stdin errors
   - Read the instructions and context files
   - Perform the agentic review
   - Write verdict to `review/verdict.md`

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | -   | -   |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #1220

This is a follow-up fix to PR #1219 which refactored the reviewer to agentic mode but missed the required `--prompt` flag for non-interactive execution.