### PR TITLE
fix(gemini): ensure default provider activation on startup

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -709,6 +709,21 @@ export async function main() {
       console.error(chalk.red((e as Error).message));
       process.exit(1);
     }
+  } else {
+    // No explicit provider specified - ensure default provider (gemini) is activated
+    // This calls refreshAuth() which initializes contentGeneratorConfig
+    // Without this, sending messages fails with "Content generator config not initialized"
+    try {
+      const defaultProvider =
+        providerManager.getActiveProviderName() || 'gemini';
+      await switchActiveProvider(defaultProvider);
+    } catch (e) {
+      // Log but don't exit - auth will be triggered lazily on first API call
+      const logger = new DebugLogger('llxprt:gemini');
+      logger.debug(
+        () => `Default provider activation skipped: ${(e as Error).message}`,
+      );
+    }
   }
 
   if (settings.merged.ui?.theme) {


### PR DESCRIPTION
## Summary

Fixes #1268 - Gemini provider was broken when starting without an explicit `--provider` flag.

## Problem

When launching the CLI without specifying a provider, the gemini provider was not being properly activated. This left `contentGeneratorConfig` uninitialized, causing the error:

```
Content generator config not initialized. Call config.refreshAuth() first.
```

Additionally, when switching from a different provider to gemini, the model was incorrectly defaulting to `gemini-2.0-flash` instead of `gemini-2.5-pro`.

## Root Cause

In `gemini.tsx`, the provider activation code only ran when `configProvider` was explicitly set (via `--provider` flag). When no provider was specified:
1. The `if (configProvider)` block was skipped
2. No call to `switchActiveProvider()` was made
3. Therefore no `refreshAuth()` was called
4. `contentGeneratorConfig` remained undefined

## Solution

Added an `else` branch that activates the default provider (gemini) when no explicit provider is specified:

```typescript
} else {
  // No explicit provider specified - ensure default provider (gemini) is activated
  // This calls refreshAuth() which initializes contentGeneratorConfig
  try {
    const defaultProvider = providerManager.getActiveProviderName() || 'gemini';
    await switchActiveProvider(defaultProvider);
  } catch (e) {
    // Log but don't exit - auth will be triggered lazily on first API call
    const logger = new DebugLogger('llxprt:gemini');
    logger.debug(() => \`Default provider activation skipped: ${(e as Error).message}\`);
  }
}
```

This ensures:
1. The default provider (gemini) is activated via `switchActiveProvider()`
2. `refreshAuth()` is called which initializes `contentGeneratorConfig`
3. GeminiProvider's `determineBestAuth()` handles auth detection internally
4. The correct default model (`gemini-2.5-pro`) is set via `getDefaultModel()`

## Testing

- All unit tests pass (3334 tests)
- Typecheck passes
- Lint passes
- Build completes successfully
- Haiku test passes with synthetic profile
