### PR TITLE
fix: apply EmojiFilter to thinking blocks in CLI and interactive stream

### DIFF
--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -306,12 +306,21 @@ export async function runNonInteractive({
             const thoughtEvent = event as ServerGeminiThoughtEvent;
             const thought = thoughtEvent.value;
             // Format thought with subject and description
-            const thoughtText =
+            let thoughtText =
               thought.subject && thought.description
                 ? `${thought.subject}: ${thought.description}`
                 : thought.subject || thought.description || '';
 
             if (thoughtText.trim()) {
+              if (emojiFilter) {
+                const filterResult = emojiFilter.filterText(thoughtText);
+                if (filterResult.blocked) {
+                  continue;
+                }
+                if (typeof filterResult.filtered === 'string') {
+                  thoughtText = filterResult.filtered;
+                }
+              }
               process.stdout.write(`<think>${thoughtText}</think>\n`);
             }
           }

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -949,14 +949,20 @@ export const useGeminiStream = (
 
             // Accumulate as ThinkingBlock for history
             {
-              const thinkingBlock: ThinkingBlock = {
-                type: 'thinking',
-                thought: [event.value.subject, event.value.description]
-                  .filter(Boolean)
-                  .join(': '),
-                sourceField: 'thought',
-              };
-              thinkingBlocksRef.current.push(thinkingBlock);
+              let thoughtText = [event.value.subject, event.value.description]
+                .filter(Boolean)
+                .join(': ');
+              const sanitized = sanitizeContent(thoughtText);
+              thoughtText = sanitized.blocked ? '' : sanitized.text;
+
+              if (thoughtText) {
+                const thinkingBlock: ThinkingBlock = {
+                  type: 'thinking',
+                  thought: thoughtText,
+                  sourceField: 'thought',
+                };
+                thinkingBlocksRef.current.push(thinkingBlock);
+              }
             }
             break;
           case ServerGeminiEventType.Content:
@@ -1057,6 +1063,7 @@ export const useGeminiStream = (
       handleMaxSessionTurnsEvent,
       handleContextWindowWillOverflowEvent,
       handleCitationEvent,
+      sanitizeContent,
     ],
   );
 


### PR DESCRIPTION
## TLDR

Applies EmojiFilter to thinking blocks (reasoning content) in both non-interactive CLI and interactive stream paths, which were previously bypassing emoji filtering entirely. When emojifilter is configured to auto/warn/error, thinking block text is now filtered consistently with regular content output.

closes #1126

## Dive Deeper

### Root Cause

EmojiFilter was already instantiated in both code paths:
- `nonInteractiveCli.ts` (line 194): `emojiFilter` created from ephemeral settings
- `useGeminiStream.ts` (line 187): `emojiFilter` created via `useMemo`, wrapped in `sanitizeContent` callback

However, when handling `GeminiEventType.Thought` events:
- **Non-interactive CLI** (line 293-316): Built `thoughtText` from subject+description and wrote `<think>` tags directly without filtering
- **Interactive stream** (line 945-960): Built ThinkingBlock with raw concatenated subject+description, never called `sanitizeContent`

### Fix

**`nonInteractiveCli.ts`**: After computing `thoughtText`, apply `emojiFilter.filterText()`. In error mode (blocked), `continue` to skip the thinking block. Otherwise, use the filtered text.

**`useGeminiStream.ts`**: Apply the existing `sanitizeContent` callback to thought text before creating ThinkingBlock. If blocked, set thought to empty string. Added `sanitizeContent` to the `useCallback` dependency array.

### Behavior by mode

| Mode | Behavior |
|------|----------|
| `allowed` | Emojis pass through unchanged |
| `auto` | Emojis silently converted/removed |
| `warn` | Emojis converted/removed (same as auto for thinking) |
| `error` | Thinking block suppressed entirely |

## Reviewer Test Plan

1. Run `npm run test` -- 3 new tests in `nonInteractiveCli.test.ts` cover all emoji filter modes for thinking blocks
2. To manually verify: configure `emojifilter: auto` in settings, use a model that produces thinking blocks with emojis, and confirm they are filtered in both interactive and non-interactive output

## Testing Matrix

|          |     |     |     |
| -------- | --- | --- | --- |
| npm run  |  Y  |  -  |  -  |
| npx      |  -  |  -  |  -  |
| Docker   |  -  |  -  |  -  |
| Podman   |  -  |  -  |  -  |
| Seatbelt |  -  |  -  |  -  |

## Linked issues / bugs

closes #1126