### PR TITLE
fix: retry on all 5xx server errors including 502 Bad Gateway

### DIFF
--- a/packages/core/src/providers/openai-vercel/OpenAIVercelProvider.shouldRetry.test.ts
+++ b/packages/core/src/providers/openai-vercel/OpenAIVercelProvider.shouldRetry.test.ts
@@ -1,0 +1,124 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { OpenAIVercelProvider } from './OpenAIVercelProvider.js';
+
+const mockSettingsService = vi.hoisted(() => ({
+  set: vi.fn(),
+  get: vi.fn(),
+  setProviderSetting: vi.fn(),
+  getProviderSettings: vi.fn().mockReturnValue({}),
+  getSettings: vi.fn(),
+  updateSettings: vi.fn(),
+  getAllGlobalSettings: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('../../settings/settingsServiceInstance.js', () => ({
+  getSettingsService: () => mockSettingsService,
+}));
+
+describe('OpenAIVercelProvider.shouldRetryResponse', () => {
+  let provider: OpenAIVercelProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSettingsService.getSettings.mockResolvedValue({});
+    provider = new OpenAIVercelProvider('test-key');
+  });
+
+  describe('should retry on all 5xx errors', () => {
+    it('should retry on 502 Bad Gateway', () => {
+      const error = { status: 502 };
+      const result = provider.shouldRetryResponse(error);
+      expect(result).toBe(true);
+    });
+
+    it('should retry on 500 Internal Server Error', () => {
+      const error = { status: 500 };
+      const result = provider.shouldRetryResponse(error);
+      expect(result).toBe(true);
+    });
+
+    it('should retry on 501 Not Implemented', () => {
+      const error = { status: 501 };
+      const result = provider.shouldRetryResponse(error);
+      expect(result).toBe(true);
+    });
+
+    it('should retry on 503 Service Unavailable', () => {
+      const error = { status: 503 };
+      const result = provider.shouldRetryResponse(error);
+      expect(result).toBe(true);
+    });
+
+    it('should retry on 504 Gateway Timeout', () => {
+      const error = { status: 504 };
+      const result = provider.shouldRetryResponse(error);
+      expect(result).toBe(true);
+    });
+
+    it('should retry on 599 (edge of 5xx range)', () => {
+      const error = { status: 599 };
+      const result = provider.shouldRetryResponse(error);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('should retry on 429 rate limit', () => {
+    it('should retry on 429 Too Many Requests', () => {
+      const error = { status: 429 };
+      const result = provider.shouldRetryResponse(error);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('should not retry on 4xx errors (except 429)', () => {
+    it('should not retry on 400 Bad Request', () => {
+      const error = { status: 400 };
+      const result = provider.shouldRetryResponse(error);
+      expect(result).toBe(false);
+    });
+
+    it('should not retry on 401 Unauthorized', () => {
+      const error = { status: 401 };
+      const result = provider.shouldRetryResponse(error);
+      expect(result).toBe(false);
+    });
+
+    it('should not retry on 404 Not Found', () => {
+      const error = { status: 404 };
+      const result = provider.shouldRetryResponse(error);
+      expect(result).toBe(false);
+    });
+
+    it('should not retry on 403 Forbidden', () => {
+      const error = { status: 403 };
+      const result = provider.shouldRetryResponse(error);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('should not retry on other status codes', () => {
+    it('should not retry on 200 OK', () => {
+      const error = { status: 200 };
+      const result = provider.shouldRetryResponse(error);
+      expect(result).toBe(false);
+    });
+
+    it('should not retry on 301 Moved Permanently', () => {
+      const error = { status: 301 };
+      const result = provider.shouldRetryResponse(error);
+      expect(result).toBe(false);
+    });
+
+    it('should not retry on 600 (outside 5xx range)', () => {
+      const error = { status: 600 };
+      const result = provider.shouldRetryResponse(error);
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/providers/openai-vercel/OpenAIVercelProvider.ts
+++ b/packages/core/src/providers/openai-vercel/OpenAIVercelProvider.ts
@@ -1940,7 +1940,7 @@ export class OpenAIVercelProvider extends BaseProvider implements IProvider {
     });
 
     const shouldRetry = Boolean(
-      status === 429 || status === 503 || status === 504,
+      status === 429 || (status !== undefined && status >= 500 && status < 600),
     );
 
     if (shouldRetry) {

--- a/packages/core/src/providers/openai/OpenAIProvider.shouldRetry.test.ts
+++ b/packages/core/src/providers/openai/OpenAIProvider.shouldRetry.test.ts
@@ -1,0 +1,124 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { OpenAIProvider } from './OpenAIProvider.js';
+
+const mockSettingsService = vi.hoisted(() => ({
+  set: vi.fn(),
+  get: vi.fn(),
+  setProviderSetting: vi.fn(),
+  getProviderSettings: vi.fn().mockReturnValue({}),
+  getSettings: vi.fn(),
+  updateSettings: vi.fn(),
+  getAllGlobalSettings: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('../../settings/settingsServiceInstance.js', () => ({
+  getSettingsService: () => mockSettingsService,
+}));
+
+describe('OpenAIProvider.shouldRetryResponse', () => {
+  let provider: OpenAIProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSettingsService.getSettings.mockResolvedValue({});
+    provider = new OpenAIProvider('test-key');
+  });
+
+  describe('should retry on all 5xx errors', () => {
+    it('should retry on 502 Bad Gateway', () => {
+      const error = { status: 502 };
+      const result = provider.shouldRetryResponse(error);
+      expect(result).toBe(true);
+    });
+
+    it('should retry on 500 Internal Server Error', () => {
+      const error = { status: 500 };
+      const result = provider.shouldRetryResponse(error);
+      expect(result).toBe(true);
+    });
+
+    it('should retry on 501 Not Implemented', () => {
+      const error = { status: 501 };
+      const result = provider.shouldRetryResponse(error);
+      expect(result).toBe(true);
+    });
+
+    it('should retry on 503 Service Unavailable', () => {
+      const error = { status: 503 };
+      const result = provider.shouldRetryResponse(error);
+      expect(result).toBe(true);
+    });
+
+    it('should retry on 504 Gateway Timeout', () => {
+      const error = { status: 504 };
+      const result = provider.shouldRetryResponse(error);
+      expect(result).toBe(true);
+    });
+
+    it('should retry on 599 (edge of 5xx range)', () => {
+      const error = { status: 599 };
+      const result = provider.shouldRetryResponse(error);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('should retry on 429 rate limit', () => {
+    it('should retry on 429 Too Many Requests', () => {
+      const error = { status: 429 };
+      const result = provider.shouldRetryResponse(error);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('should not retry on 4xx errors (except 429)', () => {
+    it('should not retry on 400 Bad Request', () => {
+      const error = { status: 400 };
+      const result = provider.shouldRetryResponse(error);
+      expect(result).toBe(false);
+    });
+
+    it('should not retry on 401 Unauthorized', () => {
+      const error = { status: 401 };
+      const result = provider.shouldRetryResponse(error);
+      expect(result).toBe(false);
+    });
+
+    it('should not retry on 404 Not Found', () => {
+      const error = { status: 404 };
+      const result = provider.shouldRetryResponse(error);
+      expect(result).toBe(false);
+    });
+
+    it('should not retry on 403 Forbidden', () => {
+      const error = { status: 403 };
+      const result = provider.shouldRetryResponse(error);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('should not retry on other status codes', () => {
+    it('should not retry on 200 OK', () => {
+      const error = { status: 200 };
+      const result = provider.shouldRetryResponse(error);
+      expect(result).toBe(false);
+    });
+
+    it('should not retry on 301 Moved Permanently', () => {
+      const error = { status: 301 };
+      const result = provider.shouldRetryResponse(error);
+      expect(result).toBe(false);
+    });
+
+    it('should not retry on 600 (outside 5xx range)', () => {
+      const error = { status: 600 };
+      const result = provider.shouldRetryResponse(error);
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/providers/openai/OpenAIProvider.ts
+++ b/packages/core/src/providers/openai/OpenAIProvider.ts
@@ -4783,7 +4783,7 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
 
     // Retry on 429 rate limit errors or 5xx server errors
     const shouldRetry = Boolean(
-      status === 429 || status === 503 || status === 504,
+      status === 429 || (status !== undefined && status >= 500 && status < 600),
     );
 
     if (!shouldRetry && isNetworkTransientError(error)) {


### PR DESCRIPTION
## Summary

Fixes #1180 - 502 Bad Gateway errors were not triggering retry/backoff in OpenAIProvider and OpenAIVercelProvider.

## Problem

The `shouldRetryResponse` method in both OpenAIProvider and OpenAIVercelProvider had overly restrictive retry logic:

```typescript
// Comment said: Retry on 429 rate limit errors or 5xx server errors
const shouldRetry = Boolean(
  status === 429 || status === 503 || status === 504,  // But only checked 503 and 504!
);
```

This excluded 502 Bad Gateway, 500 Internal Server Error, 501 Not Implemented, and other 5xx errors from retry logic.

## Solution

Changed the retry condition to match the full 5xx range, consistent with other providers:

```typescript
const shouldRetry = Boolean(
  status === 429 || (status !== undefined && status >= 500 && status < 600),
);
```

## Consistency

This change aligns OpenAIProvider and OpenAIVercelProvider with the retry behavior of:
- `utils/retry.ts` (defaultShouldRetry)
- AnthropicProvider
- GeminiProvider  
- OpenAIResponsesProvider
- LoadBalancingProvider

All of these correctly handle the full 5xx range.

## Testing

Added comprehensive test suites for both providers:
- `OpenAIProvider.shouldRetry.test.ts` (14 tests)
- `OpenAIVercelProvider.shouldRetry.test.ts` (14 tests)

Tests verify:
- All 5xx errors trigger retry (500, 501, 502, 503, 504, 599)
- 429 rate limit triggers retry (regression test)
- 4xx errors (except 429) do NOT trigger retry
- Other status codes do NOT trigger retry

## Verification

All checks pass:
- npm run test (all 3210+ tests pass)
- npm run lint
- npm run typecheck
- npm run format
- npm run build
- Smoke test with haiku prompt

## Files Changed

**Modified:**
- `packages/core/src/providers/openai/OpenAIProvider.ts`
- `packages/core/src/providers/openai-vercel/OpenAIVercelProvider.ts`

**Added:**
- `packages/core/src/providers/openai/OpenAIProvider.shouldRetry.test.ts`
- `packages/core/src/providers/openai-vercel/OpenAIVercelProvider.shouldRetry.test.ts`