### PR TITLE
fix: make CLI build script cross-platform safe

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
     "llxprt": "dist/index.js"
   },
   "scripts": {
-    "build": "node ../../scripts/build_package.js && chmod 755 dist/index.js",
+    "build": "node ../../scripts/build_package.js && node ../../scripts/chmod_executable.js dist/index.js",
     "start": "node dist/index.js",
     "debug": "node --inspect-brk dist/index.js",
     "lint": "eslint . --ext .ts,.tsx",

--- a/scripts/chmod_executable.js
+++ b/scripts/chmod_executable.js
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { chmodSync } from 'fs';
+import { platform } from 'os';
+
+if (platform() === 'win32') {
+  process.exit(0);
+}
+
+const target = process.argv[2];
+if (!target) {
+  console.error('Usage: node chmod_executable.js <file>');
+  process.exit(1);
+}
+
+chmodSync(target, 0o755);


### PR DESCRIPTION
## TLDR

Replaces the bare \`chmod 755\` shell command in the CLI package build script with a cross-platform Node.js helper script that gracefully skips the chmod on Windows. closes #1201

## Dive Deeper

The CLI package.json build script contained:
\`\`\`
node ../../scripts/build_package.js && chmod 755 dist/index.js
\`\`\`

This fails on Windows because \`chmod\` is a Unix command. The fix introduces \`scripts/chmod_executable.js\` which:
- On Unix (macOS/Linux): calls \`fs.chmodSync(target, 0o755)\` to set executable permissions
- On Windows: exits immediately with success (no-op) since Windows doesn't use Unix file permissions

This pattern is already used elsewhere in the codebase (e.g. \`scripts/build_sandbox.js\`, \`esbuild.config.js\`).

## Reviewer Test Plan

1. On macOS/Linux: run \`npm run build\` and verify \`packages/cli/dist/index.js\` has 755 permissions
2. On Windows: run \`npm run build\` and verify it completes without error (previously would fail with 'chmod is not recognized')

## Testing Matrix

|          | Apple | Win | Linux |
| -------- | --- | --- | --- |
| npm run  | Yes | -  | -  |
| npx      | -  | -  | -  |
| Docker   | -  | -  | -  |
| Podman   | -  | -  | -  |
| Seatbelt | -  | -  | -  |

## Linked issues / bugs

closes #1201