### PR TITLE
fix: update mouse selection on release and add Cmd+C/Ctrl+C keyboard shortcut (#1284)

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -1924,7 +1924,27 @@ export const AppContainer = (props: AppContainerProps) => {
   const pendingHistoryItemRef = useRef<DOMElement>(null);
   const rootUiRef = useRef<DOMElement>(null);
 
-  useMouseSelection({ enabled: true, rootRef: rootUiRef });
+  const { copySelectionToClipboard } = useMouseSelection({
+    enabled: true,
+    rootRef: rootUiRef,
+    onCopiedText: (text) => {
+      if (selectionLogger.enabled) {
+        selectionLogger.debug(
+          () => `Copied ${text.length} characters to clipboard`,
+        );
+      }
+    },
+  });
+
+  // Fix for issue #1284: Add keyboard shortcut for Cmd+C/Ctrl+C to copy selection
+  useKeypress(
+    (key) => {
+      if (key.name === 'c' && (key.ctrl || key.meta)) {
+        void copySelectionToClipboard();
+      }
+    },
+    { isActive: true },
+  );
 
   useLayoutEffect(() => {
     if (mainControlsRef.current) {

--- a/packages/cli/src/ui/hooks/useMouseSelection.ts
+++ b/packages/cli/src/ui/hooks/useMouseSelection.ts
@@ -296,6 +296,13 @@ export function useMouseSelection({
 
       if (event.name === 'left-release') {
         if (!isDraggingRef.current) return;
+        const anchor = anchorPointRef.current;
+        if (anchor) {
+          const releasePoint = resolveSelectionPoint(event);
+          if (releasePoint) {
+            updateSelectionRange(anchor, releasePoint);
+          }
+        }
         isDraggingRef.current = false;
         void copySelectionToClipboard();
       }
@@ -311,5 +318,5 @@ export function useMouseSelection({
 
   useMouse(mouseHandler, { isActive: enabled });
 
-  return { clearSelection };
+  return { clearSelection, copySelectionToClipboard };
 }


### PR DESCRIPTION
Fixes #1284

The mouse selection copy feature was unreliable, often requiring multiple
attempts before the selected text was actually copied to the clipboard.

## Root causes

1. The final mouse release position was never captured in the selection.
   The selection ended at the last move event coordinate, which often
   happened slightly before/after the actual release point due to mouse
   event sampling rates.

2. No keyboard shortcut for Cmd+C/Ctrl+C to copy the current selection.

## Changes

- Update selection range on mouse left-release event to capture the
  final release position before copying
- Export copySelectionToClipboard function from useMouseSelection hook
- Add useKeypress handler for Cmd+C/Ctrl+C to trigger copy operation
- Add onCopiedText callback to provide debug feedback when text is copied

## This ensures

- Mouse selection copy works on the first attempt
- Users can copy with Cmd+C (Mac) or Ctrl+C (Linux/Windows) keyboard shortcut
- Debug logging shows when copies succeed