### PR TITLE
feat(core): clip run_shell_command output in the middle when truncating

### DIFF
--- a/docs/tools/shell.md
+++ b/docs/tools/shell.md
@@ -107,6 +107,7 @@ With a PTY enabled, `run_shell_command` supports fully interactive programs (for
 
 - **Security:** Be cautious when executing commands, especially those constructed from user input, to prevent security vulnerabilities.
 - **Interactive commands:** Avoid commands that require interactive user input, as this can cause the tool to hang. Use non-interactive flags if available (e.g., `npm init -y`).
+- **Output limiting:** In `truncate` mode, `run_shell_command` clips the output by removing the middle to preserve both head and tail. In `warn` and `sample`, it uses the default limiter behavior.
 - **Error handling:** Check the `Stderr`, `Error`, and `Exit Code` fields to determine if a command executed successfully.
 - **Background processes:** When a command is run in the background with `&`, the tool will return immediately and the process will continue to run in the background. The `Background PIDs` field will contain the process ID of the background process.
 


### PR DESCRIPTION
## Proposed change

Improves run_shell_command output truncation so that large outputs remain useful to the model. In truncate mode, instead of cutting off the tail, the tool clips the middle of the output, preserving both the beginning (context/setup) and the end (results/errors).

## Implementation details

- Adds a reusable clipMiddle() helper to toolOutputLimiter.
- Updates ShellTool to apply middle-clipping for the final model payload when tool-output-truncate-mode is truncate, while keeping existing warn/sample behavior unchanged.
- Adds unit tests for clipMiddle().
- Updates docs/tools/shell.md to document the truncation behavior.

## Related issue

Fixes #1230 — Improve run_shell_command truncation: preserve head + tail (clip middle)
