### PR TITLE
feat: add configurable file-read-max-lines setting

### DIFF
--- a/packages/core/src/settings/__tests__/settingsRegistry.test.ts
+++ b/packages/core/src/settings/__tests__/settingsRegistry.test.ts
@@ -163,6 +163,32 @@ describe('getSettingHelp', () => {
 
     expect(help['shell-replacement']).not.toBe('');
   });
+
+  describe('file-read-max-lines setting', () => {
+    it('validates positive integer for file-read-max-lines', () => {
+      const result = validateSetting('file-read-max-lines', 3000);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects negative value for file-read-max-lines', () => {
+      const result = validateSetting('file-read-max-lines', -100);
+
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects non-integer value for file-read-max-lines', () => {
+      const result = validateSetting('file-read-max-lines', 100.5);
+
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects zero value for file-read-max-lines', () => {
+      const result = validateSetting('file-read-max-lines', 0);
+
+      expect(result.success).toBe(false);
+    });
+  });
 });
 
 describe('validateSetting', () => {

--- a/packages/core/src/settings/settingsRegistry.ts
+++ b/packages/core/src/settings/settingsRegistry.ts
@@ -341,6 +341,23 @@ export const SETTINGS_REGISTRY: readonly SettingSpec[] = [
     },
   },
   {
+    key: 'file-read-max-lines',
+    category: 'cli-behavior',
+    description:
+      'Default maximum lines to read from text files when no explicit limit is provided (default: 2000)',
+    type: 'number',
+    persistToProfile: true,
+    validate: (value: unknown): ValidationResult => {
+      if (typeof value === 'number' && Number.isInteger(value) && value > 0) {
+        return { success: true, value };
+      }
+      return {
+        success: false,
+        message: 'file-read-max-lines must be a positive integer',
+      };
+    },
+  },
+  {
     key: 'tool-output-max-tokens',
     category: 'cli-behavior',
     description: 'Maximum tokens in tool output',

--- a/packages/core/src/tools/__tests__/file-read-max-lines.test.ts
+++ b/packages/core/src/tools/__tests__/file-read-max-lines.test.ts
@@ -1,0 +1,229 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ReadFileTool } from '../read-file.js';
+import { ReadManyFilesTool } from '../read-many-files.js';
+import path from 'path';
+import os from 'os';
+import fs from 'fs';
+import fsp from 'fs/promises';
+import { Config } from '../../config/config.js';
+import { FileDiscoveryService } from '../../services/fileDiscoveryService.js';
+import { StandardFileSystemService } from '../../services/fileSystemService.js';
+import { createMockWorkspaceContext } from '../../test-utils/mockWorkspaceContext.js';
+import { WorkspaceContext } from '../../utils/workspaceContext.js';
+import {
+  COMMON_IGNORE_PATTERNS,
+  DEFAULT_FILE_EXCLUDES,
+} from '../../utils/ignorePatterns.js';
+
+describe('file-read-max-lines setting', () => {
+  let tempRootDir: string;
+  let readFileTool: ReadFileTool;
+  let readManyFilesTool: ReadManyFilesTool;
+  const abortSignal = new AbortController().signal;
+
+  beforeEach(async () => {
+    tempRootDir = await fsp.mkdtemp(
+      path.join(os.tmpdir(), 'file-read-max-lines-test-'),
+    );
+  });
+
+  afterEach(async () => {
+    if (fs.existsSync(tempRootDir)) {
+      await fsp.rm(tempRootDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('ReadFileTool', () => {
+    it('uses configured file-read-max-lines when no explicit limit is provided', async () => {
+      const testFile = path.join(tempRootDir, 'test.txt');
+      const lines = Array.from({ length: 100 }, (_, i) => `Line ${i + 1}`);
+      await fsp.writeFile(testFile, lines.join('\n'));
+
+      const mockConfigInstance = {
+        getFileService: () => new FileDiscoveryService(tempRootDir),
+        getFileSystemService: () => new StandardFileSystemService(),
+        getTargetDir: () => tempRootDir,
+        getWorkspaceContext: () => createMockWorkspaceContext(tempRootDir),
+        getConversationLoggingEnabled: () => false,
+        getEphemeralSettings: () => ({ 'file-read-max-lines': 50 }),
+      } as unknown as Config;
+
+      readFileTool = new ReadFileTool(mockConfigInstance);
+      const invocation = readFileTool.build({ absolute_path: testFile });
+
+      if (typeof invocation === 'string') {
+        throw new Error(`Unexpected validation error: ${invocation}`);
+      }
+
+      const result = await invocation.execute(abortSignal);
+      const content = String(result.llmContent);
+
+      expect(content).toContain('Line 1');
+      expect(content).toContain('Line 50');
+      expect(content).not.toContain('Line 51');
+    });
+
+    it('uses default value when file-read-max-lines is not configured', async () => {
+      const testFile = path.join(tempRootDir, 'test.txt');
+      const lines = Array.from({ length: 2100 }, (_, i) => `Line ${i + 1}`);
+      await fsp.writeFile(testFile, lines.join('\n'));
+
+      const mockConfigInstance = {
+        getFileService: () => new FileDiscoveryService(tempRootDir),
+        getFileSystemService: () => new StandardFileSystemService(),
+        getTargetDir: () => tempRootDir,
+        getWorkspaceContext: () => createMockWorkspaceContext(tempRootDir),
+        getConversationLoggingEnabled: () => false,
+        getEphemeralSettings: () => ({}),
+      } as unknown as Config;
+
+      readFileTool = new ReadFileTool(mockConfigInstance);
+      const invocation = readFileTool.build({ absolute_path: testFile });
+
+      if (typeof invocation === 'string') {
+        throw new Error(`Unexpected validation error: ${invocation}`);
+      }
+
+      const result = await invocation.execute(abortSignal);
+      const content = String(result.llmContent);
+
+      expect(content).toContain('Line 1');
+      expect(content).toContain('Line 2000');
+      expect(content).not.toContain('Line 2001');
+    });
+
+    it('respects explicit limit parameter over file-read-max-lines setting', async () => {
+      const testFile = path.join(tempRootDir, 'test.txt');
+      const lines = Array.from({ length: 100 }, (_, i) => `Line ${i + 1}`);
+      await fsp.writeFile(testFile, lines.join('\n'));
+
+      const mockConfigInstance = {
+        getFileService: () => new FileDiscoveryService(tempRootDir),
+        getFileSystemService: () => new StandardFileSystemService(),
+        getTargetDir: () => tempRootDir,
+        getWorkspaceContext: () => createMockWorkspaceContext(tempRootDir),
+        getConversationLoggingEnabled: () => false,
+        getEphemeralSettings: () => ({ 'file-read-max-lines': 50 }),
+      } as unknown as Config;
+
+      readFileTool = new ReadFileTool(mockConfigInstance);
+      const invocation = readFileTool.build({
+        absolute_path: testFile,
+        limit: 25,
+      });
+
+      if (typeof invocation === 'string') {
+        throw new Error(`Unexpected validation error: ${invocation}`);
+      }
+
+      const result = await invocation.execute(abortSignal);
+      const content = String(result.llmContent);
+
+      expect(content).toContain('Line 1');
+      expect(content).toContain('Line 25');
+      expect(content).not.toContain('Line 26');
+    });
+  });
+
+  describe('ReadManyFilesTool', () => {
+    it('uses configured file-read-max-lines for each file', async () => {
+      const testFile1 = path.join(tempRootDir, 'test1.txt');
+      const testFile2 = path.join(tempRootDir, 'test2.txt');
+      const lines = Array.from({ length: 100 }, (_, i) => `Line ${i + 1}`);
+      await fsp.writeFile(testFile1, lines.join('\n'));
+      await fsp.writeFile(testFile2, lines.join('\n'));
+
+      const fileService = new FileDiscoveryService(tempRootDir);
+      const mockConfig = {
+        getFileService: () => fileService,
+        getFileSystemService: () => new StandardFileSystemService(),
+        getEphemeralSettings: () => ({ 'file-read-max-lines': 30 }),
+        getFileFilteringOptions: () => ({
+          respectGitIgnore: true,
+          respectLlxprtIgnore: true,
+        }),
+        getTargetDir: () => tempRootDir,
+        getWorkspaceDirs: () => [tempRootDir],
+        getWorkspaceContext: () => new WorkspaceContext(tempRootDir),
+        getFileExclusions: () => ({
+          getCoreIgnorePatterns: () => COMMON_IGNORE_PATTERNS,
+          getDefaultExcludePatterns: () => DEFAULT_FILE_EXCLUDES,
+          getGlobExcludes: () => COMMON_IGNORE_PATTERNS,
+          buildExcludePatterns: () => DEFAULT_FILE_EXCLUDES,
+          getReadManyFilesExcludes: () => DEFAULT_FILE_EXCLUDES,
+        }),
+      } as Partial<Config> as Config;
+
+      readManyFilesTool = new ReadManyFilesTool(mockConfig);
+      const invocation = readManyFilesTool.build({
+        paths: ['*.txt'],
+      });
+
+      if (typeof invocation === 'string') {
+        throw new Error(`Unexpected validation error: ${invocation}`);
+      }
+
+      const result = await invocation.execute(abortSignal);
+      const contentParts = Array.isArray(result.llmContent)
+        ? result.llmContent
+        : [result.llmContent];
+      const content = contentParts.map(String).join('');
+
+      expect(content).toContain('Line 1');
+      expect(content).toContain('Line 30');
+      expect(content).not.toContain('Line 31');
+    });
+
+    it('uses default value when file-read-max-lines is not configured', async () => {
+      const testFile = path.join(tempRootDir, 'test.txt');
+      const lines = Array.from({ length: 2100 }, (_, i) => `Line ${i + 1}`);
+      await fsp.writeFile(testFile, lines.join('\n'));
+
+      const fileService = new FileDiscoveryService(tempRootDir);
+      const mockConfig = {
+        getFileService: () => fileService,
+        getFileSystemService: () => new StandardFileSystemService(),
+        getEphemeralSettings: () => ({}),
+        getFileFilteringOptions: () => ({
+          respectGitIgnore: true,
+          respectLlxprtIgnore: true,
+        }),
+        getTargetDir: () => tempRootDir,
+        getWorkspaceDirs: () => [tempRootDir],
+        getWorkspaceContext: () => new WorkspaceContext(tempRootDir),
+        getFileExclusions: () => ({
+          getCoreIgnorePatterns: () => COMMON_IGNORE_PATTERNS,
+          getDefaultExcludePatterns: () => DEFAULT_FILE_EXCLUDES,
+          getGlobExcludes: () => COMMON_IGNORE_PATTERNS,
+          buildExcludePatterns: () => DEFAULT_FILE_EXCLUDES,
+          getReadManyFilesExcludes: () => DEFAULT_FILE_EXCLUDES,
+        }),
+      } as Partial<Config> as Config;
+
+      readManyFilesTool = new ReadManyFilesTool(mockConfig);
+      const invocation = readManyFilesTool.build({
+        paths: ['*.txt'],
+      });
+
+      if (typeof invocation === 'string') {
+        throw new Error(`Unexpected validation error: ${invocation}`);
+      }
+
+      const result = await invocation.execute(abortSignal);
+      const contentParts = Array.isArray(result.llmContent)
+        ? result.llmContent
+        : [result.llmContent];
+      const content = contentParts.map(String).join('');
+
+      expect(content).toContain('Line 1');
+      expect(content).toContain('Line 2000');
+      expect(content).not.toContain('Line 2001');
+    });
+  });
+});

--- a/packages/core/src/tools/read-file.test.ts
+++ b/packages/core/src/tools/read-file.test.ts
@@ -41,6 +41,7 @@ describe('ReadFileTool', () => {
       getTargetDir: () => tempRootDir,
       getWorkspaceContext: () => createMockWorkspaceContext(tempRootDir),
       getConversationLoggingEnabled: () => false,
+      getEphemeralSettings: () => ({}),
     } as unknown as Config;
     tool = new ReadFileTool(mockConfigInstance);
   });

--- a/packages/core/src/tools/read-file.ts
+++ b/packages/core/src/tools/read-file.ts
@@ -20,6 +20,7 @@ import { type PartUnion } from '@google/genai';
 import {
   processSingleFileContent,
   getSpecificMimeType,
+  DEFAULT_MAX_LINES_TEXT_FILE,
 } from '../utils/fileUtils.js';
 import { Config } from '../config/config.js';
 import {
@@ -155,12 +156,18 @@ class ReadFileToolInvocation extends BaseToolInvocation<
   }
 
   async execute(): Promise<ToolResult> {
+    const ephemeralSettings = this.config.getEphemeralSettings();
+    const effectiveLimit =
+      this.params.limit ??
+      (ephemeralSettings['file-read-max-lines'] as number | undefined) ??
+      DEFAULT_MAX_LINES_TEXT_FILE;
+
     const result = await processSingleFileContent(
       this.getFilePath(),
       this.config.getTargetDir(),
       this.config.getFileSystemService(),
       this.params.offset,
-      this.params.limit,
+      effectiveLimit,
     );
 
     if (result.error) {

--- a/packages/core/src/tools/read-many-files.ts
+++ b/packages/core/src/tools/read-many-files.ts
@@ -21,6 +21,7 @@ import {
   processSingleFileContent,
   DEFAULT_ENCODING,
   getSpecificMimeType,
+  DEFAULT_MAX_LINES_TEXT_FILE,
 } from '../utils/fileUtils.js';
 import { type PartListUnion } from '@google/genai';
 import { Config, DEFAULT_FILE_FILTERING_OPTIONS } from '../config/config.js';
@@ -395,10 +396,17 @@ ${finalExclusionPatternsForDescription
       }
 
       // Use processSingleFileContent for all file types now
+      const ephemeralSettings = this.config.getEphemeralSettings();
+      const maxLinesPerFile =
+        (ephemeralSettings['file-read-max-lines'] as number | undefined) ??
+        DEFAULT_MAX_LINES_TEXT_FILE;
+
       const fileReadResult = await processSingleFileContent(
         filePath,
         this.config.getTargetDir(),
         this.config.getFileSystemService(),
+        undefined,
+        maxLinesPerFile,
       );
 
       if (fileReadResult.error) {

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -14,7 +14,7 @@ import { ToolErrorType } from '../tools/tool-error.js';
 import { BINARY_EXTENSIONS } from './ignorePatterns.js';
 
 // Constants for text file processing
-const DEFAULT_MAX_LINES_TEXT_FILE = 2000;
+export const DEFAULT_MAX_LINES_TEXT_FILE = 2000;
 const MAX_LINE_LENGTH_TEXT_FILE = 2000;
 
 // Default values for encoding and separator format


### PR DESCRIPTION
## Summary

Adds a new ephemeral setting \`file-read-max-lines\` that allows users to configure the default maximum lines to read from text files when no explicit limit parameter is provided. Previously this was hardcoded to 2000 lines.

Users can now adjust this via: \`/set file-read-max-lines <value>\`

## Problem

Issue #1173 reports that the default 2000-line limit for \`read_file\` often hides relevant content in large files. Users requested the ability to configure this default.

## Solution

This PR introduces a new ephemeral setting that:
- Is validated to accept only positive integers
- Persists to user profiles
- Has a priority order: explicit \`limit\` parameter > ephemeral setting > default (2000)
- Works consistently across both \`read_file\` and \`read_many_files\` tools

## Changes

| File | Change |
|------|--------|
| \`settingsRegistry.ts\` | Add \`file-read-max-lines\` setting spec with validation |
| \`fileUtils.ts\` | Export \`DEFAULT_MAX_LINES_TEXT_FILE\` constant |
| \`read-file.ts\` | Use ephemeral setting when no explicit limit provided |
| \`read-many-files.ts\` | Apply same configurable limit per file |
| \`file-read-max-lines.test.ts\` | New behavioral tests for the setting |
| \`settingsRegistry.test.ts\` | Validation tests for the setting |

## Testing

- Added 5 behavioral tests covering both tools with and without the setting configured
- Added 4 validation tests for the setting registry
- All existing tests continue to pass
- Manually verified with \`/set file-read-max-lines 5000\` and reading large files

## Usage

\`\`\`
/set file-read-max-lines 5000    # Set to 5000 lines
/set file-read-max-lines         # Show current value
\`\`\`

Fixes #1173