### PR TITLE
fix(cli): preserve thinking ownership/order across split assistant segments

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.thinking.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.thinking.test.tsx
@@ -992,4 +992,229 @@ describe('useGeminiStream - ThinkingBlock Integration', () => {
     );
     expect(historyItem.thinkingBlocks![1].thought).toContain('Subject only');
   });
+
+  describe('Ordering contract: thinking ownership on content split (#1272)', () => {
+    it('should attach thinkingBlocks only to the first committed gemini item, not gemini_content', async () => {
+      // Override findLastSafeSplitPoint to force a split: split at first chunk boundary
+      const { findLastSafeSplitPoint } = await import(
+        '../utils/markdownUtilities.js'
+      );
+      const mockedSplitPoint = vi.mocked(findLastSafeSplitPoint);
+
+      // First call returns a split point (half the combined text), subsequent calls return full length
+      let callCount = 0;
+      mockedSplitPoint.mockImplementation((s: string) => {
+        callCount++;
+        // On the first content event, force a split mid-string
+        if (callCount === 1 && s.length > 5) {
+          return 5;
+        }
+        return s.length;
+      });
+
+      mockSendMessageStream.mockReturnValue(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.Thought,
+            value: {
+              subject: 'Analyzing',
+              description: 'the problem',
+            },
+          };
+          yield {
+            type: ServerGeminiEventType.Content,
+            value: 'Hello world, this is a long response',
+          };
+          yield {
+            type: ServerGeminiEventType.Finished,
+            value: { reason: FinishReason.STOP },
+          };
+        })(),
+      );
+
+      const { result } = renderTestHook();
+
+      await act(async () => {
+        await result.current.submitQuery('test query');
+      });
+
+      await waitFor(() => {
+        const geminiCalls = mockAddItem.mock.calls.filter(
+          (call) =>
+            call[0].type === MessageType.GEMINI ||
+            call[0].type === 'gemini_content',
+        );
+        expect(geminiCalls.length).toBeGreaterThanOrEqual(2);
+      });
+
+      const committedGeminiItems = mockAddItem.mock.calls
+        .filter(
+          (call) =>
+            call[0].type === MessageType.GEMINI ||
+            call[0].type === 'gemini_content',
+        )
+        .map((call) => call[0] as HistoryItemGemini);
+
+      // First committed item (type: 'gemini') should own thinkingBlocks
+      const firstItem = committedGeminiItems[0];
+      expect(firstItem.type).toBe('gemini');
+      expect(firstItem.thinkingBlocks).toBeDefined();
+      expect(firstItem.thinkingBlocks!.length).toBeGreaterThan(0);
+      expect(firstItem.thinkingBlocks![0].sourceField).toBe('thought');
+
+      // Subsequent gemini_content items should NOT have thinkingBlocks
+      for (let i = 1; i < committedGeminiItems.length; i++) {
+        const item = committedGeminiItems[i];
+        const hasThinking =
+          item.thinkingBlocks && item.thinkingBlocks.length > 0;
+        expect(hasThinking).toBeFalsy();
+      }
+
+      // Restore mock
+      mockedSplitPoint.mockImplementation((s: string) => s.length);
+    });
+
+    it('should not duplicate thinkingBlocks across multiple committed content segments', async () => {
+      const { findLastSafeSplitPoint } = await import(
+        '../utils/markdownUtilities.js'
+      );
+      const mockedSplitPoint = vi.mocked(findLastSafeSplitPoint);
+
+      // Force a split on every call to generate multiple committed segments
+      mockedSplitPoint.mockImplementation((s: string) => {
+        if (s.length > 10) {
+          return 10;
+        }
+        return s.length;
+      });
+
+      mockSendMessageStream.mockReturnValue(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.Thought,
+            value: {
+              subject: 'Deep thinking',
+              description: 'about the problem',
+            },
+          };
+          // Send enough content to trigger multiple splits
+          yield {
+            type: ServerGeminiEventType.Content,
+            value: 'First segment of content that is long enough. ',
+          };
+          yield {
+            type: ServerGeminiEventType.Content,
+            value: 'Second segment of content that continues. ',
+          };
+          yield {
+            type: ServerGeminiEventType.Finished,
+            value: { reason: FinishReason.STOP },
+          };
+        })(),
+      );
+
+      const { result } = renderTestHook();
+
+      await act(async () => {
+        await result.current.submitQuery('test query');
+      });
+
+      await waitFor(() => {
+        const allGeminiCalls = mockAddItem.mock.calls.filter(
+          (call) =>
+            call[0].type === MessageType.GEMINI ||
+            call[0].type === 'gemini_content',
+        );
+        expect(allGeminiCalls.length).toBeGreaterThanOrEqual(2);
+      });
+
+      const committedItems = mockAddItem.mock.calls
+        .filter(
+          (call) =>
+            call[0].type === MessageType.GEMINI ||
+            call[0].type === 'gemini_content',
+        )
+        .map((call) => call[0] as HistoryItemGemini);
+
+      // Count how many items have thinkingBlocks
+      const itemsWithThinking = committedItems.filter(
+        (item) => item.thinkingBlocks && item.thinkingBlocks.length > 0,
+      );
+
+      // Exactly one item should own thinkingBlocks
+      expect(itemsWithThinking).toHaveLength(1);
+      expect(itemsWithThinking[0].type).toBe('gemini');
+
+      // Restore mock
+      mockedSplitPoint.mockImplementation((s: string) => s.length);
+    });
+
+    it('should maintain thinking-above-content ordering on the first committed gemini item', async () => {
+      const { findLastSafeSplitPoint } = await import(
+        '../utils/markdownUtilities.js'
+      );
+      const mockedSplitPoint = vi.mocked(findLastSafeSplitPoint);
+
+      mockedSplitPoint.mockImplementation((s: string) => {
+        if (s.length > 8) {
+          return 8;
+        }
+        return s.length;
+      });
+
+      mockSendMessageStream.mockReturnValue(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.Thought,
+            value: {
+              subject: 'Planning',
+              description: 'the response',
+            },
+          };
+          yield {
+            type: ServerGeminiEventType.Content,
+            value: 'Here is the detailed response text',
+          };
+          yield {
+            type: ServerGeminiEventType.Finished,
+            value: { reason: FinishReason.STOP },
+          };
+        })(),
+      );
+
+      const { result } = renderTestHook();
+
+      await act(async () => {
+        await result.current.submitQuery('test query');
+      });
+
+      await waitFor(() => {
+        const geminiCalls = mockAddItem.mock.calls.filter(
+          (call) =>
+            call[0].type === MessageType.GEMINI ||
+            call[0].type === 'gemini_content',
+        );
+        expect(geminiCalls.length).toBeGreaterThanOrEqual(1);
+      });
+
+      const allCommitted = mockAddItem.mock.calls
+        .filter(
+          (call) =>
+            call[0].type === MessageType.GEMINI ||
+            call[0].type === 'gemini_content',
+        )
+        .map((call) => call[0] as HistoryItemGemini);
+
+      // The first committed item must be 'gemini' type with thinking
+      const first = allCommitted[0];
+      expect(first.type).toBe('gemini');
+      expect(first.thinkingBlocks).toBeDefined();
+      expect(first.thinkingBlocks!.length).toBe(1);
+      expect(first.thinkingBlocks![0].thought).toBe('Planning: the response');
+      expect(first.text.length).toBeGreaterThan(0);
+
+      // Restore mock
+      mockedSplitPoint.mockImplementation((s: string) => s.length);
+    });
+  });
 });

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -767,16 +767,15 @@ export const useGeminiStream = (
           },
           userMessageTimestamp,
         );
+
+        // Clear thinking blocks after committing to prevent duplication
+        // on subsequent gemini_content items (#1272)
+        thinkingBlocksRef.current = [];
       }
 
-      // @plan:PLAN-20251202-THINKING-UI.P08
-      // Preserve thinkingBlocks in continuation pending item
       setPendingHistoryItem({
         type: 'gemini_content',
         text: afterText,
-        ...(thinkingBlocksRef.current.length > 0
-          ? { thinkingBlocks: [...thinkingBlocksRef.current] }
-          : {}),
       });
       return afterText;
     },

--- a/project-plans/issue1272redeux/plan.md
+++ b/project-plans/issue1272redeux/plan.md
@@ -1,0 +1,104 @@
+# Issue #1272 (Redeux) — Minimal Ordering-Only Remediation Plan
+
+## Goal
+
+Implement a minimal, TDD-first fix for #1272 that corrects thinking/content ordering in CLI display/history assembly **without** introducing real-time thinking streaming and **without** global thinking text normalization.
+
+## Scope Constraints (Must Keep)
+
+1. Keep main-style thinking model in UI hook:
+   - `thinkingBlocksRef` array in `useGeminiStream`
+   - thought text derived from `subject/description`
+   - `sourceField: 'thought'`
+2. Keep `GeminiMessage` pending behavior:
+   - thinking hidden while pending (`showThinking && !isPending`)
+3. Do **not** change provider streaming semantics for this task.
+4. Do **not** add `normalizeThinkingText`-style flattening to interactive UI path.
+5. Limit changes to CLI stream assembly path (primarily `useGeminiStream` and tests).
+
+## Problem Hypothesis
+
+Ordering regressions happen at pending/commit boundaries when content chunks are split into `gemini` and `gemini_content` items while thinking blocks are repeatedly attached to both pending and committed items. The minimal fix should ensure deterministic commit order and avoid duplicate/misaligned thinking attachment.
+
+## Target Ordering Contract
+
+For each assistant turn in interactive CLI history:
+
+1. Exactly one committed `gemini` item should carry that turn’s `thinkingBlocks` (if any thought events occurred).
+2. Any overflow continuation `gemini_content` items for the same turn should **not** duplicate `thinkingBlocks`.
+3. The visible display order must remain:
+   - thinking (rendered by `GeminiMessage` on committed item)
+   - then assistant text content for that same committed sequence.
+4. Pending UI remains unchanged (no live thinking body rendering in pending message).
+
+## TDD Plan
+
+### Step 1 — Add failing tests first
+
+Primary test file:
+- `packages/cli/src/ui/hooks/useGeminiStream.thinking.test.tsx`
+
+Add/adjust tests to assert:
+
+1. **Single-owner thinking blocks**
+   - When content splits into `gemini` + `gemini_content`, only first committed `gemini` has `thinkingBlocks`.
+   - `gemini_content` entries have no `thinkingBlocks`.
+
+2. **No duplicate thinking on multiple content flushes**
+   - With multiple content chunks causing multiple commits, thinking is not repeated on each committed segment.
+
+3. **Stable ordering with thought-before-content stream sequence**
+   - Thought event(s) then content yields final history where thinking is attached to first committed assistant item, followed by content continuation items.
+
+4. **Preserve source metadata**
+   - `sourceField` remains `'thought'`.
+
+### Step 2 — Minimal implementation to satisfy tests
+
+Primary implementation file:
+- `packages/cli/src/ui/hooks/useGeminiStream.ts`
+
+Expected minimal approach:
+
+- Introduce turn-local consumption semantics for thinking blocks so they are committed once per assistant turn.
+- Ensure `beforeText` commit path and flush path share the same "first committed gemini item owns thinking" rule.
+- Ensure continuation (`gemini_content`) updates do not reattach thinking blocks after first committed ownership is established.
+- Keep all other behavior intact (sanitization, pending updates, tool flow, cancellation behavior).
+
+### Step 3 — Run focused tests
+
+Run at minimum:
+
+- `npm run test -- packages/cli/src/ui/hooks/useGeminiStream.thinking.test.tsx`
+- Any directly impacted sibling tests if needed:
+  - `packages/cli/src/ui/hooks/useGeminiStream.test.tsx`
+  - `packages/cli/src/ui/components/messages/GeminiMessage.test.tsx`
+
+### Step 4 — Full verification cycle
+
+From project root, run:
+
+1. `npm run test`
+2. `npm run lint`
+3. `npm run typecheck`
+4. `npm run format`
+5. `npm run build`
+6. `node scripts/start.js --profile-load synthetic --keyfile ~/.llxprt/keys/.synthetic2_key "write me a haiku and nothing else"`
+
+## Non-Goals
+
+- No provider-side incremental reasoning emission changes.
+- No replacement of `thinkingBlocksRef` with text buffers.
+- No display normalization pipeline (`thinkingTextJoiner`) in interactive UI.
+
+## Risk Notes
+
+- `useGeminiStream` has many responsibilities; keep edits narrowly scoped to thinking block attachment logic.
+- Avoid regressions in cancellation and queued submission behavior by not touching unrelated branches.
+
+## Acceptance Criteria
+
+1. New ordering tests fail before implementation and pass after.
+2. Existing behavior constraints remain unchanged (no live thinking body while pending).
+3. Thinking appears once, in-order, on committed assistant history display.
+4. Full verification suite passes.


### PR DESCRIPTION
## TLDR

This PR applies a minimal, ordering-only fix for the #1272 UX problem in interactive CLI history assembly.

What changed:
- Ensures thinkingBlocks are owned by exactly one committed assistant item (the first gemini segment) when content is split.
- Prevents thinkingBlocks duplication across gemini_content continuation items.
- Keeps current main behavior intact:
  - no live/realtime thinking-body streaming
  - no global thinking-text normalization rewrite
  - same source metadata shape (sourceField remains thought)

Why:
- The user-visible problem was that thinking/content association could look incorrect when response text split into multiple committed segments.

## Dive Deeper

Root cause in useGeminiStream:
- In split-content flows, thinking blocks were repeatedly carried into continuation paths, which could duplicate thinking across committed segments and make ordering feel wrong.

Implementation details:
- In the split path, after committing the first gemini segment (which includes thinking), clear thinkingBlocksRef ownership for the turn continuation.
- Do not attach thinkingBlocks to gemini_content pending continuation items.

This preserves existing design constraints:
- Thinking still displays only on committed GeminiMessage (not pending), matching current UI behavior.
- No provider-side streaming semantics changed in this PR.

## Reviewer Test Plan

Targeted automated tests added first (TDD) and then fixed:

1) Run focused thinking-ordering suite:
   npm run test -- src/ui/hooks/useGeminiStream.thinking.test.tsx

2) Run adjacent regression suite:
   npm run test -- src/ui/hooks/useGeminiStream.dedup.test.tsx

3) Optional manual validation in interactive CLI:
   - Use a prompt that triggers thought events plus a long response so content splits.
   - Confirm only the first committed gemini message contains thinking blocks.
   - Confirm gemini_content continuation rows do not repeat thinking blocks.

Additional verification run in this branch:
- npm run lint
- npm run format
- npm run build
- node scripts/start.js --profile-load synthetic --keyfile ~/.llxprt/keys/.synthetic2_key "write me a haiku and nothing else"

Note on repo baseline:
- Full workspace npm run test and npm run typecheck currently report unrelated pre-existing failures outside this change area; this PR is scoped to CLI ordering behavior only.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Closes #1272 in effect for the reported ordering problem (thinking/content association in committed output).

Important nuance:
- This PR does not implement true live thinking streaming; it addresses the ordering symptom and duplicate-thinking behavior in CLI history/display assembly.
