### PR TITLE
fix: remove --prompt/-p deprecation warning

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -1086,17 +1086,12 @@ export async function main() {
     settings,
   );
 
-  const hasDeprecatedPromptArg = process.argv.some((arg) =>
-    arg.startsWith('--prompt'),
-  );
-
   try {
     await runNonInteractive({
       config: nonInteractiveConfig,
       settings,
       input,
       prompt_id,
-      hasDeprecatedPromptArg,
     });
   } catch (error) {
     if (nonInteractiveConfig.getOutputFormat() === OutputFormat.JSON) {

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -45,7 +45,6 @@ interface RunNonInteractiveParams {
   settings: LoadedSettings;
   input: string;
   prompt_id: string;
-  hasDeprecatedPromptArg?: boolean;
 }
 
 export async function runNonInteractive({
@@ -53,7 +52,6 @@ export async function runNonInteractive({
   settings,
   input,
   prompt_id,
-  hasDeprecatedPromptArg,
 }: RunNonInteractiveParams): Promise<void> {
   const outputFormat =
     typeof config.getOutputFormat === 'function'
@@ -413,21 +411,6 @@ export async function runNonInteractive({
     let jsonResponseText = '';
 
     let turnCount = 0;
-    const deprecateText =
-      'The --prompt (-p) flag has been deprecated and will be removed in a future version. Please use a positional argument for your prompt. See gemini --help for more information.\n';
-    if (hasDeprecatedPromptArg) {
-      if (streamFormatter) {
-        streamFormatter.emitEvent({
-          type: JsonStreamEventType.MESSAGE,
-          timestamp: new Date().toISOString(),
-          role: 'assistant',
-          content: deprecateText,
-          delta: true,
-        });
-      } else {
-        process.stderr.write(deprecateText);
-      }
-    }
     while (true) {
       turnCount++;
       if (


### PR DESCRIPTION
## Summary

Removes the deprecation warning displayed when using the `--prompt` (`-p`) CLI flag in non-interactive mode.

## Problem

The deprecation warning had two issues (see #1327):

1. **The flag will not be removed** - Due to sandboxing plans, the `--prompt`/`-p` flag needs to stay. The warning falsely promised removal in a future version.
2. **Incorrect help reference** - The warning said "See gemini --help" which is wrong for LLxprt Code.

## Changes

**packages/cli/src/nonInteractiveCli.ts**
- Removed `hasDeprecatedPromptArg` from the `RunNonInteractiveParams` interface and function signature
- Removed the deprecation warning display logic (both stderr and stream-json paths)

**packages/cli/src/gemini.tsx**
- Removed the `hasDeprecatedPromptArg` detection from `process.argv`
- Removed passing `hasDeprecatedPromptArg` to `runNonInteractive()`

**packages/cli/src/nonInteractiveCli.test.ts**
- Removed two test cases that verified the deprecation warning behavior
- Cleaned up unused `OutputFormat` import and `processStderrSpy` variable

## What is NOT changed

The `--prompt`/`-p` flag itself continues to work exactly as before - only the warning message is removed.

## Verification

- All tests pass (npm run test)
- Lint clean (npm run lint)
- Build succeeds (npm run build)
- Smoke test passes (node scripts/start.js --profile-load synthetic "write me a haiku")

Fixes #1327