### PR TITLE
fix(cli): error when explicit --profile-load fails instead of silently falling back

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -899,6 +899,11 @@ export async function loadCliConfig(
             )
           : undefined));
 
+  // Track whether profile was explicitly specified via --profile-load
+  const profileExplicitlySpecified =
+    bootstrapArgs.profileName != null &&
+    normaliseProfileName(bootstrapArgs.profileName) != null;
+
   if (profileToLoad) {
     try {
       const profileManager = new ProfileManager();
@@ -944,6 +949,13 @@ export async function loadCliConfig(
         return failureSummary;
       });
       console.error(failureSummary);
+
+      // If profile was explicitly specified via --profile-load, error out
+      if (profileExplicitlySpecified) {
+        throw error;
+      }
+
+      // Otherwise, warn and continue (profile from env var or default setting)
       profileWarnings.push(failureSummary);
       // Continue without the profile settings
     }

--- a/packages/cli/src/integration-tests/cli-args.integration.test.ts
+++ b/packages/cli/src/integration-tests/cli-args.integration.test.ts
@@ -147,7 +147,7 @@ describe('CLI --profile-load Integration Tests', () => {
       expect(fullOutput).toMatch(/gemini|provider.*gemini/i);
     });
 
-    it('should handle non-existent profile gracefully', async () => {
+    it('should error when non-existent profile is explicitly specified', async () => {
       // Create a keyfile so it doesn't hang on auth
       const keyfilePath = await createTempKeyfile(tempDir, 'test-key');
 
@@ -166,16 +166,16 @@ describe('CLI --profile-load Integration Tests', () => {
         },
       );
 
-      // Should log error but continue
+      // Should log error and exit with non-zero code
       const fullOutput = result.stdout + result.stderr;
       expect(fullOutput).toMatch(
         /Failed to load profile.*non-existent-profile|Profile.*non-existent-profile.*not found/i,
       );
-      // Should not crash with timeout
-      expect(result.exitCode).not.toBe(-1);
+      // Should exit with error code 1 when profile fails to load
+      expect(result.exitCode).toBe(1);
     });
 
-    it('should handle invalid profile format', async () => {
+    it('should error when invalid profile format is explicitly specified', async () => {
       // Create an invalid profile file
       const profilesDir = path.join(tempDir, '.llxprt', 'profiles');
       await fs.mkdir(profilesDir, { recursive: true });
@@ -196,6 +196,8 @@ describe('CLI --profile-load Integration Tests', () => {
       expect(fullOutput).toMatch(
         /Failed to load profile.*invalid-profile|Profile.*invalid-profile.*corrupted/i,
       );
+      // Should exit with error code 1 when profile is corrupted
+      expect(result.exitCode).toBe(1);
     });
   });
 


### PR DESCRIPTION
## Summary

When a user explicitly specifies `--profile-load` with a missing or corrupted profile, the CLI now errors with exit code 1 instead of logging a warning and continuing with the default provider. This prevents silent failures that could lead to unexpected behavior.

## Changes

- Track whether profile was explicitly specified via `--profile-load` flag
- Throw error when explicit profile load fails (missing file or invalid JSON)
- Preserve existing behavior for env var/default profile (warn and continue)
- Update integration tests to expect exit code 1 for explicit failures

## Testing

- Modified integration tests pass (except pre-existing failures unrelated to this change)
- All unit tests pass
- Lint, typecheck, format, and build all pass
- Smoke test with synthetic profile successful

Fixes #1205