### PR TITLE
fix: Add stream retry with exponential backoff to AnthropicProvider

### DIFF
--- a/packages/core/src/providers/anthropic/AnthropicProvider.streamRetry.test.ts
+++ b/packages/core/src/providers/anthropic/AnthropicProvider.streamRetry.test.ts
@@ -227,6 +227,9 @@ describe('AnthropicProvider stream retry behavior', () => {
             blocks: [{ type: 'text', text: 'hello' }],
           },
         ] as IContent[],
+        ephemerals: {
+          retrywait: 3000, // Override default delay
+        },
       }),
     );
 
@@ -243,6 +246,9 @@ describe('AnthropicProvider stream retry behavior', () => {
 
     expect(firstDelay).toBeGreaterThan(0);
     expect(secondDelay).toBeGreaterThan(firstDelay);
+    // Verify initial delay respects ephemeral setting (~3000ms with jitter)
+    expect(firstDelay).toBeGreaterThan(2100);
+    expect(firstDelay).toBeLessThan(3900);
   });
 
   it('fails after max attempts with error thrown', async () => {
@@ -287,8 +293,8 @@ describe('AnthropicProvider stream retry behavior', () => {
       }
     }).rejects.toThrow('terminated');
 
-    // Should attempt 4 times (max attempts)
-    expect(mockAnthropicClient.messages.create).toHaveBeenCalledTimes(4);
+    // Default maxAttempts from getRetryConfig is 6
+    expect(mockAnthropicClient.messages.create).toHaveBeenCalledTimes(6);
   });
 
   it('throws non-retryable errors immediately', async () => {
@@ -335,5 +341,134 @@ describe('AnthropicProvider stream retry behavior', () => {
 
     // Should not retry non-retryable errors
     expect(mockAnthropicClient.messages.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('respects retries ephemeral setting', async () => {
+    const createErrorStream = () =>
+      (async function* () {
+        yield {
+          type: 'message_start',
+          message: { usage: { input_tokens: 10, output_tokens: 0 } },
+        };
+        throw new Error('terminated');
+      })();
+
+    mockAnthropicClient.messages.create.mockImplementation(() => ({
+      withResponse: () =>
+        Promise.resolve({
+          data: createErrorStream(),
+          response: { headers: new Headers() },
+        }),
+    }));
+
+    retryWithBackoffMock.mockImplementation(
+      async (fn: () => Promise<unknown>) => fn(),
+    );
+
+    const provider = new AnthropicProvider('test-key');
+
+    const generator = provider.generateChatCompletion(
+      createProviderCallOptions({
+        providerName: provider.name,
+        contents: [
+          {
+            speaker: 'human',
+            blocks: [{ type: 'text', text: 'hello' }],
+          },
+        ] as IContent[],
+        ephemerals: {
+          retries: 2, // Override default
+        },
+      }),
+    );
+
+    await expect(async () => {
+      for await (const _chunk of generator) {
+        // Should throw after 2 attempts
+      }
+    }).rejects.toThrow('terminated');
+
+    expect(mockAnthropicClient.messages.create).toHaveBeenCalledTimes(2);
+  });
+
+  it('respects retrywait ephemeral setting', async () => {
+    const createErrorStream = () =>
+      (async function* () {
+        yield {
+          type: 'message_start',
+          message: { usage: { input_tokens: 10, output_tokens: 0 } },
+        };
+        throw new Error('terminated');
+      })();
+
+    const successStream = (async function* () {
+      yield {
+        type: 'message_start',
+        message: { usage: { input_tokens: 10, output_tokens: 0 } },
+      };
+      yield {
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'text', text: '' },
+      };
+      yield {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'text_delta', text: 'success' },
+      };
+      yield { type: 'content_block_stop', index: 0 };
+      yield {
+        type: 'message_delta',
+        delta: { stop_reason: 'end_turn' },
+        usage: { output_tokens: 5 },
+      };
+    })();
+
+    let callCount = 0;
+    mockAnthropicClient.messages.create.mockImplementation(() => {
+      const stream = callCount === 0 ? createErrorStream() : successStream;
+      callCount++;
+      return {
+        withResponse: () =>
+          Promise.resolve({
+            data: stream,
+            response: { headers: new Headers() },
+          }),
+      };
+    });
+
+    retryWithBackoffMock.mockImplementation(
+      async (fn: () => Promise<unknown>) => fn(),
+    );
+
+    const provider = new AnthropicProvider('test-key');
+
+    const generator = provider.generateChatCompletion(
+      createProviderCallOptions({
+        providerName: provider.name,
+        contents: [
+          {
+            speaker: 'human',
+            blocks: [{ type: 'text', text: 'hello' }],
+          },
+        ] as IContent[],
+        ephemerals: {
+          retrywait: 1500, // Override default 4000ms
+        },
+      }),
+    );
+
+    const chunks: IContent[] = [];
+    for await (const chunk of generator) {
+      chunks.push(chunk);
+    }
+
+    expect(mockAnthropicClient.messages.create).toHaveBeenCalledTimes(2);
+    expect(delayMock).toHaveBeenCalledTimes(1);
+
+    const delay = delayMock.mock.calls[0]?.[0] as number;
+    // Should be ~1500ms with jitter (between 1050-1950)
+    expect(delay).toBeGreaterThan(1050);
+    expect(delay).toBeLessThan(1950);
   });
 });

--- a/packages/core/src/test-utils/providerCallOptions.ts
+++ b/packages/core/src/test-utils/providerCallOptions.ts
@@ -42,6 +42,7 @@ export interface ProviderCallOptionsInit {
   runtimeId?: string;
   runtimeMetadata?: Record<string, unknown>;
   invocation?: RuntimeInvocationContext;
+  ephemerals?: Record<string, unknown>;
 }
 
 function applySettingsOverrides(
@@ -69,9 +70,11 @@ function applySettingsOverrides(
 function buildEphemeralsSnapshot(
   providerName: string,
   settings: SettingsService,
+  overrides?: Record<string, unknown>,
 ): Record<string, unknown> {
   const snapshot: Record<string, unknown> = {
     ...settings.getAllGlobalSettings(),
+    ...(overrides ?? {}),
   };
 
   snapshot[providerName] = {
@@ -161,7 +164,11 @@ function ensureInvocation(
     return init.invocation;
   }
 
-  const ephemeralsSnapshot = buildEphemeralsSnapshot(providerName, settings);
+  const ephemeralsSnapshot = buildEphemeralsSnapshot(
+    providerName,
+    settings,
+    init.ephemerals,
+  );
 
   const userMemorySnapshot =
     typeof init.userMemory === 'string' ? init.userMemory : undefined;


### PR DESCRIPTION
## TLDR

Fixes the issue where transient network errors (like \`terminated\`, \`connection reset\`, etc.) during AnthropicProvider stream consumption were breaking the agent loop instead of being properly retried with exponential backoff. This mirrors the fix from PR #1227 for OpenAIResponsesProvider.

Both providers now read retry configuration from ephemeral settings (\`retries\` and \`retrywait\`) instead of hardcoded constants, ensuring consistency with fetch-level retry behavior and respecting user-configured profile settings. Bucket failover via \`onPersistent429\` is preserved in Anthropic stream retries.

## Dive Deeper

### Problem

The AnthropicProvider had \`retryWithBackoff\` around the initial API call, but when streaming is enabled, the stream consumption loop only caught errors and re-threw them - no retry with backoff. Additionally, the initial implementation hardcoded retry constants instead of reading from the ephemeral settings that users configure in profiles.

### Solution

1. **AnthropicProvider stream retry** - Wrapped stream consumption in a retry loop:
   - On retry, makes a fresh API call via \`apiCallWithResponse\` (with full \`retryWithBackoff\` + \`onPersistent429\` bucket failover)
   - Uses \`isNetworkTransientError\` to determine if errors are retryable
   - Non-retryable errors thrown immediately

2. **Ephemeral settings integration** - Both providers now read from user-configurable settings:
   - **AnthropicProvider**: Reuses \`maxAttempts\`/\`initialDelayMs\` from \`getRetryConfig()\` (defaults: 6 attempts, 4000ms)
   - **OpenAIResponsesProvider**: Reads \`retries\`/\`retrywait\` from \`options.invocation.ephemerals\` (defaults: Codex 5 / regular 4 attempts, 5000ms)
   - Removed redundant hardcoded \`STREAM_RETRY_*\` constants from both providers

3. **Exponential backoff with jitter**: Same formula as \`retryWithBackoff\`: jitter = currentDelay * 0.3 * (Math.random() * 2 - 1), delay doubles each retry, capped at 30s

4. **Bucket failover preserved**: Anthropic stream retry passes \`onPersistent429Callback\` to the inner \`retryWithBackoff\` call, so load-balanced/bucketed profiles work correctly

## Reviewer Test Plan

1. Run \`npm run test\` - all tests pass including new stream retry + ephemeral settings tests
2. Verify ephemeral settings are respected:
   - Set \`retries: 2\` in a profile - stream retry should only attempt 2 times
   - Set \`retrywait: 1000\` - initial delay should be ~1000ms instead of default

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

closes #1228