### PR TITLE
feat: add ast_grep and structural_analysis tools

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -23,6 +23,9 @@ import { EditTool } from '../tools/edit.js';
 import { ShellTool } from '../tools/shell.js';
 import { ASTEditTool } from '../tools/ast-edit.js';
 import { ASTReadFileTool } from '../tools/ast-edit.js';
+// @plan PLAN-20260211-ASTGREP.P05
+import { AstGrepTool } from '../tools/ast-grep.js';
+import { StructuralAnalysisTool } from '../tools/structural-analysis.js';
 import { WriteFileTool } from '../tools/write-file.js';
 import { GoogleWebFetchTool } from '../tools/google-web-fetch.js';
 import { ReadManyFilesTool } from '../tools/read-many-files.js';
@@ -2073,6 +2076,9 @@ export class Config {
     registerCoreTool(ReadManyFilesTool, this);
     registerCoreTool(ReadLineRangeTool, this);
     registerCoreTool(ASTReadFileTool, this);
+    // @plan PLAN-20260211-ASTGREP.P05
+    registerCoreTool(AstGrepTool, this);
+    registerCoreTool(StructuralAnalysisTool, this);
     registerCoreTool(DeleteLineRangeTool, this);
     registerCoreTool(InsertAtLineTool, this);
     registerCoreTool(ShellTool, this);

--- a/packages/core/src/tools/ast-edit.ts
+++ b/packages/core/src/tools/ast-edit.ts
@@ -40,66 +40,17 @@ import { DebugLogger } from '../debug/index.js';
 import type { AnsiOutput } from '../utils/terminalSerializer.js';
 
 const logger = new DebugLogger('llxprt:tools:ast-edit');
+// @plan PLAN-20260211-ASTGREP.P03
+import { parse, Lang, findInFiles } from '@ast-grep/napi';
+// Shared language mapping and utilities — single source of truth
+export {
+  LANGUAGE_MAP,
+  JAVASCRIPT_FAMILY_EXTENSIONS,
+} from '../utils/ast-grep-utils.js';
 import {
-  parse,
-  Lang,
-  findInFiles,
-  registerDynamicLanguage,
-} from '@ast-grep/napi';
-
-import python from '@ast-grep/lang-python';
-import go from '@ast-grep/lang-go';
-import rust from '@ast-grep/lang-rust';
-import java from '@ast-grep/lang-java';
-import cpp from '@ast-grep/lang-cpp';
-import c from '@ast-grep/lang-c';
-import json from '@ast-grep/lang-json';
-import ruby from '@ast-grep/lang-ruby';
-
-registerDynamicLanguage({
-  python,
-  go,
-  rust,
-  java,
-  cpp,
-  c,
-  json,
-  ruby,
-} as any); // eslint-disable-line @typescript-eslint/no-explicit-any -- Required for ast-grep dynamic language registration (third-party API limitation)
-
-// ===== Shared Language Mapping =====
-/**
- * Shared language mapping for file extensions to AST language types.
- * This is the single source of truth for language mapping across all tools.
- * Must be kept in sync with ast-grep's supported languages.
- */
-export const LANGUAGE_MAP: Record<string, string | Lang> = {
-  ts: Lang.TypeScript,
-  js: Lang.JavaScript,
-  tsx: Lang.Tsx,
-  jsx: Lang.Tsx,
-  py: 'python',
-  rb: 'ruby',
-  go: 'go',
-  rs: 'rust',
-  java: 'java',
-  cpp: 'cpp',
-  c: 'c',
-  html: Lang.Html,
-  css: Lang.Css,
-  json: 'json',
-};
-
-// ===== Language Families =====
-/**
- * File extensions that belong to JavaScript/TypeScript language family.
- */
-export const JAVASCRIPT_FAMILY_EXTENSIONS: readonly string[] = [
-  'ts',
-  'js',
-  'tsx',
-  'jsx',
-];
+  LANGUAGE_MAP,
+  JAVASCRIPT_FAMILY_EXTENSIONS,
+} from '../utils/ast-grep-utils.js';
 
 // ===== Code Keywords =====
 /**

--- a/packages/core/src/tools/ast-grep.test.ts
+++ b/packages/core/src/tools/ast-grep.test.ts
@@ -1,0 +1,280 @@
+// @plan PLAN-20260211-ASTGREP.P04
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { AstGrepTool } from './ast-grep.js';
+import type { ToolResult } from './tools.js';
+import type { Config } from '../config/config.js';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+
+describe('AstGrepTool', () => {
+  let tempDir: string;
+  let tool: AstGrepTool;
+  const abortSignal = new AbortController().signal;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ast-grep-test-'));
+    const mockConfig = {
+      getTargetDir: () => tempDir,
+    } as unknown as Config;
+    tool = new AstGrepTool(mockConfig);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function writeFile(name: string, content: string): Promise<string> {
+    const filePath = path.join(tempDir, name);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, content);
+    return filePath;
+  }
+
+  interface AstGrepMetadata {
+    matches: Array<{
+      file: string;
+      startLine: number;
+      startCol: number;
+      endLine: number;
+      endCol: number;
+      text: string;
+      nodeKind: string;
+      metaVariables: Record<string, string>;
+    }>;
+    truncated: boolean;
+    totalMatches?: number;
+  }
+
+  async function execute(params: Record<string, unknown>): Promise<ToolResult> {
+    const invocation = tool.createInvocation(params);
+    return invocation.execute(abortSignal);
+  }
+
+  function meta(result: ToolResult): AstGrepMetadata {
+    return result.metadata as unknown as AstGrepMetadata;
+  }
+
+  describe('pattern search (REQ-ASTGREP-002)', () => {
+    it('should find method calls matching pattern', async () => {
+      await writeFile(
+        'test.ts',
+        `
+class Foo {
+  bar() {
+    this.world();
+    this.hello();
+  }
+}
+`,
+      );
+      const result = await execute({
+        pattern: '$OBJ.world()',
+        language: 'typescript',
+        path: tempDir,
+      });
+      expect(meta(result).matches.length).toBe(1);
+      expect(meta(result).matches[0].text).toBe('this.world()');
+      expect(meta(result).matches[0].nodeKind).toBe('call_expression');
+    });
+
+    it('should not match comments (AST-aware)', async () => {
+      await writeFile(
+        'test.ts',
+        `
+// this.foo() is not a real call
+/* this.foo() also not real */
+const s = "this.foo()";
+`,
+      );
+      const result = await execute({
+        pattern: '$OBJ.foo()',
+        language: 'typescript',
+        path: tempDir,
+      });
+      expect(meta(result).matches.length).toBe(0);
+    });
+
+    it('should capture metavariables', async () => {
+      await writeFile('test.ts', `this.myMethod(1, 2, 3);`);
+      const result = await execute({
+        pattern: '$OBJ.myMethod($$$ARGS)',
+        language: 'typescript',
+        path: tempDir,
+      });
+      expect(meta(result).matches.length).toBe(1);
+      expect(meta(result).matches[0].metaVariables.OBJ).toBe('this');
+    });
+  });
+
+  describe('rule search (REQ-ASTGREP-003)', () => {
+    it('should find nodes matching a YAML rule', async () => {
+      await writeFile(
+        'test.ts',
+        `
+class Foo {
+  hello() { }
+  world() { }
+}
+`,
+      );
+      const result = await execute({
+        rule: {
+          kind: 'method_definition',
+          has: { kind: 'property_identifier', regex: '^hello$' },
+        },
+        language: 'typescript',
+        path: tempDir,
+      });
+      expect(meta(result).matches.length).toBe(1);
+      expect(meta(result).matches[0].text).toContain('hello');
+    });
+  });
+
+  describe('mutual exclusion (REQ-ASTGREP-004)', () => {
+    it('should error when both pattern and rule provided', async () => {
+      await writeFile('test.ts', 'const x = 1;');
+      const result = await execute({
+        pattern: '$X',
+        rule: { kind: 'identifier' },
+        language: 'typescript',
+        path: tempDir,
+      });
+      expect(result.llmContent).toContain('exactly one');
+    });
+
+    it('should error when neither pattern nor rule provided', async () => {
+      await writeFile('test.ts', 'const x = 1;');
+      const result = await execute({
+        language: 'typescript',
+        path: tempDir,
+      });
+      expect(result.llmContent).toContain('exactly one');
+    });
+  });
+
+  describe('path handling (REQ-ASTGREP-005/006)', () => {
+    it('should default to workspace root when no path provided', async () => {
+      await writeFile('test.ts', 'this.foo();');
+      const result = await execute({
+        pattern: '$OBJ.foo()',
+        language: 'typescript',
+      });
+      expect(meta(result).matches.length).toBe(1);
+    });
+
+    it('should error for path outside workspace', async () => {
+      const result = await execute({
+        pattern: '$X',
+        language: 'typescript',
+        path: '/etc/passwd',
+      });
+      expect(result.llmContent).toContain('outside');
+    });
+  });
+
+  describe('result format (REQ-ASTGREP-007)', () => {
+    it('should return all required fields', async () => {
+      await writeFile('test.ts', 'this.foo();');
+      const result = await execute({
+        pattern: '$OBJ.foo()',
+        language: 'typescript',
+        path: tempDir,
+      });
+      const match = meta(result).matches[0];
+      expect(match).toHaveProperty('file');
+      expect(match).toHaveProperty('startLine');
+      expect(match).toHaveProperty('startCol');
+      expect(match).toHaveProperty('endLine');
+      expect(match).toHaveProperty('endCol');
+      expect(match).toHaveProperty('text');
+      expect(match).toHaveProperty('nodeKind');
+      expect(match).toHaveProperty('metaVariables');
+      // File should be relative
+      expect(match.file).not.toContain(tempDir);
+    });
+  });
+
+  describe('result limit (REQ-ASTGREP-008)', () => {
+    it('should truncate results at maxResults', async () => {
+      await writeFile(
+        'test.ts',
+        Array.from({ length: 5 }, (_, i) => `this.foo${i}();`).join('\n'),
+      );
+      const result = await execute({
+        pattern: '$OBJ.$METHOD()',
+        language: 'typescript',
+        path: tempDir,
+        maxResults: 2,
+      });
+      expect(meta(result).matches.length).toBe(2);
+      expect(meta(result).truncated).toBe(true);
+    });
+  });
+
+  describe('empty results (REQ-ASTGREP-009)', () => {
+    it('should return empty array when no matches', async () => {
+      await writeFile('test.ts', 'const x = 1;');
+      const result = await execute({
+        pattern: '$OBJ.nonexistent()',
+        language: 'typescript',
+        path: tempDir,
+      });
+      expect(meta(result).matches).toEqual([]);
+      expect(meta(result).truncated).toBe(false);
+    });
+  });
+
+  describe('invalid pattern (REQ-ASTGREP-011)', () => {
+    it('should return clear error for unparseable pattern', async () => {
+      await writeFile('test.ts', 'const x = 1;');
+      const result = await execute({
+        pattern: 'async $METHOD($$$PARAMS): $RET { $$$BODY }',
+        language: 'typescript',
+        path: tempDir,
+      });
+      // Multi-node patterns fail in ast-grep — should get an error or empty results
+      expect(result).toBeDefined();
+      expect(
+        meta(result).matches?.length === 0 ||
+          /error|parse|pattern/i.test(String(result.llmContent)),
+      ).toBe(true);
+    });
+  });
+
+  describe('language detection (REQ-ASTGREP-013)', () => {
+    it('should auto-detect language for single .ts file', async () => {
+      const filePath = await writeFile('test.ts', 'this.foo();');
+      const result = await execute({
+        pattern: '$OBJ.foo()',
+        path: filePath,
+      });
+      expect(meta(result).matches.length).toBe(1);
+    });
+
+    it('should error for directory without language', async () => {
+      await writeFile('test.ts', 'this.foo();');
+      const result = await execute({
+        pattern: '$OBJ.foo()',
+        path: tempDir,
+      });
+      expect(result.llmContent).toContain('language');
+    });
+  });
+
+  describe('glob filtering (REQ-ASTGREP-010)', () => {
+    it('should filter files by glob pattern', async () => {
+      await writeFile('main.ts', 'this.foo();');
+      await writeFile('main.test.ts', 'this.foo();');
+      const result = await execute({
+        pattern: '$OBJ.foo()',
+        language: 'typescript',
+        path: tempDir,
+        globs: ['!*.test.ts'],
+      });
+      expect(meta(result).matches.length).toBe(1);
+      expect(meta(result).matches[0].file).toContain('main.ts');
+      expect(meta(result).matches[0].file).not.toContain('test');
+    });
+  });
+});

--- a/packages/core/src/tools/ast-grep.ts
+++ b/packages/core/src/tools/ast-grep.ts
@@ -1,0 +1,400 @@
+/**
+ * AST-aware structural code search tool using @ast-grep/napi.
+ * Finds code patterns by AST structure rather than text matching.
+ *
+ * @plan PLAN-20260211-ASTGREP.P05
+ */
+
+import * as path from 'node:path';
+import { promises as fs, statSync, existsSync } from 'node:fs';
+import FastGlob from 'fast-glob';
+import {
+  BaseDeclarativeTool,
+  BaseToolInvocation,
+  Kind,
+  type ToolInvocation,
+  type ToolResult,
+} from './tools.js';
+import { makeRelative } from '../utils/paths.js';
+import type { SgNode, NapiConfig } from '@ast-grep/napi';
+import {
+  parse,
+  Lang,
+  getAstLanguage,
+  resolveLanguageFromPath,
+  LANGUAGE_MAP,
+} from '../utils/ast-grep-utils.js';
+import type { Config } from '../config/config.js';
+import type { MessageBus } from '../confirmation-bus/message-bus.js';
+
+const DEFAULT_MAX_RESULTS = 100;
+
+export interface AstGrepToolParams {
+  pattern?: string;
+  rule?: Record<string, unknown>;
+  language?: string;
+  path?: string;
+  globs?: string[];
+  maxResults?: number;
+}
+
+interface AstGrepMatch {
+  file: string;
+  startLine: number;
+  startCol: number;
+  endLine: number;
+  endCol: number;
+  text: string;
+  nodeKind: string;
+  metaVariables: Record<string, string>;
+}
+
+interface AstGrepResult {
+  matches: AstGrepMatch[];
+  truncated: boolean;
+  totalMatches?: number;
+  skippedFiles?: number;
+}
+
+class AstGrepToolInvocation extends BaseToolInvocation<
+  AstGrepToolParams,
+  ToolResult
+> {
+  constructor(
+    private readonly config: Config,
+    params: AstGrepToolParams,
+  ) {
+    super(params);
+  }
+
+  getDescription(): string {
+    const { pattern, rule } = this.params;
+    if (pattern) return `AST pattern: '${pattern}'`;
+    if (rule) return `AST rule query`;
+    return 'AST search';
+  }
+
+  private makeError(message: string): ToolResult {
+    return { llmContent: message, returnDisplay: message };
+  }
+
+  async execute(signal: AbortSignal): Promise<ToolResult> {
+    const { pattern, rule, language, globs, maxResults } = this.params;
+    const limit = maxResults ?? DEFAULT_MAX_RESULTS;
+
+    // REQ-ASTGREP-004: exactly one of pattern or rule
+    if ((pattern && rule) || (!pattern && !rule)) {
+      return this.makeError(
+        'Error: Provide exactly one of `pattern` or `rule`, not both and not neither.',
+      );
+    }
+
+    // Resolve search path
+    const targetDir = this.config.getTargetDir();
+    let searchPath = this.params.path || targetDir;
+
+    // Handle relative paths
+    if (!path.isAbsolute(searchPath)) {
+      searchPath = path.resolve(targetDir, searchPath);
+    }
+
+    // REQ-ASTGREP-006: workspace boundary (path.sep-aware to prevent sibling bypass)
+    const normalizedTarget = targetDir.endsWith(path.sep)
+      ? targetDir
+      : targetDir + path.sep;
+    if (searchPath !== targetDir && !searchPath.startsWith(normalizedTarget)) {
+      return this.makeError(
+        `Error: Path "${this.params.path}" resolves outside the workspace root.`,
+      );
+    }
+
+    // Determine if single file or directory
+    let isSingleFile = false;
+    try {
+      const stats = statSync(searchPath);
+      isSingleFile = stats.isFile();
+    } catch {
+      if (!existsSync(searchPath)) {
+        return this.makeError(`Error: Path does not exist: ${searchPath}`);
+      }
+    }
+
+    // REQ-ASTGREP-013: language detection
+    let resolvedLang: string | Lang | undefined;
+    if (language) {
+      resolvedLang = getAstLanguage(language);
+      if (!resolvedLang) {
+        return this.makeError(
+          `Error: Unrecognized language "${language}". Supported: ${Object.keys(LANGUAGE_MAP).join(', ')}`,
+        );
+      }
+    } else if (isSingleFile) {
+      resolvedLang = resolveLanguageFromPath(searchPath);
+      if (!resolvedLang) {
+        return this.makeError(
+          'Error: Could not detect language from file extension. Please provide a `language` parameter.',
+        );
+      }
+    } else {
+      return this.makeError(
+        'Error: `language` parameter is required when searching a directory.',
+      );
+    }
+
+    try {
+      const allMatches: AstGrepMatch[] = [];
+      let skippedFiles = 0;
+
+      if (isSingleFile) {
+        // Single file: use parse + findAll
+        const content = await fs.readFile(searchPath, 'utf-8');
+        const matches = this.searchContent(
+          content,
+          resolvedLang,
+          searchPath,
+          targetDir,
+          pattern,
+          rule,
+        );
+        allMatches.push(...matches);
+      } else {
+        // Directory: find files, then search each
+        const extensions = this.getExtensionsForLanguage(resolvedLang);
+        let files = await FastGlob(
+          extensions.map((ext) => `**/*.${ext}`),
+          {
+            cwd: searchPath,
+            absolute: true,
+            dot: false,
+            ignore: ['**/node_modules/**', '**/.git/**'],
+          },
+        );
+
+        // Apply glob filters
+        if (globs && globs.length > 0) {
+          const includePatterns = globs.filter((g) => !g.startsWith('!'));
+          const excludePatterns = globs
+            .filter((g) => g.startsWith('!'))
+            .map((g) => g.slice(1));
+
+          if (includePatterns.length > 0) {
+            const includeSet = new Set(
+              await FastGlob(includePatterns, {
+                cwd: searchPath,
+                absolute: true,
+              }),
+            );
+            files = files.filter((f) => includeSet.has(f));
+          }
+          if (excludePatterns.length > 0) {
+            const excludeSet = new Set(
+              await FastGlob(excludePatterns, {
+                cwd: searchPath,
+                absolute: true,
+              }),
+            );
+            files = files.filter((f) => !excludeSet.has(f));
+          }
+        }
+
+        for (const file of files) {
+          if (signal.aborted) break;
+          try {
+            const content = await fs.readFile(file, 'utf-8');
+            const matches = this.searchContent(
+              content,
+              resolvedLang,
+              file,
+              targetDir,
+              pattern,
+              rule,
+            );
+            allMatches.push(...matches);
+          } catch {
+            skippedFiles++;
+          }
+        }
+      }
+
+      // REQ-ASTGREP-008: result limit
+      const truncated = allMatches.length > limit;
+      const result: AstGrepResult = {
+        matches: allMatches.slice(0, limit),
+        truncated,
+        skippedFiles: skippedFiles > 0 ? skippedFiles : undefined,
+      };
+      if (truncated) {
+        result.totalMatches = allMatches.length;
+      }
+
+      // Format output for LLM
+      const matchCount = result.matches.length;
+      const searchDesc = pattern ? `pattern "${pattern}"` : 'rule query';
+      let llmContent = `Found ${matchCount} AST match${matchCount !== 1 ? 'es' : ''} for ${searchDesc}`;
+      if (truncated) {
+        llmContent += ` (showing ${matchCount} of ${result.totalMatches})`;
+      }
+      llmContent += ':\n---\n';
+
+      for (const m of result.matches) {
+        llmContent += `${m.file}:${m.startLine} [${m.nodeKind}] ${m.text}\n`;
+        if (Object.keys(m.metaVariables).length > 0) {
+          for (const [k, v] of Object.entries(m.metaVariables)) {
+            llmContent += `  $${k} = ${v}\n`;
+          }
+        }
+      }
+
+      const displayMessage = `Found ${matchCount} AST match${matchCount !== 1 ? 'es' : ''}${truncated ? ' (truncated)' : ''}`;
+
+      return {
+        llmContent: llmContent.trim(),
+        returnDisplay: displayMessage,
+        metadata: result as unknown as Record<string, unknown>,
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return this.makeError(`Error searching: ${msg}`);
+    }
+  }
+
+  private searchContent(
+    content: string,
+    language: string | Lang,
+    filePath: string,
+    workspaceRoot: string,
+    pattern?: string,
+    rule?: Record<string, unknown>,
+  ): AstGrepMatch[] {
+    const root = parse(language as Lang, content);
+    const sgRoot = root.root();
+    const relativePath = makeRelative(filePath, workspaceRoot);
+
+    let nodes: SgNode[];
+    if (pattern) {
+      nodes = sgRoot.findAll(pattern);
+    } else if (rule) {
+      nodes = sgRoot.findAll({ rule } as NapiConfig);
+    } else {
+      return [];
+    }
+
+    return nodes.map((node) => {
+      const range = node.range();
+      const metaVariables: Record<string, string> = {};
+
+      // Extract single metavariables ($NAME patterns, excluding $$$ multi-vars)
+      if (pattern) {
+        const metaVarNames =
+          pattern.match(/(?<!\$)\$(?!\$)([A-Z_][A-Z0-9_]*)/g) || [];
+        for (const raw of metaVarNames) {
+          const name = raw.slice(1); // remove $
+          const match = node.getMatch(name);
+          if (match) {
+            metaVariables[name] = match.text();
+          }
+        }
+        // Extract multi metavariables ($$$NAME patterns)
+        const multiVarNames = pattern.match(/\$\$\$([A-Z_][A-Z0-9_]*)/g) || [];
+        for (const raw of multiVarNames) {
+          const name = raw.slice(3); // remove $$$
+          const matches = node.getMultipleMatches(name);
+          if (matches && matches.length > 0) {
+            metaVariables[name] = matches
+              .map((m: SgNode) => m.text())
+              .join(', ');
+          }
+        }
+      }
+
+      return {
+        file: relativePath,
+        startLine: range.start.line + 1,
+        startCol: range.start.column,
+        endLine: range.end.line + 1,
+        endCol: range.end.column,
+        text: node.text(),
+        nodeKind: String(node.kind()),
+        metaVariables,
+      };
+    });
+  }
+
+  private getExtensionsForLanguage(lang: string | Lang): string[] {
+    const extensions: string[] = [];
+    for (const [ext, mappedLang] of Object.entries(LANGUAGE_MAP)) {
+      if (mappedLang === lang) {
+        extensions.push(ext);
+      }
+    }
+    return extensions.length > 0 ? extensions : ['*'];
+  }
+}
+
+export class AstGrepTool extends BaseDeclarativeTool<
+  AstGrepToolParams,
+  ToolResult
+> {
+  static readonly Name = 'ast_grep';
+
+  constructor(
+    private readonly config: Config,
+    _messageBus?: MessageBus,
+  ) {
+    super(
+      AstGrepTool.Name,
+      'AstGrep',
+      'Searches for code patterns using AST (Abstract Syntax Tree) structural matching, not text matching. ' +
+        'Use this for finding specific code structures: method calls, class declarations, import patterns, try/catch blocks, etc. ' +
+        'Supports metavariable capture ($VAR for single node, $$$VAR for multiple). ' +
+        'Unlike search_file_content (ripgrep), this tool understands code structure and ignores comments/strings.',
+      Kind.Search,
+      {
+        properties: {
+          pattern: {
+            description:
+              'AST pattern to search for. Use $VAR for single-node metavariables, $$$VAR for multi-node. ' +
+              'Examples: "$OBJ.foo()", "class $NAME extends $PARENT { $$$BODY }", "try { $$$T } catch ($E) { $$$C }"',
+            type: 'string',
+          },
+          rule: {
+            description:
+              'YAML rule object for complex queries. Fields: kind, has, inside, stopBy, regex. ' +
+              'Use when pattern syntax is insufficient (e.g., matching by AST node kind).',
+            type: 'object',
+          },
+          language: {
+            description:
+              'Programming language: typescript, javascript, python, ruby, go, rust, java, cpp, c, html, css, json. ' +
+              'Required for directory searches. Auto-detected for single files.',
+            type: 'string',
+          },
+          path: {
+            description:
+              'File or directory to search. Defaults to workspace root.',
+            type: 'string',
+          },
+          globs: {
+            description:
+              'Glob patterns to include/exclude files. Prefix with ! to exclude. Example: ["*.ts", "!*.test.ts"]',
+            type: 'array',
+            items: { type: 'string' },
+          },
+          maxResults: {
+            description: 'Maximum matches to return. Default 100.',
+            type: 'number',
+          },
+        },
+        required: [],
+        type: 'object',
+      },
+    );
+  }
+
+  protected override createInvocation(
+    params: AstGrepToolParams,
+    _messageBus?: MessageBus,
+  ): ToolInvocation<AstGrepToolParams, ToolResult> {
+    return new AstGrepToolInvocation(this.config, params);
+  }
+}

--- a/packages/core/src/tools/structural-analysis.test.ts
+++ b/packages/core/src/tools/structural-analysis.test.ts
@@ -1,0 +1,427 @@
+// @plan PLAN-20260211-ASTGREP.P06
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { StructuralAnalysisTool } from './structural-analysis.js';
+import type { ToolResult } from './tools.js';
+import type { Config } from '../config/config.js';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+
+interface MetadataResult {
+  results: Array<Record<string, unknown>> | Record<string, unknown>;
+  truncated: boolean;
+}
+
+describe('StructuralAnalysisTool', () => {
+  let tempDir: string;
+  let tool: StructuralAnalysisTool;
+  const abortSignal = new AbortController().signal;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'structural-analysis-test-'),
+    );
+    const mockConfig = {
+      getTargetDir: () => tempDir,
+    } as unknown as Config;
+    tool = new StructuralAnalysisTool(mockConfig);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function writeFile(name: string, content: string): Promise<void> {
+    const filePath = path.join(tempDir, name);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, content);
+  }
+
+  async function execute(params: Record<string, unknown>): Promise<ToolResult> {
+    const invocation = tool.createInvocation(params);
+    return invocation.execute(abortSignal);
+  }
+
+  function meta(result: ToolResult): MetadataResult {
+    return result.metadata as unknown as MetadataResult;
+  }
+
+  // ===== Common / Mode dispatch =====
+  describe('mode dispatch (REQ-SA-002)', () => {
+    it('should error on invalid mode', async () => {
+      const result = await execute({
+        mode: 'invalid',
+        language: 'typescript',
+      });
+      expect(result.llmContent).toContain('Invalid mode');
+      expect(result.llmContent).toContain('callers');
+    });
+  });
+
+  describe('language parameter (REQ-SA-003)', () => {
+    it('should error on missing language', async () => {
+      const result = await execute({ mode: 'definitions', symbol: 'Foo' });
+      expect(result.llmContent).toContain('language');
+    });
+  });
+
+  describe('workspace boundary (REQ-SA-005)', () => {
+    it('should error for path outside workspace', async () => {
+      const result = await execute({
+        mode: 'definitions',
+        language: 'typescript',
+        symbol: 'Foo',
+        path: '/etc/passwd',
+      });
+      expect(result.llmContent).toContain('outside');
+    });
+  });
+
+  // ===== Definitions (REQ-SA-DEFS-001) =====
+  describe('definitions mode', () => {
+    it('should find class definition by name', async () => {
+      await writeFile('foo.ts', 'export class MyService { run() {} }');
+      const result = await execute({
+        mode: 'definitions',
+        language: 'typescript',
+        symbol: 'MyService',
+        path: tempDir,
+      });
+      expect(meta(result).results.length).toBeGreaterThan(0);
+      expect(meta(result).results[0].kind).toContain('class');
+    });
+
+    it('should find function definition by name', async () => {
+      await writeFile(
+        'util.ts',
+        'function doStuff(x: number) { return x * 2; }',
+      );
+      const result = await execute({
+        mode: 'definitions',
+        language: 'typescript',
+        symbol: 'doStuff',
+        path: tempDir,
+      });
+      expect(meta(result).results.length).toBeGreaterThan(0);
+    });
+
+    it('should return empty for nonexistent symbol', async () => {
+      await writeFile('foo.ts', 'const x = 1;');
+      const result = await execute({
+        mode: 'definitions',
+        language: 'typescript',
+        symbol: 'NonExistent',
+        path: tempDir,
+      });
+      expect(meta(result).results).toEqual([]);
+      expect(meta(result).truncated).toBe(false);
+    });
+
+    it('should find definitions across multiple files', async () => {
+      await writeFile('a.ts', 'class Widget { }');
+      await writeFile('b.ts', 'class Widget extends Base { }');
+      const result = await execute({
+        mode: 'definitions',
+        language: 'typescript',
+        symbol: 'Widget',
+        path: tempDir,
+      });
+      expect(meta(result).results.length).toBe(2);
+    });
+  });
+
+  // ===== Hierarchy (REQ-SA-HIER-001/002) =====
+  describe('hierarchy mode', () => {
+    it('should find parent class', async () => {
+      await writeFile(
+        'child.ts',
+        'class ChildTool extends BaseTool { run() {} }',
+      );
+      const result = await execute({
+        mode: 'hierarchy',
+        language: 'typescript',
+        symbol: 'ChildTool',
+        path: tempDir,
+      });
+      expect(meta(result).results.extends).toContain('BaseTool');
+    });
+
+    it('should find interface implementation', async () => {
+      await writeFile(
+        'impl.ts',
+        'class MyServer implements ContentGenerator { generate() {} }',
+      );
+      const result = await execute({
+        mode: 'hierarchy',
+        language: 'typescript',
+        symbol: 'MyServer',
+        path: tempDir,
+      });
+      expect(meta(result).results.implements).toContain('ContentGenerator');
+    });
+
+    it('should find subclasses', async () => {
+      await writeFile('a.ts', 'class ToolA extends BaseTool { }');
+      await writeFile('b.ts', 'class ToolB extends BaseTool { }');
+      const result = await execute({
+        mode: 'hierarchy',
+        language: 'typescript',
+        symbol: 'BaseTool',
+        path: tempDir,
+      });
+      expect(meta(result).results.extendedBy.length).toBe(2);
+      const names = meta(result).results.extendedBy.map(
+        (e: Record<string, unknown>) => e.name,
+      );
+      expect(names).toContain('ToolA');
+      expect(names).toContain('ToolB');
+    });
+
+    it('should find implementors', async () => {
+      await writeFile(
+        'impl.ts',
+        'class Server implements IGenerator { gen() {} }',
+      );
+      const result = await execute({
+        mode: 'hierarchy',
+        language: 'typescript',
+        symbol: 'IGenerator',
+        path: tempDir,
+      });
+      expect(meta(result).results.implementedBy.length).toBe(1);
+      expect(meta(result).results.implementedBy[0].name).toBe('Server');
+    });
+  });
+
+  // ===== Callers (REQ-SA-CALLERS-001-006) =====
+  // @plan PLAN-20260211-ASTGREP.P08
+  describe('callers mode', () => {
+    it('should find basic callers', async () => {
+      await writeFile(
+        'service.ts',
+        `class Service {
+  targetMethod() { return 1; }
+  callerA() { this.targetMethod(); }
+  callerB() { this.targetMethod(); }
+  unrelated() { this.other(); }
+}`,
+      );
+      const result = await execute({
+        mode: 'callers',
+        language: 'typescript',
+        symbol: 'targetMethod',
+        path: tempDir,
+      });
+      expect(meta(result).results.length).toBe(2);
+      const methods = meta(result).results.map(
+        (r: Record<string, unknown>) => r.method,
+      );
+      expect(methods).toContain('callerA');
+      expect(methods).toContain('callerB');
+    });
+
+    it('should include via context', async () => {
+      await writeFile(
+        'service.ts',
+        `class Service {
+  target() { }
+  caller() { const x = this.target(); }
+}`,
+      );
+      const result = await execute({
+        mode: 'callers',
+        language: 'typescript',
+        symbol: 'target',
+        path: tempDir,
+      });
+      expect(meta(result).results.length).toBe(1);
+      expect(meta(result).results[0].via).toContain('target');
+    });
+
+    it('should handle cycle detection', async () => {
+      await writeFile(
+        'cycle.ts',
+        `class Svc {
+  a() { this.b(); }
+  b() { this.a(); }
+}`,
+      );
+      const result = await execute({
+        mode: 'callers',
+        language: 'typescript',
+        symbol: 'a',
+        depth: 3,
+        path: tempDir,
+      });
+      // Should not infinite loop — b calls a, but a is already visited
+      expect(meta(result).results.length).toBeGreaterThan(0);
+    });
+
+    it('should respect maxNodes', async () => {
+      await writeFile(
+        'many.ts',
+        `class Svc {
+  target() {}
+  a() { this.target(); }
+  b() { this.target(); }
+  c() { this.target(); }
+  d() { this.target(); }
+  e() { this.target(); }
+}`,
+      );
+      const result = await execute({
+        mode: 'callers',
+        language: 'typescript',
+        symbol: 'target',
+        maxNodes: 2,
+        path: tempDir,
+      });
+      expect(meta(result).results.length).toBeLessThanOrEqual(2);
+      expect(meta(result).truncated).toBe(true);
+    });
+  });
+
+  // ===== Callees (REQ-SA-CALLEES-001-003) =====
+  // @plan PLAN-20260211-ASTGREP.P08
+  describe('callees mode', () => {
+    it('should find basic callees', async () => {
+      await writeFile(
+        'service.ts',
+        `class Svc {
+  myMethod() {
+    this.foo();
+    this.bar();
+    console.log("hello");
+  }
+}`,
+      );
+      const result = await execute({
+        mode: 'callees',
+        language: 'typescript',
+        symbol: 'myMethod',
+        path: tempDir,
+      });
+      expect(meta(result).results.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('should deduplicate chained calls', async () => {
+      await writeFile(
+        'chain.ts',
+        `class Svc {
+  myMethod() {
+    this.a().b().c();
+  }
+}`,
+      );
+      const result = await execute({
+        mode: 'callees',
+        language: 'typescript',
+        symbol: 'myMethod',
+        path: tempDir,
+      });
+      // Should have the outermost call this.a().b().c() but not this.a() or this.a().b() separately
+      const texts = meta(result).results.map(
+        (r: Record<string, unknown>) => r.text,
+      );
+      const chainCall = texts.find(
+        (t: string) => t.includes('a()') && t.includes('c()'),
+      );
+      expect(chainCall).toBeDefined();
+      // There should be exactly 1 call entry (the outermost chain)
+      expect(meta(result).results.length).toBe(1);
+    });
+  });
+
+  // ===== References (REQ-SA-REFS-001-003) =====
+  // @plan PLAN-20260211-ASTGREP.P10
+  describe('references mode', () => {
+    it('should find categorized references', async () => {
+      await writeFile(
+        'usage.ts',
+        `import { MyClass } from './myclass';
+const obj = new MyClass();
+const x: MyClass = obj;
+class Child extends MyClass { }
+obj.doSomething();
+`,
+      );
+      const result = await execute({
+        mode: 'references',
+        language: 'typescript',
+        symbol: 'MyClass',
+        path: tempDir,
+      });
+      const { counts } = meta(result).results;
+      expect(counts['Instantiations']).toBeGreaterThan(0);
+      expect(counts['Imports']).toBeGreaterThan(0);
+      expect(counts['Extends/Implements']).toBeGreaterThan(0);
+    });
+
+    it('should label heuristic category', async () => {
+      await writeFile(
+        'usage.ts',
+        `const myClass = new MyClass();
+myClass.foo();
+`,
+      );
+      const result = await execute({
+        mode: 'references',
+        language: 'typescript',
+        symbol: 'MyClass',
+        path: tempDir,
+      });
+      expect(meta(result).results.categories).toHaveProperty(
+        'Instance method calls (heuristic)',
+      );
+    });
+  });
+
+  // ===== Dependencies (REQ-SA-DEPS-001/002) =====
+  // @plan PLAN-20260211-ASTGREP.P10
+  describe('dependencies mode', () => {
+    it('should find imports', async () => {
+      await writeFile(
+        'main.ts',
+        `import { foo } from './foo';
+import bar from './bar';
+import './side-effect';
+`,
+      );
+      const result = await execute({
+        mode: 'dependencies',
+        language: 'typescript',
+        path: tempDir,
+      });
+      expect(meta(result).results.imports.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  // ===== Exports (REQ-SA-EXPORTS-001) =====
+  // @plan PLAN-20260211-ASTGREP.P10
+  describe('exports mode', () => {
+    it('should find all export types', async () => {
+      await writeFile(
+        'mod.ts',
+        `export class MyClass { }
+export function doStuff() { }
+export const VALUE = 42;
+export interface IFace { }
+export type MyType = string;
+export default class DefaultClass { }
+`,
+      );
+      const result = await execute({
+        mode: 'exports',
+        language: 'typescript',
+        path: tempDir,
+      });
+      expect(meta(result).results.length).toBeGreaterThanOrEqual(5);
+      const kinds = meta(result).results.map(
+        (e: Record<string, unknown>) => e.kind,
+      );
+      expect(kinds).toContain('class');
+      expect(kinds).toContain('function');
+      expect(kinds).toContain('const');
+    });
+  });
+});

--- a/packages/core/src/tools/structural-analysis.ts
+++ b/packages/core/src/tools/structural-analysis.ts
@@ -1,0 +1,1328 @@
+/**
+ * Multi-hop AST-based code analysis tool.
+ * Analyzes code relationships: call graphs, type hierarchies, symbol references,
+ * module dependencies, and exports using @ast-grep/napi.
+ *
+ * This is name-based (not type-resolved) analysis. See overview.md for limitations.
+ *
+ * @plan PLAN-20260211-ASTGREP.P07
+ */
+
+import * as path from 'node:path';
+import { promises as fs } from 'node:fs';
+import FastGlob from 'fast-glob';
+import {
+  BaseDeclarativeTool,
+  BaseToolInvocation,
+  Kind,
+  type ToolInvocation,
+  type ToolResult,
+} from './tools.js';
+import { makeRelative } from '../utils/paths.js';
+import type { SgNode, NapiConfig } from '@ast-grep/napi';
+import {
+  parse,
+  Lang,
+  getAstLanguage,
+  LANGUAGE_MAP,
+} from '../utils/ast-grep-utils.js';
+import type { Config } from '../config/config.js';
+import type { MessageBus } from '../confirmation-bus/message-bus.js';
+
+const VALID_MODES = [
+  'callers',
+  'callees',
+  'definitions',
+  'hierarchy',
+  'references',
+  'dependencies',
+  'exports',
+] as const;
+type Mode = (typeof VALID_MODES)[number];
+
+const DEFAULT_DEPTH = 1;
+const MAX_DEPTH = 5;
+const DEFAULT_MAX_NODES = 50;
+
+export interface StructuralAnalysisParams {
+  mode: string;
+  language: string;
+  path?: string;
+  symbol?: string;
+  depth?: number;
+  maxNodes?: number;
+  target?: string;
+  reverse?: boolean;
+}
+
+interface AnalysisResult {
+  mode: string;
+  symbol?: string;
+  truncated: boolean;
+  results: unknown;
+}
+
+class StructuralAnalysisInvocation extends BaseToolInvocation<
+  StructuralAnalysisParams,
+  ToolResult
+> {
+  constructor(
+    private readonly config: Config,
+    params: StructuralAnalysisParams,
+  ) {
+    super(params);
+  }
+
+  getDescription(): string {
+    const { mode, symbol } = this.params;
+    if (symbol) return `${mode}: ${symbol}`;
+    return `${mode} analysis`;
+  }
+
+  private makeError(message: string): ToolResult {
+    return { llmContent: message, returnDisplay: message };
+  }
+
+  private formatResult(analysisResult: AnalysisResult): ToolResult {
+    const llmContent = JSON.stringify(analysisResult, null, 2);
+    const mode = analysisResult.mode;
+    const symbol = analysisResult.symbol ? ` for ${analysisResult.symbol}` : '';
+    const displayMessage = `${mode} analysis${symbol} complete${analysisResult.truncated ? ' (truncated)' : ''}`;
+    return {
+      llmContent,
+      returnDisplay: displayMessage,
+      metadata: analysisResult as unknown as Record<string, unknown>,
+    };
+  }
+
+  async execute(signal: AbortSignal): Promise<ToolResult> {
+    const { mode, language, symbol, depth, maxNodes, target, reverse } =
+      this.params;
+
+    // Validate mode
+    if (!VALID_MODES.includes(mode as Mode)) {
+      return this.makeError(
+        `Error: Invalid mode "${mode}". Valid modes: ${VALID_MODES.join(', ')}`,
+      );
+    }
+
+    // Validate language
+    if (!language) {
+      return this.makeError('Error: `language` parameter is required.');
+    }
+    const resolvedLang = getAstLanguage(language);
+    if (!resolvedLang) {
+      return this.makeError(
+        `Error: Unrecognized language "${language}". Supported: ${Object.keys(LANGUAGE_MAP).join(', ')}`,
+      );
+    }
+
+    // Resolve search path
+    const targetDir = this.config.getTargetDir();
+    let searchPath = this.params.path || target || targetDir;
+    if (!path.isAbsolute(searchPath)) {
+      searchPath = path.resolve(targetDir, searchPath);
+    }
+
+    // Workspace boundary (path.sep-aware to prevent sibling bypass)
+    const normalizedTarget = targetDir.endsWith(path.sep)
+      ? targetDir
+      : targetDir + path.sep;
+    if (searchPath !== targetDir && !searchPath.startsWith(normalizedTarget)) {
+      return this.makeError('Error: Path resolves outside the workspace root.');
+    }
+
+    // Symbol required for symbol-scoped modes
+    const symbolModes: Mode[] = [
+      'callers',
+      'callees',
+      'definitions',
+      'hierarchy',
+      'references',
+    ];
+    if (symbolModes.includes(mode as Mode) && !symbol) {
+      return this.makeError(
+        `Error: \`symbol\` parameter is required for "${mode}" mode.`,
+      );
+    }
+
+    const effectiveDepth = Math.min(depth ?? DEFAULT_DEPTH, MAX_DEPTH);
+    const effectiveMaxNodes = maxNodes ?? DEFAULT_MAX_NODES;
+
+    try {
+      let analysisResult: AnalysisResult;
+      switch (mode as Mode) {
+        case 'definitions':
+          analysisResult = await this.executeDefinitions(
+            symbol!,
+            resolvedLang,
+            searchPath,
+            targetDir,
+            signal,
+          );
+          break;
+        case 'hierarchy':
+          analysisResult = await this.executeHierarchy(
+            symbol!,
+            resolvedLang,
+            searchPath,
+            targetDir,
+            signal,
+          );
+          break;
+        case 'callers':
+          analysisResult = await this.executeCallers(
+            symbol!,
+            resolvedLang,
+            searchPath,
+            targetDir,
+            effectiveDepth,
+            effectiveMaxNodes,
+            signal,
+          );
+          break;
+        case 'callees':
+          analysisResult = await this.executeCallees(
+            symbol!,
+            resolvedLang,
+            searchPath,
+            targetDir,
+            effectiveDepth,
+            effectiveMaxNodes,
+            signal,
+          );
+          break;
+        case 'references':
+          analysisResult = await this.executeReferences(
+            symbol!,
+            resolvedLang,
+            searchPath,
+            targetDir,
+            signal,
+          );
+          break;
+        case 'dependencies':
+          analysisResult = await this.executeDependencies(
+            searchPath,
+            resolvedLang,
+            targetDir,
+            !!reverse,
+            signal,
+          );
+          break;
+        case 'exports':
+          analysisResult = await this.executeExports(
+            searchPath,
+            resolvedLang,
+            targetDir,
+            signal,
+          );
+          break;
+        default:
+          return this.makeError(`Error: Mode "${mode}" is not implemented.`);
+      }
+      return this.formatResult(analysisResult);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return this.makeError(`Error in ${mode}: ${msg}`);
+    }
+  }
+
+  private async getFiles(
+    searchPath: string,
+    lang: string | Lang,
+  ): Promise<string[]> {
+    const stat = await fs.stat(searchPath).catch(() => null);
+    if (stat?.isFile()) {
+      return [searchPath];
+    }
+    const extensions = this.getExtensionsForLanguage(lang);
+    return FastGlob(
+      extensions.map((ext) => `**/*.${ext}`),
+      {
+        cwd: searchPath,
+        absolute: true,
+        dot: false,
+        ignore: ['**/node_modules/**', '**/.git/**'],
+      },
+    );
+  }
+
+  private getExtensionsForLanguage(lang: string | Lang): string[] {
+    const exts: string[] = [];
+    for (const [ext, mapped] of Object.entries(LANGUAGE_MAP)) {
+      if (mapped === lang) exts.push(ext);
+    }
+    return exts.length > 0 ? exts : ['*'];
+  }
+
+  private escapeRegex(s: string): string {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
+  /**
+   * AST node kinds that represent function-like containers.
+   * Used for callers mode to find the scope a call lives in.
+   */
+  private static readonly FUNCTION_CONTAINER_KINDS = new Set([
+    'method_definition',
+    'function_declaration',
+    'arrow_function',
+  ]);
+
+  /**
+   * Extract a name from a function-like container node.
+   * - method_definition: first property_identifier child
+   * - function_declaration: first identifier child
+   * - arrow_function: name from parent variable_declarator's identifier
+   */
+  private getContainerName(node: SgNode): string | null {
+    const kind = String(node.kind());
+
+    if (kind === 'method_definition') {
+      const nameNode = node
+        .children()
+        .find((c: SgNode) => String(c.kind()) === 'property_identifier');
+      return nameNode?.text() ?? null;
+    }
+
+    if (kind === 'function_declaration') {
+      const nameNode = node
+        .children()
+        .find((c: SgNode) => String(c.kind()) === 'identifier');
+      return nameNode?.text() ?? null;
+    }
+
+    if (kind === 'arrow_function') {
+      // Walk up to variable_declarator → get its identifier
+      const parent = node.parent();
+      if (parent && String(parent.kind()) === 'variable_declarator') {
+        const nameNode = parent
+          .children()
+          .find((c: SgNode) => String(c.kind()) === 'identifier');
+        return nameNode?.text() ?? null;
+      }
+      return null;
+    }
+
+    return null;
+  }
+
+  private async parseFile(
+    filePath: string,
+    lang: string | Lang,
+  ): Promise<{ root: SgNode; content: string } | null> {
+    try {
+      const content = await fs.readFile(filePath, 'utf-8');
+      const result = parse(lang as Lang, content);
+      return { root: result.root(), content };
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Extracts the function/method name from a call_expression node.
+   * Handles: `foo()` → "foo", `obj.bar()` → "bar", `a.b.c()` → "c"
+   */
+  private extractCalleeName(callNode: SgNode): string | null {
+    const children = callNode.children();
+    if (children.length === 0) return null;
+    const callee = children[0]; // first child of call_expression is the callee
+    const kind = String(callee.kind());
+    if (kind === 'identifier') {
+      return callee.text();
+    }
+    if (kind === 'member_expression') {
+      // Last property_identifier child is the method name
+      const props = callee
+        .children()
+        .filter((c: SgNode) => String(c.kind()) === 'property_identifier');
+      if (props.length > 0) {
+        return props[props.length - 1].text();
+      }
+    }
+    return null;
+  }
+
+  // ===== DEFINITIONS =====
+  private async executeDefinitions(
+    symbol: string,
+    lang: string | Lang,
+    searchPath: string,
+    workspaceRoot: string,
+    signal: AbortSignal,
+  ): Promise<AnalysisResult> {
+    const files = await this.getFiles(searchPath, lang);
+    const definitions: Array<{
+      file: string;
+      line: number;
+      kind: string;
+      text: string;
+    }> = [];
+
+    for (const file of files) {
+      if (signal.aborted) break;
+      const parsed = await this.parseFile(file, lang);
+      if (!parsed) continue;
+
+      const relPath = makeRelative(file, workspaceRoot);
+
+      // Search for various definition forms
+      const patterns = [
+        // Method definitions
+        { pat: `${symbol}($$$PARAMS) { $$$BODY }`, kind: 'method' },
+        // Function declarations
+        { pat: `function ${symbol}($$$PARAMS) { $$$BODY }`, kind: 'function' },
+        // Class declarations
+        { pat: `class ${symbol} { $$$BODY }`, kind: 'class' },
+        { pat: `class ${symbol} extends $PARENT { $$$BODY }`, kind: 'class' },
+      ];
+
+      for (const { pat, kind } of patterns) {
+        try {
+          const matches = parsed.root.findAll(pat);
+          for (const m of matches) {
+            const range = m.range();
+            definitions.push({
+              file: relPath,
+              line: range.start.line + 1,
+              kind,
+              text: m.text().substring(0, 200),
+            });
+          }
+        } catch {
+          // Pattern may not be valid for all languages
+        }
+      }
+
+      // Also search by YAML rule for identifiers in declaration positions
+      try {
+        const ruleMatches = parsed.root.findAll({
+          rule: {
+            any: [
+              {
+                kind: 'class_declaration',
+                has: {
+                  kind: 'type_identifier',
+                  regex: `^${this.escapeRegex(symbol)}$`,
+                },
+              },
+              {
+                kind: 'interface_declaration',
+                has: {
+                  kind: 'type_identifier',
+                  regex: `^${this.escapeRegex(symbol)}$`,
+                },
+              },
+              {
+                kind: 'type_alias_declaration',
+                has: {
+                  kind: 'type_identifier',
+                  regex: `^${this.escapeRegex(symbol)}$`,
+                },
+              },
+            ],
+          },
+        } as NapiConfig);
+        for (const m of ruleMatches) {
+          const range = m.range();
+          const exists = definitions.some(
+            (d) => d.file === relPath && d.line === range.start.line + 1,
+          );
+          if (!exists) {
+            definitions.push({
+              file: relPath,
+              line: range.start.line + 1,
+              kind: String(m.kind()),
+              text: m.text().substring(0, 200),
+            });
+          }
+        }
+      } catch {
+        // Rule may not apply
+      }
+    }
+
+    return {
+      mode: 'definitions',
+      symbol,
+      truncated: false,
+      results: definitions,
+    };
+  }
+
+  // ===== HIERARCHY =====
+  private async executeHierarchy(
+    symbol: string,
+    lang: string | Lang,
+    searchPath: string,
+    workspaceRoot: string,
+    signal: AbortSignal,
+  ): Promise<AnalysisResult> {
+    const files = await this.getFiles(searchPath, lang);
+    const extendsParent: string[] = [];
+    const implementsInterfaces: string[] = [];
+    const extendedBy: Array<{ name: string; file: string; line: number }> = [];
+    const implementedBy: Array<{ name: string; file: string; line: number }> =
+      [];
+
+    for (const file of files) {
+      if (signal.aborted) break;
+      const parsed = await this.parseFile(file, lang);
+      if (!parsed) continue;
+
+      const relPath = makeRelative(file, workspaceRoot);
+
+      // Find what the symbol extends/implements
+      try {
+        const extendsMatches = parsed.root.findAll(
+          `class ${symbol} extends $PARENT { $$$BODY }`,
+        );
+        for (const m of extendsMatches) {
+          const parent = m.getMatch('PARENT');
+          if (parent) extendsParent.push(parent.text());
+        }
+      } catch {
+        /* skip */
+      }
+
+      try {
+        const implMatches = parsed.root.findAll(
+          `class ${symbol} implements $IFACE { $$$BODY }`,
+        );
+        for (const m of implMatches) {
+          const iface = m.getMatch('IFACE');
+          if (iface) implementsInterfaces.push(iface.text());
+        }
+      } catch {
+        /* skip */
+      }
+
+      // Find what extends/implements the symbol
+      try {
+        const childMatches = parsed.root.findAll(
+          `class $NAME extends ${symbol} { $$$BODY }`,
+        );
+        for (const m of childMatches) {
+          const name = m.getMatch('NAME');
+          if (name) {
+            extendedBy.push({
+              name: name.text(),
+              file: relPath,
+              line: m.range().start.line + 1,
+            });
+          }
+        }
+      } catch {
+        /* skip */
+      }
+
+      try {
+        const implByMatches = parsed.root.findAll(
+          `class $NAME implements ${symbol} { $$$BODY }`,
+        );
+        for (const m of implByMatches) {
+          const name = m.getMatch('NAME');
+          if (name) {
+            implementedBy.push({
+              name: name.text(),
+              file: relPath,
+              line: m.range().start.line + 1,
+            });
+          }
+        }
+      } catch {
+        /* skip */
+      }
+    }
+
+    return {
+      mode: 'hierarchy',
+      symbol,
+      truncated: false,
+      results: {
+        extends: extendsParent,
+        implements: implementsInterfaces,
+        extendedBy,
+        implementedBy,
+      },
+    };
+  }
+
+  // ===== CALLERS =====
+  // @plan PLAN-20260211-ASTGREP.P09
+  private async executeCallers(
+    symbol: string,
+    lang: string | Lang,
+    searchPath: string,
+    workspaceRoot: string,
+    depth: number,
+    maxNodes: number,
+    signal: AbortSignal,
+  ): Promise<AnalysisResult> {
+    const files = await this.getFiles(searchPath, lang);
+    const visited = new Set<string>();
+    let nodesVisited = 0;
+    let truncated = false;
+
+    interface CallerEntry {
+      method: string;
+      file: string;
+      line: number;
+      via: string;
+      callers?: CallerEntry[];
+    }
+
+    const findCallersOf = async (
+      sym: string,
+      currentDepth: number,
+    ): Promise<CallerEntry[]> => {
+      if (currentDepth <= 0 || nodesVisited >= maxNodes || signal.aborted) {
+        if (nodesVisited >= maxNodes) truncated = true;
+        return [];
+      }
+
+      const callers: CallerEntry[] = [];
+
+      for (const file of files) {
+        if (signal.aborted || nodesVisited >= maxNodes) break;
+        const parsed = await this.parseFile(file, lang);
+        if (!parsed) continue;
+
+        const relPath = makeRelative(file, workspaceRoot);
+
+        // Find all member-expression calls to the symbol: $OBJ.sym(...)
+        try {
+          const memberCalls = parsed.root.findAll({
+            rule: {
+              kind: 'member_expression',
+              has: {
+                kind: 'property_identifier',
+                regex: `^${this.escapeRegex(sym)}$`,
+              },
+            },
+          } as NapiConfig);
+
+          for (const callNode of memberCalls) {
+            if (nodesVisited >= maxNodes) {
+              truncated = true;
+              break;
+            }
+
+            // Walk up to the nearest function-like container
+            let container: SgNode | null = callNode.parent();
+            while (
+              container &&
+              !StructuralAnalysisInvocation.FUNCTION_CONTAINER_KINDS.has(
+                String(container.kind()),
+              )
+            ) {
+              container = container.parent();
+            }
+            if (!container) continue;
+
+            const methodName = this.getContainerName(container);
+            if (!methodName || methodName === sym) continue;
+
+            const key = `${methodName}@${relPath}`;
+            if (visited.has(key)) continue;
+            visited.add(key);
+            nodesVisited++;
+
+            // Get via context from surrounding statement
+            let viaText = '';
+            let node: SgNode = callNode;
+            let parentNode = node.parent();
+            while (parentNode) {
+              const parentKind = String(parentNode.kind());
+              if (
+                parentKind.includes('statement') ||
+                StructuralAnalysisInvocation.FUNCTION_CONTAINER_KINDS.has(
+                  parentKind,
+                )
+              ) {
+                break;
+              }
+              node = parentNode;
+              parentNode = node.parent();
+            }
+            viaText = node.text().trim().substring(0, 200);
+
+            const entry: CallerEntry = {
+              method: methodName,
+              file: relPath,
+              line: container.range().start.line + 1,
+              via: viaText,
+            };
+
+            if (currentDepth > 1 && nodesVisited < maxNodes) {
+              entry.callers = await findCallersOf(methodName, currentDepth - 1);
+            }
+
+            callers.push(entry);
+          }
+        } catch {
+          /* skip */
+        }
+
+        // Also check for direct (non-member) calls: foo() rather than obj.foo()
+        try {
+          const directCallNodes = parsed.root.findAll(`${sym}($$$ARGS)`);
+
+          for (const callNode of directCallNodes) {
+            // Walk up to the nearest function-like container
+            let ancestor: SgNode | null = callNode.parent();
+            while (
+              ancestor &&
+              !StructuralAnalysisInvocation.FUNCTION_CONTAINER_KINDS.has(
+                String(ancestor.kind()),
+              )
+            ) {
+              ancestor = ancestor.parent();
+            }
+            if (!ancestor) continue;
+
+            const methodName = this.getContainerName(ancestor);
+            if (!methodName || methodName === sym) continue;
+
+            const key = `${methodName}@${relPath}`;
+            if (visited.has(key)) continue;
+            visited.add(key);
+            nodesVisited++;
+
+            callers.push({
+              method: methodName,
+              file: relPath,
+              line: ancestor.range().start.line + 1,
+              via: `${sym}(...)`,
+            });
+          }
+        } catch {
+          /* skip */
+        }
+      }
+
+      return callers;
+    };
+
+    const results = await findCallersOf(symbol, depth);
+
+    return {
+      mode: 'callers',
+      symbol,
+      truncated,
+      results,
+    };
+  }
+
+  // ===== CALLEES =====
+  // @plan PLAN-20260211-ASTGREP.P09
+  private async executeCallees(
+    symbol: string,
+    lang: string | Lang,
+    searchPath: string,
+    workspaceRoot: string,
+    depth: number,
+    maxNodes: number,
+    signal: AbortSignal,
+  ): Promise<AnalysisResult> {
+    const files = await this.getFiles(searchPath, lang);
+    const visited = new Set<string>();
+    let nodesVisited = 0;
+    let truncated = false;
+
+    interface CalleeEntry {
+      text: string;
+      file: string;
+      line: number;
+      callees?: CalleeEntry[];
+    }
+
+    const findCalleesOf = async (
+      sym: string,
+      currentDepth: number,
+    ): Promise<CalleeEntry[]> => {
+      if (currentDepth <= 0 || nodesVisited >= maxNodes || signal.aborted) {
+        if (nodesVisited >= maxNodes) truncated = true;
+        return [];
+      }
+
+      const callees: CalleeEntry[] = [];
+
+      for (const file of files) {
+        if (signal.aborted) break;
+        const parsed = await this.parseFile(file, lang);
+        if (!parsed) continue;
+
+        const relPath = makeRelative(file, workspaceRoot);
+
+        try {
+          // Find the method definition
+          const methodMatches = parsed.root.findAll({
+            rule: {
+              kind: 'method_definition',
+              has: {
+                kind: 'property_identifier',
+                regex: `^${this.escapeRegex(sym)}$`,
+              },
+            },
+          } as NapiConfig);
+
+          for (const methodNode of methodMatches) {
+            // Find all call expressions inside
+            const callMatches = methodNode.findAll({
+              rule: { kind: 'call_expression' },
+            } as NapiConfig);
+
+            // Byte-range deduplication: keep only outermost calls
+            const ranges = callMatches.map((c: SgNode) => ({
+              node: c,
+              start: c.range().start.index,
+              end: c.range().end.index,
+            }));
+            ranges.sort(
+              (
+                a: { start: number; end: number },
+                b: { start: number; end: number },
+              ) => a.start - b.start || b.end - a.end,
+            );
+
+            const outermost: typeof ranges = [];
+            for (const r of ranges) {
+              const isContained = outermost.some(
+                (o: { start: number; end: number }) =>
+                  r.start >= o.start && r.end <= o.end,
+              );
+              if (!isContained) outermost.push(r);
+            }
+
+            for (const { node } of outermost) {
+              const callText = node.text().substring(0, 200);
+              const key = `${callText}@${relPath}`;
+              if (visited.has(key)) continue;
+              visited.add(key);
+              nodesVisited++;
+
+              const entry: CalleeEntry = {
+                text: callText,
+                file: relPath,
+                line: node.range().start.line + 1,
+              };
+
+              // Recurse for depth > 1: extract callee name and follow it
+              if (currentDepth > 1 && nodesVisited < maxNodes) {
+                const calleeName = this.extractCalleeName(node);
+                if (calleeName && calleeName !== sym) {
+                  entry.callees = await findCalleesOf(
+                    calleeName,
+                    currentDepth - 1,
+                  );
+                }
+              }
+
+              callees.push(entry);
+            }
+          }
+        } catch {
+          /* skip */
+        }
+      }
+
+      return callees;
+    };
+
+    const results = await findCalleesOf(symbol, depth);
+
+    return {
+      mode: 'callees',
+      symbol,
+      truncated,
+      results,
+    };
+  }
+
+  // ===== REFERENCES =====
+  // @plan PLAN-20260211-ASTGREP.P10
+  private async executeReferences(
+    symbol: string,
+    lang: string | Lang,
+    searchPath: string,
+    workspaceRoot: string,
+    signal: AbortSignal,
+  ): Promise<AnalysisResult> {
+    const files = await this.getFiles(searchPath, lang);
+    const categories: Record<
+      string,
+      Array<{ file: string; line: number; text: string }>
+    > = {
+      'Direct calls': [],
+      'Instance method calls (heuristic)': [],
+      Instantiations: [],
+      'Type annotations': [],
+      'Extends/Implements': [],
+      Imports: [],
+    };
+
+    const seen = new Set<string>();
+    const addResult = (
+      category: string,
+      file: string,
+      line: number,
+      text: string,
+    ): void => {
+      const key = `${category}:${file}:${line}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+      categories[category].push({ file, line, text: text.substring(0, 200) });
+    };
+
+    for (const file of files) {
+      if (signal.aborted) break;
+      const parsed = await this.parseFile(file, lang);
+      if (!parsed) continue;
+
+      const relPath = makeRelative(file, workspaceRoot);
+
+      // Member calls: obj.symbol()
+      try {
+        const memberCalls = parsed.root.findAll(`$OBJ.${symbol}($$$ARGS)`);
+        for (const m of memberCalls) {
+          addResult(
+            'Direct calls',
+            relPath,
+            m.range().start.line + 1,
+            m.text(),
+          );
+        }
+      } catch {
+        /* skip */
+      }
+
+      // Standalone calls: symbol()
+      try {
+        const standaloneCalls = parsed.root.findAll(`${symbol}($$$ARGS)`);
+        for (const m of standaloneCalls) {
+          addResult(
+            'Direct calls',
+            relPath,
+            m.range().start.line + 1,
+            m.text(),
+          );
+        }
+      } catch {
+        /* skip */
+      }
+
+      // Instantiations: new Symbol(...)
+      try {
+        const news = parsed.root.findAll(`new ${symbol}($$$ARGS)`);
+        for (const m of news) {
+          addResult(
+            'Instantiations',
+            relPath,
+            m.range().start.line + 1,
+            m.text(),
+          );
+        }
+      } catch {
+        /* skip */
+      }
+
+      // Instance method calls (heuristic): calls on variables named like the symbol
+      try {
+        const lowerSymbol = symbol.charAt(0).toLowerCase() + symbol.slice(1);
+        const instanceCalls = parsed.root.findAll({
+          rule: {
+            kind: 'call_expression',
+            has: {
+              kind: 'member_expression',
+              has: {
+                kind: 'identifier',
+                regex: `(?i)${this.escapeRegex(lowerSymbol)}|${this.escapeRegex(symbol)}`,
+              },
+            },
+          },
+        } as NapiConfig);
+        for (const m of instanceCalls) {
+          addResult(
+            'Instance method calls (heuristic)',
+            relPath,
+            m.range().start.line + 1,
+            m.text(),
+          );
+        }
+      } catch {
+        /* skip */
+      }
+
+      // Type annotations
+      try {
+        const typeRefs = parsed.root.findAll({
+          rule: {
+            kind: 'type_annotation',
+            has: {
+              kind: 'type_identifier',
+              regex: `^${this.escapeRegex(symbol)}$`,
+            },
+          },
+        } as NapiConfig);
+        for (const m of typeRefs) {
+          addResult(
+            'Type annotations',
+            relPath,
+            m.range().start.line + 1,
+            m.text(),
+          );
+        }
+      } catch {
+        /* skip */
+      }
+
+      // Extends/Implements
+      try {
+        const heritage = parsed.root.findAll(
+          `class $NAME extends ${symbol} { $$$BODY }`,
+        );
+        for (const m of heritage) {
+          addResult(
+            'Extends/Implements',
+            relPath,
+            m.range().start.line + 1,
+            `class ${m.getMatch('NAME')?.text()} extends ${symbol}`,
+          );
+        }
+      } catch {
+        /* skip */
+      }
+
+      try {
+        const implHeritage = parsed.root.findAll(
+          `class $NAME implements ${symbol} { $$$BODY }`,
+        );
+        for (const m of implHeritage) {
+          addResult(
+            'Extends/Implements',
+            relPath,
+            m.range().start.line + 1,
+            `class ${m.getMatch('NAME')?.text()} implements ${symbol}`,
+          );
+        }
+      } catch {
+        /* skip */
+      }
+
+      // Imports
+      try {
+        const imports = parsed.root.findAll({
+          rule: {
+            kind: 'import_specifier',
+            has: { kind: 'identifier', regex: `^${this.escapeRegex(symbol)}$` },
+          },
+        } as NapiConfig);
+        for (const m of imports) {
+          addResult('Imports', relPath, m.range().start.line + 1, m.text());
+        }
+      } catch {
+        /* skip */
+      }
+    }
+
+    // Build counts
+    const counts: Record<string, number> = {};
+    for (const [cat, items] of Object.entries(categories)) {
+      counts[cat] = items.length;
+    }
+
+    return {
+      mode: 'references',
+      symbol,
+      truncated: false,
+      results: { categories, counts },
+    };
+  }
+
+  // ===== DEPENDENCIES =====
+  // @plan PLAN-20260211-ASTGREP.P10
+  private async executeDependencies(
+    searchPath: string,
+    lang: string | Lang,
+    workspaceRoot: string,
+    reverse: boolean,
+    signal: AbortSignal,
+  ): Promise<AnalysisResult> {
+    const files = await this.getFiles(searchPath, lang);
+    const imports: Array<{
+      file: string;
+      line: number;
+      source: string;
+      kind: string;
+    }> = [];
+
+    for (const file of files) {
+      if (signal.aborted) break;
+      const parsed = await this.parseFile(file, lang);
+      if (!parsed) continue;
+
+      const relPath = makeRelative(file, workspaceRoot);
+
+      // Named imports: import { X } from 'Y'
+      try {
+        const named = parsed.root.findAll(`import { $$$NAMES } from $SOURCE`);
+        for (const m of named) {
+          const src = m.getMatch('SOURCE');
+          if (src) {
+            imports.push({
+              file: relPath,
+              line: m.range().start.line + 1,
+              source: src.text().replace(/['"]/g, ''),
+              kind: 'named',
+            });
+          }
+        }
+      } catch {
+        /* skip */
+      }
+
+      // Default imports: import X from 'Y'
+      try {
+        const defaults = parsed.root.findAll(`import $DEFAULT from $SOURCE`);
+        for (const m of defaults) {
+          const src = m.getMatch('SOURCE');
+          if (src) {
+            imports.push({
+              file: relPath,
+              line: m.range().start.line + 1,
+              source: src.text().replace(/['"]/g, ''),
+              kind: 'default',
+            });
+          }
+        }
+      } catch {
+        /* skip */
+      }
+
+      // Dynamic imports: import('X')
+      try {
+        const dynamic = parsed.root.findAll({
+          rule: {
+            kind: 'call_expression',
+            has: { kind: 'import' },
+          },
+        } as NapiConfig);
+        for (const m of dynamic) {
+          imports.push({
+            file: relPath,
+            line: m.range().start.line + 1,
+            source: m.text(),
+            kind: 'dynamic',
+          });
+        }
+      } catch {
+        /* skip */
+      }
+
+      // Re-exports: export { X } from 'Y'
+      try {
+        const reexports = parsed.root.findAll({
+          rule: {
+            kind: 'export_statement',
+            has: { kind: 'string', regex: '.' },
+          },
+        } as NapiConfig);
+        for (const m of reexports) {
+          if (m.text().includes('from')) {
+            imports.push({
+              file: relPath,
+              line: m.range().start.line + 1,
+              source: m.text().substring(0, 200),
+              kind: 'reexport',
+            });
+          }
+        }
+      } catch {
+        /* skip */
+      }
+    }
+
+    const reverseImports: typeof imports = [];
+    if (reverse) {
+      // Find files that import the target
+      const allFiles = await this.getFiles(workspaceRoot, lang);
+      const targetRel = makeRelative(searchPath, workspaceRoot);
+      for (const file of allFiles) {
+        if (signal.aborted) break;
+        const parsed = await this.parseFile(file, lang);
+        if (!parsed) continue;
+        const relPath = makeRelative(file, workspaceRoot);
+        if (relPath === targetRel) continue;
+
+        const content = parsed.content || '';
+        if (content.includes(path.basename(searchPath).replace(/\.\w+$/, ''))) {
+          try {
+            const allImports = parsed.root.findAll({
+              rule: { kind: 'import_statement' },
+            } as NapiConfig);
+            for (const m of allImports) {
+              const text = m.text();
+              if (
+                text.includes(path.basename(searchPath).replace(/\.\w+$/, ''))
+              ) {
+                reverseImports.push({
+                  file: relPath,
+                  line: m.range().start.line + 1,
+                  source: text.substring(0, 200),
+                  kind: 'import',
+                });
+              }
+            }
+          } catch {
+            /* skip */
+          }
+        }
+      }
+    }
+
+    return {
+      mode: 'dependencies',
+      truncated: false,
+      results: {
+        imports,
+        reverseImports: reverse ? reverseImports : undefined,
+      },
+    };
+  }
+
+  // ===== EXPORTS =====
+  // @plan PLAN-20260211-ASTGREP.P10
+  private async executeExports(
+    searchPath: string,
+    lang: string | Lang,
+    workspaceRoot: string,
+    signal: AbortSignal,
+  ): Promise<AnalysisResult> {
+    const files = await this.getFiles(searchPath, lang);
+    const exports: Array<{
+      file: string;
+      line: number;
+      text: string;
+      kind: string;
+    }> = [];
+
+    for (const file of files) {
+      if (signal.aborted) break;
+      const parsed = await this.parseFile(file, lang);
+      if (!parsed) continue;
+
+      const relPath = makeRelative(file, workspaceRoot);
+
+      try {
+        const exportNodes = parsed.root.findAll({
+          rule: { kind: 'export_statement' },
+        } as NapiConfig);
+        for (const m of exportNodes) {
+          const text = m.text();
+          let kind = 'export';
+          if (/^export\s+default\b/.test(text)) kind = 'default';
+          else if (text.includes('class')) kind = 'class';
+          else if (text.includes('function')) kind = 'function';
+          else if (
+            text.includes('const') ||
+            text.includes('let') ||
+            text.includes('var')
+          )
+            kind = 'const';
+          else if (text.includes('interface')) kind = 'interface';
+          else if (text.includes('type ')) kind = 'type';
+          else if (text.includes('from')) kind = 'reexport';
+
+          exports.push({
+            file: relPath,
+            line: m.range().start.line + 1,
+            text: text.substring(0, 200),
+            kind,
+          });
+        }
+      } catch {
+        /* skip */
+      }
+    }
+
+    return {
+      mode: 'exports',
+      truncated: false,
+      results: exports,
+    };
+  }
+}
+
+export class StructuralAnalysisTool extends BaseDeclarativeTool<
+  StructuralAnalysisParams,
+  ToolResult
+> {
+  static readonly Name = 'structural_analysis';
+
+  constructor(
+    private readonly config: Config,
+    _messageBus?: MessageBus,
+  ) {
+    super(
+      StructuralAnalysisTool.Name,
+      'StructuralAnalysis',
+      'Performs multi-hop AST-based code analysis: call graphs, type hierarchies, symbol references, ' +
+        'module dependencies, and exports. This is name-based (not type-resolved) analysis. ' +
+        'Use for understanding code relationships. Unlike ast_grep (single-query), this chains multiple queries.',
+      Kind.Search,
+      {
+        properties: {
+          mode: {
+            description: `Analysis mode: ${VALID_MODES.join(', ')}`,
+            type: 'string',
+            enum: [...VALID_MODES],
+          },
+          language: {
+            description: 'Programming language (e.g., typescript, python)',
+            type: 'string',
+          },
+          path: {
+            description: 'Directory to search. Defaults to workspace root.',
+            type: 'string',
+          },
+          symbol: {
+            description:
+              'Symbol name for callers/callees/definitions/hierarchy/references modes.',
+            type: 'string',
+          },
+          depth: {
+            description:
+              'Recursion depth for callers/callees. Default 1, max 5.',
+            type: 'number',
+          },
+          maxNodes: {
+            description:
+              'Max symbols to visit during recursive traversal. Default 50.',
+            type: 'number',
+          },
+          target: {
+            description: 'File/directory for dependencies/exports modes.',
+            type: 'string',
+          },
+          reverse: {
+            description:
+              'For dependencies mode: also find what imports the target.',
+            type: 'boolean',
+          },
+        },
+        required: ['mode', 'language'],
+        type: 'object',
+      },
+    );
+  }
+
+  protected override createInvocation(
+    params: StructuralAnalysisParams,
+    _messageBus?: MessageBus,
+  ): ToolInvocation<StructuralAnalysisParams, ToolResult> {
+    return new StructuralAnalysisInvocation(this.config, params);
+  }
+}

--- a/packages/core/src/tools/tool-names.ts
+++ b/packages/core/src/tools/tool-names.ts
@@ -56,6 +56,11 @@ export const LIST_SUBAGENTS_TOOL = 'list_subagents';
 // Shell Tool
 export const SHELL_TOOL = 'shell';
 
+// @plan PLAN-20260211-ASTGREP.P04
+// AST Analysis Tools
+export const AST_GREP_TOOL = 'ast_grep';
+export const STRUCTURAL_ANALYSIS_TOOL = 'structural_analysis';
+
 /**
  * Union type of all tool names for type safety
  */
@@ -83,4 +88,6 @@ export type ToolName =
   | typeof TODO_WRITE_TOOL
   | typeof TODO_PAUSE_TOOL
   | typeof LIST_SUBAGENTS_TOOL
-  | typeof SHELL_TOOL;
+  | typeof SHELL_TOOL
+  | typeof AST_GREP_TOOL
+  | typeof STRUCTURAL_ANALYSIS_TOOL;

--- a/packages/core/src/utils/ast-grep-utils.test.ts
+++ b/packages/core/src/utils/ast-grep-utils.test.ts
@@ -1,0 +1,137 @@
+// @plan PLAN-20260211-ASTGREP.P02
+import { describe, it, expect } from 'vitest';
+import { Lang } from '@ast-grep/napi';
+import {
+  getAstLanguage,
+  resolveLanguageFromPath,
+  isAstGrepAvailable,
+  parseSource,
+  LANGUAGE_MAP,
+  JAVASCRIPT_FAMILY_EXTENSIONS,
+} from './ast-grep-utils.js';
+
+describe('ast-grep-utils', () => {
+  describe('LANGUAGE_MAP', () => {
+    it('should have ts mapped to Lang.TypeScript', () => {
+      expect(LANGUAGE_MAP['ts']).toBe(Lang.TypeScript);
+    });
+
+    it('should have py mapped to python', () => {
+      expect(LANGUAGE_MAP['py']).toBe('python');
+    });
+
+    it('should have all expected extensions', () => {
+      const expectedKeys = [
+        'ts',
+        'js',
+        'tsx',
+        'jsx',
+        'py',
+        'rb',
+        'go',
+        'rs',
+        'java',
+        'cpp',
+        'c',
+        'html',
+        'css',
+        'json',
+      ];
+      for (const key of expectedKeys) {
+        expect(LANGUAGE_MAP).toHaveProperty(key);
+      }
+    });
+  });
+
+  describe('JAVASCRIPT_FAMILY_EXTENSIONS', () => {
+    it('should include ts, js, tsx, jsx', () => {
+      expect(JAVASCRIPT_FAMILY_EXTENSIONS).toContain('ts');
+      expect(JAVASCRIPT_FAMILY_EXTENSIONS).toContain('js');
+      expect(JAVASCRIPT_FAMILY_EXTENSIONS).toContain('tsx');
+      expect(JAVASCRIPT_FAMILY_EXTENSIONS).toContain('jsx');
+    });
+  });
+
+  describe('getAstLanguage', () => {
+    it('should return Lang.TypeScript for ts extension', () => {
+      expect(getAstLanguage('ts')).toBe(Lang.TypeScript);
+    });
+
+    it('should return python for py extension', () => {
+      expect(getAstLanguage('py')).toBe('python');
+    });
+
+    it('should return Lang.TypeScript for full name typescript', () => {
+      expect(getAstLanguage('typescript')).toBe(Lang.TypeScript);
+    });
+
+    it('should return undefined for unknown extension', () => {
+      expect(getAstLanguage('unknown')).toBeUndefined();
+    });
+
+    it('should handle case-insensitive full names', () => {
+      expect(getAstLanguage('TypeScript')).toBe(Lang.TypeScript);
+      expect(getAstLanguage('Python')).toBe('python');
+    });
+  });
+
+  describe('resolveLanguageFromPath', () => {
+    it('should detect TypeScript from .ts extension', () => {
+      expect(resolveLanguageFromPath('foo.ts')).toBe(Lang.TypeScript);
+    });
+
+    it('should return undefined for unknown extension', () => {
+      expect(resolveLanguageFromPath('foo.xyz')).toBeUndefined();
+    });
+
+    it('should detect Python from nested path', () => {
+      expect(resolveLanguageFromPath('path/to/file.py')).toBe('python');
+    });
+
+    it('should detect JavaScript from .js extension', () => {
+      expect(resolveLanguageFromPath('index.js')).toBe(Lang.JavaScript);
+    });
+
+    it('should handle files with no extension', () => {
+      expect(resolveLanguageFromPath('Makefile')).toBeUndefined();
+    });
+  });
+
+  describe('isAstGrepAvailable', () => {
+    it('should return true when @ast-grep/napi is available', () => {
+      expect(isAstGrepAvailable()).toBe(true);
+    });
+  });
+
+  describe('parseSource', () => {
+    it('should parse valid TypeScript source', () => {
+      const result = parseSource(Lang.TypeScript, 'const x = 1;');
+      expect(result).toHaveProperty('root');
+      expect(result).not.toHaveProperty('error');
+    });
+
+    it('should return error for invalid source that cannot be parsed', () => {
+      // Note: tree-sitter is error-tolerant so most "invalid" code still parses.
+      // We test that parseSource returns a root even for malformed code
+      // (tree-sitter produces error nodes rather than failing entirely).
+      // The real error case is an unsupported language.
+      const result = parseSource(Lang.TypeScript, '}{');
+      // tree-sitter will parse this with error nodes but won't throw
+      expect(result).toHaveProperty('root');
+    });
+
+    it('should return error for unsupported language string', () => {
+      const result = parseSource(
+        'nonexistent_language' as unknown as string,
+        'code',
+      );
+      expect(result).toHaveProperty('error');
+      expect(result).not.toHaveProperty('root');
+    });
+
+    it('should parse Python source with dynamic language', () => {
+      const result = parseSource('python', 'x = 1');
+      expect(result).toHaveProperty('root');
+    });
+  });
+});

--- a/packages/core/src/utils/ast-grep-utils.ts
+++ b/packages/core/src/utils/ast-grep-utils.ts
@@ -1,0 +1,159 @@
+/**
+ * Shared AST-grep utilities for all tools that use @ast-grep/napi.
+ * Single source of truth for language mapping, parsing, and error normalization.
+ *
+ * @plan PLAN-20260211-ASTGREP.P03
+ */
+
+import {
+  parse,
+  Lang,
+  findInFiles,
+  registerDynamicLanguage,
+} from '@ast-grep/napi';
+
+import python from '@ast-grep/lang-python';
+import go from '@ast-grep/lang-go';
+import rust from '@ast-grep/lang-rust';
+import java from '@ast-grep/lang-java';
+import cpp from '@ast-grep/lang-cpp';
+import c from '@ast-grep/lang-c';
+import json from '@ast-grep/lang-json';
+import ruby from '@ast-grep/lang-ruby';
+
+import * as path from 'node:path';
+
+let dynamicLanguagesRegistered = false;
+
+function ensureDynamicLanguages(): void {
+  if (dynamicLanguagesRegistered) return;
+  registerDynamicLanguage({
+    python,
+    go,
+    rust,
+    java,
+    cpp,
+    c,
+    json,
+    ruby,
+  } as any); // eslint-disable-line @typescript-eslint/no-explicit-any -- Required for ast-grep dynamic language registration (third-party API limitation)
+  dynamicLanguagesRegistered = true;
+}
+
+// Register on module load
+ensureDynamicLanguages();
+
+/**
+ * File extension to ast-grep language mapping.
+ * Single source of truth across all AST tools.
+ */
+export const LANGUAGE_MAP: Record<string, string | Lang> = {
+  ts: Lang.TypeScript,
+  js: Lang.JavaScript,
+  tsx: Lang.Tsx,
+  jsx: Lang.Tsx,
+  py: 'python',
+  rb: 'ruby',
+  go: 'go',
+  rs: 'rust',
+  java: 'java',
+  cpp: 'cpp',
+  c: 'c',
+  html: Lang.Html,
+  css: Lang.Css,
+  json: 'json',
+};
+
+/**
+ * Reverse mapping from full language names to Lang/string values.
+ */
+const LANGUAGE_NAME_MAP: Record<string, string | Lang> = {
+  typescript: Lang.TypeScript,
+  javascript: Lang.JavaScript,
+  tsx: Lang.Tsx,
+  jsx: Lang.Tsx,
+  python: 'python',
+  ruby: 'ruby',
+  go: 'go',
+  rust: 'rust',
+  java: 'java',
+  cpp: 'cpp',
+  c: 'c',
+  html: Lang.Html,
+  css: Lang.Css,
+  json: 'json',
+};
+
+/**
+ * File extensions that belong to the JavaScript/TypeScript language family.
+ */
+export const JAVASCRIPT_FAMILY_EXTENSIONS: readonly string[] = [
+  'ts',
+  'js',
+  'tsx',
+  'jsx',
+];
+
+/**
+ * Resolve a file extension or language name to an ast-grep language.
+ * Accepts both extensions ('ts', 'py') and full names ('typescript', 'python').
+ * Returns undefined for unrecognized inputs.
+ */
+export function getAstLanguage(extOrName: string): string | Lang | undefined {
+  // Try extension first
+  const byExt = LANGUAGE_MAP[extOrName];
+  if (byExt !== undefined) return byExt;
+
+  // Try full name (case-insensitive)
+  const lower = extOrName.toLowerCase();
+  const byName = LANGUAGE_NAME_MAP[lower];
+  if (byName !== undefined) return byName;
+
+  return undefined;
+}
+
+/**
+ * Detect the ast-grep language from a file path's extension.
+ * Returns undefined if the extension is not recognized.
+ */
+export function resolveLanguageFromPath(
+  filePath: string,
+): string | Lang | undefined {
+  const ext = path.extname(filePath).slice(1); // remove the dot
+  if (!ext) return undefined;
+  return LANGUAGE_MAP[ext];
+}
+
+/**
+ * Check if @ast-grep/napi is available and usable.
+ */
+export function isAstGrepAvailable(): boolean {
+  try {
+    // If we got this far, the import succeeded
+    return typeof parse === 'function' && typeof findInFiles === 'function';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Parse source code with error normalization.
+ * Returns { root } on success or { error } on failure.
+ * Does not throw.
+ */
+export function parseSource(
+  language: string | Lang,
+  content: string,
+): { root: ReturnType<typeof parse> } | { error: string } {
+  try {
+    ensureDynamicLanguages();
+    const result = parse(language as Lang, content);
+    return { root: result };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { error: `Failed to parse source: ${message}` };
+  }
+}
+
+// Re-export ast-grep APIs for convenience
+export { parse, Lang, findInFiles } from '@ast-grep/napi';

--- a/project-plans/issue1130/PLAN.md
+++ b/project-plans/issue1130/PLAN.md
@@ -1,0 +1,602 @@
+# Plan: AST-Grep Tooling
+
+Plan ID: PLAN-20260211-ASTGREP
+Generated: 2026-02-11
+Total Phases: 12 (P01–P12)
+Requirements: REQ-ASTGREP-001 through REQ-ASTGREP-016, REQ-SA-001 through REQ-SA-008, REQ-SA-CALLERS-001 through REQ-SA-CALLERS-006, REQ-SA-CALLEES-001 through REQ-SA-CALLEES-003, REQ-SA-DEFS-001, REQ-SA-HIER-001/002, REQ-SA-REFS-001 through REQ-SA-REFS-003, REQ-SA-DEPS-001/002, REQ-SA-EXPORTS-001, REQ-INFRA-001 through REQ-INFRA-007
+
+## Critical Reminders
+
+Before implementing ANY phase, ensure you have:
+
+1. Completed preflight verification (Phase P01)
+2. Verified @ast-grep/napi APIs work as assumed (parse, findInFiles, SgNode)
+3. Written tests BEFORE implementation code (test phase precedes impl phase)
+4. Verified all imports, types, and dependencies exist as assumed
+
+---
+
+## Requirements Traceability Matrix
+
+| Requirement | Phase (Test) | Phase (Impl) |
+|-------------|-------------|--------------|
+| REQ-INFRA-001 (napi integration) | — | P03 |
+| REQ-INFRA-002 (shared utils) | P02 | P03 |
+| REQ-INFRA-003 (graceful degradation) | P11 | P12 |
+| REQ-INFRA-004 (tool defaults) | — | P05, P07 |
+| REQ-INFRA-005 (no test file dep) | all | all |
+| REQ-INFRA-006 (timeouts) | P11 | P12 |
+| REQ-INFRA-007 (existing compat) | P11 | P12 |
+| REQ-ASTGREP-001 (registration) | P04 | P05 |
+| REQ-ASTGREP-002 (pattern search) | P04 | P05 |
+| REQ-ASTGREP-003 (rule search) | P04 | P05 |
+| REQ-ASTGREP-004 (mutual exclusion) | P04 | P05 |
+| REQ-ASTGREP-005 (default path) | P04 | P05 |
+| REQ-ASTGREP-006 (workspace boundary) | P04 | P05 |
+| REQ-ASTGREP-007 (result format) | P04 | P05 |
+| REQ-ASTGREP-008 (result limit) | P04 | P05 |
+| REQ-ASTGREP-009 (empty results) | P04 | P05 |
+| REQ-ASTGREP-010 (glob filtering) | P04 | P05 |
+| REQ-ASTGREP-011 (invalid pattern error) | P04 | P05 |
+| REQ-ASTGREP-012 (unavailable engine) | P11 | P12 |
+| REQ-ASTGREP-013 (language detect) | P04 | P05 |
+| REQ-ASTGREP-014 (tool description) | — | P05 |
+| REQ-ASTGREP-015 (cancellation) | P04 | P05 |
+| REQ-ASTGREP-016 (per-file errors) | P04 | P05 |
+| REQ-SA-001 (registration) | P06 | P07 |
+| REQ-SA-002 (mode parameter) | P06 | P07 |
+| REQ-SA-003 (language param) | P06 | P07 |
+| REQ-SA-004 (tool description) | — | P07 |
+| REQ-SA-005 (workspace boundary) | P06 | P07 |
+| REQ-SA-006 (cancellation) | P06 | P07 |
+| REQ-SA-007 (empty results) | P06 | P07 |
+| REQ-SA-008 (path output format) | P06 | P07 |
+| REQ-SA-DEFS-001 (definitions) | P06 | P07 |
+| REQ-SA-HIER-001 (upward hierarchy) | P06 | P07 |
+| REQ-SA-HIER-002 (downward hierarchy) | P06 | P07 |
+| REQ-SA-CALLERS-001–006 | P08 | P09 |
+| REQ-SA-CALLEES-001–003 | P08 | P09 |
+| REQ-SA-REFS-001–003 | P10 | P10 |
+| REQ-SA-DEPS-001/002 | P10 | P10 |
+| REQ-SA-EXPORTS-001 | P10 | P10 |
+
+---
+
+## Architecture Overview
+
+```
+packages/core/src/
+├── tools/
+│   ├── ast-grep.ts                    # NEW: ast_grep tool
+│   ├── ast-grep.test.ts               # NEW: tests
+│   ├── structural-analysis.ts         # NEW: structural_analysis tool
+│   ├── structural-analysis.test.ts    # NEW: tests
+│   ├── ast-edit.ts                    # MODIFY: use shared utils
+│   └── tool-names.ts                  # MODIFY: add constants
+├── utils/
+│   ├── ast-grep-utils.ts             # NEW: shared ast-grep utilities
+│   └── ast-grep-utils.test.ts        # NEW: tests
+├── config/
+│   └── config.ts                      # MODIFY: register new tools
+└── prompt-config/
+    └── defaults/
+        ├── tools/ast-grep.md          # NEW: tool prompt
+        ├── tools/structural-analysis.md # NEW: tool prompt
+        └── tool-defaults.ts           # MODIFY: add entries
+```
+
+Key decisions:
+- Use `@ast-grep/napi` (already a dependency) — NOT the `sg` CLI binary
+- Extract shared language mapping + parse helpers from `ast-edit.ts` into `ast-grep-utils.ts`
+- Both new tools extend `BaseDeclarativeTool` (like RipGrepTool, GrepTool)
+- Both tools use `Config` for workspace root and path validation
+
+---
+
+# Phase P01: Preflight Verification
+
+## Phase ID
+`PLAN-20260211-ASTGREP.P01`
+
+## Prerequisites
+- Branch `issue1130` exists and is clean
+
+## Tasks
+
+### Verify @ast-grep/napi availability and APIs
+```bash
+npm ls @ast-grep/napi
+```
+
+### Verify parse + findAll + getMatch behavior
+```bash
+node -e "
+const { parse, Lang } = require('@ast-grep/napi');
+const root = parse(Lang.TypeScript, 'class Foo extends Bar { hello() { this.world(); } }');
+const matches = root.root().findAll('\$OBJ.world()');
+console.log('matches:', matches.length);
+if (matches.length > 0) {
+  const m = matches[0];
+  console.log('text:', m.text());
+  console.log('kind:', m.kind());
+  console.log('range:', JSON.stringify(m.range()));
+  const env = m.getMatch('OBJ');
+  console.log('metavar OBJ:', env ? env.text() : 'null');
+}
+"
+```
+Expected: 1 match, text=`this.world()`, kind=`call_expression`, metavar OBJ=`this`
+
+### Verify findInFiles API and callback contract
+```bash
+node -e "
+const { findInFiles, Lang } = require('@ast-grep/napi');
+findInFiles({
+  paths: ['packages/core/src/config/config.ts'],
+  language: Lang.TypeScript,
+  matcher: { rule: { kind: 'class_declaration' } }
+}, (err, nodes) => {
+  // Verify callback shape: err is null on success, nodes is array of SgNode
+  console.log('callback err:', err);
+  console.log('callback nodes type:', Array.isArray(nodes) ? 'array' : typeof nodes);
+  console.log('callback nodes count:', nodes.length);
+  if (nodes.length > 0) {
+    const n = nodes[0];
+    console.log('node has text():', typeof n.text === 'function');
+    console.log('node has kind():', typeof n.kind === 'function');
+    console.log('node has range():', typeof n.range === 'function');
+    console.log('node has getMatch():', typeof n.getMatch === 'function');
+  }
+  return nodes;
+}).then(r => {
+  console.log('findInFiles resolved, file count:', r.length);
+}).catch(e => console.log('Error:', e.message));
+"
+```
+Expected: callback receives null err, array of SgNode objects with text/kind/range/getMatch methods
+
+### Verify existing exports in ast-edit.ts
+```bash
+grep -n 'export const LANGUAGE_MAP\|export const JAVASCRIPT_FAMILY' packages/core/src/tools/ast-edit.ts
+```
+
+### Verify tool registration pattern
+```bash
+grep -c 'registerCoreTool' packages/core/src/config/config.ts
+```
+
+### Blocking issues
+If any check fails, document the issue and stop.
+
+---
+
+# Phase P02: Shared AST Utilities — Tests
+
+## Phase ID
+`PLAN-20260211-ASTGREP.P02`
+
+## Prerequisites
+- Phase P01 completed
+
+## Requirements Implemented
+
+### REQ-INFRA-002: Shared AST Utilities
+**Full Text**: AST operations common to ast_grep, structural_analysis, ast_edit, and ast_read_file shall be factored into a shared utility module.
+**Behavior**:
+- GIVEN: A test imports `getAstLanguage` from `ast-grep-utils`
+- WHEN: Called with extension `'ts'`
+- THEN: Returns `Lang.TypeScript`
+**Why This Matters**: Single source of truth for language mapping
+
+## Implementation Tasks
+
+### Files to Create
+- `packages/core/src/utils/ast-grep-utils.test.ts`
+  - MUST include: `@plan PLAN-20260211-ASTGREP.P02`
+  - Test: `getAstLanguage('ts')` → `Lang.TypeScript`
+  - Test: `getAstLanguage('py')` → `'python'`
+  - Test: `getAstLanguage('unknown')` → `undefined`
+  - Test: `resolveLanguageFromPath('foo.ts')` → `Lang.TypeScript`
+  - Test: `resolveLanguageFromPath('foo.xyz')` → `undefined`
+  - Test: `isAstGrepAvailable()` → `true`
+  - Test: `parseSource(Lang.TypeScript, 'const x = 1;')` → success
+  - Test: `parseSource(Lang.TypeScript, '}{invalid')` → error (not throw)
+
+## Verification
+```bash
+test -f packages/core/src/utils/ast-grep-utils.test.ts && echo "OK"
+npm run typecheck
+```
+
+---
+
+# Phase P03: Shared AST Utilities — Implementation
+
+## Phase ID
+`PLAN-20260211-ASTGREP.P03`
+
+## Prerequisites
+- Phase P02 completed (failing tests exist)
+
+## Requirements Implemented
+### REQ-INFRA-001: napi integration, REQ-INFRA-002: shared utils
+
+## Implementation Tasks
+
+### Files to Create
+- `packages/core/src/utils/ast-grep-utils.ts`
+  - MUST include: `@plan PLAN-20260211-ASTGREP.P03`
+  - Extract from ast-edit.ts: `LANGUAGE_MAP`, `JAVASCRIPT_FAMILY_EXTENSIONS`, dynamic language registration
+  - New exports: `getAstLanguage()`, `resolveLanguageFromPath()`, `isAstGrepAvailable()`, `parseSource()`
+
+### Files to Modify
+- `packages/core/src/tools/ast-edit.ts`
+  - Replace local LANGUAGE_MAP, JAVASCRIPT_FAMILY_EXTENSIONS, language registration with imports from `../utils/ast-grep-utils.js`
+  - ALL existing behavior unchanged
+  - ADD: `@plan PLAN-20260211-ASTGREP.P03`
+
+## Verification
+```bash
+npm test -- --run packages/core/src/utils/ast-grep-utils.test.ts
+npm test -- --run packages/core/src/tools/ast-edit.test.ts
+npm run test && npm run typecheck
+```
+
+---
+
+# Phase P04: ast_grep Tool — Tests
+
+## Phase ID
+`PLAN-20260211-ASTGREP.P04`
+
+## Prerequisites
+- Phase P03 completed
+
+## Requirements Implemented
+### REQ-ASTGREP-002 through REQ-ASTGREP-016 (test side)
+
+## Implementation Tasks
+
+### Files to Create
+- `packages/core/src/tools/ast-grep.test.ts`
+  - MUST include: `@plan PLAN-20260211-ASTGREP.P04`
+  - Use real temp files, real ast-grep parsing, no mocks of ast-grep
+
+  **REQ-ASTGREP-002**: pattern `$OBJ.foo()` finds `this.foo()`, doesn't find `// foo()` comment
+  **REQ-ASTGREP-003**: rule with `kind: call_expression` + `has` finds calls
+  **REQ-ASTGREP-004**: both pattern+rule → error; neither → error
+  **REQ-ASTGREP-005/006**: no path → workspace root; path outside → error
+  **REQ-ASTGREP-007**: result format: file (relative), startLine, startCol, endLine, endCol, text, nodeKind, metaVariables
+  **REQ-ASTGREP-008**: maxResults=2 on 5 matches → 2 returned, truncated=true
+  **REQ-ASTGREP-009**: no matches → empty array, truncated=false
+  **REQ-ASTGREP-011**: unparseable pattern → clear error message
+  **REQ-ASTGREP-010**: globs `["*.ts"]` includes only .ts files; globs `["!*.test.ts"]` excludes test files
+  **REQ-ASTGREP-013**: single .ts file auto-detects; directory without language → error
+  **REQ-ASTGREP-016**: binary file skipped, skippedFiles count
+
+### Files to Modify
+- `packages/core/src/tools/tool-names.ts`
+  - ADD: `export const AST_GREP_TOOL = 'ast_grep';`
+  - ADD to ToolName union type
+  - ADD: `@plan PLAN-20260211-ASTGREP.P04`
+
+## Verification
+```bash
+test -f packages/core/src/tools/ast-grep.test.ts && echo "OK"
+grep 'AST_GREP_TOOL' packages/core/src/tools/tool-names.ts
+npm run typecheck
+```
+
+---
+
+# Phase P05: ast_grep Tool — Implementation
+
+## Phase ID
+`PLAN-20260211-ASTGREP.P05`
+
+## Prerequisites
+- Phase P04 completed (failing tests)
+
+## Requirements Implemented
+### REQ-ASTGREP-001 through REQ-ASTGREP-016 (implementation)
+
+## Implementation Tasks
+
+### Files to Create
+- `packages/core/src/tools/ast-grep.ts`
+  - MUST include: `@plan PLAN-20260211-ASTGREP.P05`
+  - `AstGrepTool` extends `BaseDeclarativeTool<AstGrepToolParams, ToolResult>`
+  - Constructor: name `ast_grep`, Kind.Search, JSON schema
+  - Execute flow:
+    1. Validate exactly one of pattern/rule (REQ-ASTGREP-004)
+    2. Resolve path, validate workspace boundary (REQ-ASTGREP-005/006)
+    3. Language detection for single files (REQ-ASTGREP-013)
+    4. Pattern mode: iterate files, parseSource + root.findAll(pattern)
+    5. Rule mode: findInFiles with NapiConfig
+    6. Glob filtering via fast-glob (REQ-ASTGREP-010)
+    7. Map results: file (relative), line/col, text, nodeKind, metaVariables (REQ-ASTGREP-007)
+    8. Apply maxResults, set truncated (REQ-ASTGREP-008)
+    9. Per-file error handling: skip unparseable, count skippedFiles (REQ-ASTGREP-016)
+    10. AbortSignal check between files (REQ-ASTGREP-015)
+
+- `packages/core/src/prompt-config/defaults/tools/ast-grep.md`
+  - Tool description for LLM (REQ-ASTGREP-014)
+  - Explain: structural AST search, metavariable syntax, differs from search_file_content
+
+### Files to Modify
+- `packages/core/src/config/config.ts`
+  - Import and registerCoreTool(AstGrepTool, this)
+  - ADD: `@plan PLAN-20260211-ASTGREP.P05`
+- `packages/core/src/prompt-config/defaults/tool-defaults.ts`
+  - Add: `'tools/ast-grep.md': loadMarkdownFile('tools/ast-grep.md'),`
+
+## Verification
+```bash
+npm test -- --run packages/core/src/tools/ast-grep.test.ts
+npm test -- --run packages/core/src/tools/ast-edit.test.ts
+npm run test && npm run typecheck && npm run lint
+```
+
+---
+
+# Phase P06: structural_analysis — Definitions + Hierarchy Tests
+
+## Phase ID
+`PLAN-20260211-ASTGREP.P06`
+
+## Prerequisites
+- Phase P05 completed
+
+## Requirements Implemented
+### REQ-SA-001–008, REQ-SA-DEFS-001, REQ-SA-HIER-001/002 (test side)
+
+## Implementation Tasks
+
+### Files to Create
+- `packages/core/src/tools/structural-analysis.test.ts`
+  - MUST include: `@plan PLAN-20260211-ASTGREP.P06`
+  - Real temp files, no mocks
+
+  **REQ-SA-002**: invalid mode → error listing valid modes
+  **REQ-SA-003**: missing language → error
+  **REQ-SA-005**: path outside workspace → error
+  **REQ-SA-007**: nonexistent symbol → empty result
+  **REQ-SA-DEFS-001**: find class, function, interface, const by name; multi-file
+  **REQ-SA-HIER-001**: class extends → parent found; class implements → interface found
+  **REQ-SA-HIER-002**: parent → subclasses; interface → implementors
+
+### Files to Modify
+- `packages/core/src/tools/tool-names.ts`
+  - ADD: `export const STRUCTURAL_ANALYSIS_TOOL = 'structural_analysis';`
+  - ADD to ToolName union
+  - ADD: `@plan PLAN-20260211-ASTGREP.P06`
+
+## Verification
+```bash
+test -f packages/core/src/tools/structural-analysis.test.ts && echo "OK"
+grep 'STRUCTURAL_ANALYSIS_TOOL' packages/core/src/tools/tool-names.ts
+npm run typecheck
+```
+
+---
+
+# Phase P07: structural_analysis — Definitions + Hierarchy Implementation
+
+## Phase ID
+`PLAN-20260211-ASTGREP.P07`
+
+## Prerequisites
+- Phase P06 completed (failing tests)
+
+## Requirements Implemented
+### REQ-SA-001–008, REQ-SA-DEFS-001, REQ-SA-HIER-001/002 (implementation)
+
+## Implementation Tasks
+
+### Files to Create
+- `packages/core/src/tools/structural-analysis.ts`
+  - MUST include: `@plan PLAN-20260211-ASTGREP.P07`
+  - `StructuralAnalysisTool` extends `BaseDeclarativeTool`
+  - Schema: mode (enum), language, path, symbol, depth, maxNodes, target, reverse
+  - Mode dispatch: definitions → `executeDefinitions()`, hierarchy → `executeHierarchy()`, others → throw "mode not yet available"
+  - `executeDefinitions()`: findInFiles with rules for method_definition, function_declaration, class_declaration, interface_declaration, type_alias_declaration, variable_declarator matching symbol
+  - `executeHierarchy()`: patterns for extends/implements, reverse search for subclasses
+  - Workspace boundary, AbortSignal, relative path output
+
+- `packages/core/src/prompt-config/defaults/tools/structural-analysis.md`
+  - Tool description (REQ-SA-004)
+
+### Files to Modify
+- `packages/core/src/config/config.ts` — register StructuralAnalysisTool
+- `packages/core/src/prompt-config/defaults/tool-defaults.ts` — add entry
+
+## Verification
+```bash
+npm test -- --run packages/core/src/tools/structural-analysis.test.ts
+npm run test && npm run typecheck && npm run lint
+```
+
+---
+
+# Phase P08: structural_analysis — Callers + Callees Tests
+
+## Phase ID
+`PLAN-20260211-ASTGREP.P08`
+
+## Prerequisites
+- Phase P07 completed
+
+## Requirements Implemented
+### REQ-SA-CALLERS-001–006, REQ-SA-CALLEES-001–003 (test side)
+
+## Implementation Tasks
+
+### Files to Modify
+- `packages/core/src/tools/structural-analysis.test.ts`
+  - MUST include: `@plan PLAN-20260211-ASTGREP.P08`
+  - Multi-file temp dirs, real TS source
+
+  **Callers**: basic discovery, via context, depth 1 vs 2, cycle detection, maxNodes truncation, member/direct/optional-chaining
+  **Callees**: basic discovery, chained dedup, recursive depth
+
+## Verification
+```bash
+npm test -- --run packages/core/src/tools/structural-analysis.test.ts
+npm run typecheck
+```
+
+---
+
+# Phase P09: structural_analysis — Callers + Callees Implementation
+
+## Phase ID
+`PLAN-20260211-ASTGREP.P09`
+
+## Prerequisites
+- Phase P08 completed (failing tests)
+
+## Requirements Implemented
+### REQ-SA-CALLERS-001–006, REQ-SA-CALLEES-001–003 (implementation)
+
+## Implementation Tasks
+
+### Files to Modify
+- `packages/core/src/tools/structural-analysis.ts`
+  - MUST include: `@plan PLAN-20260211-ASTGREP.P09`
+  - `executeCallers()`: YAML rule — method_definition has (stopBy:end) call_expression with property_identifier regex matching symbol. Extract containing method, file, line, via text. Recurse with name+file visited set and maxNodes cap.
+  - `executeCallees()`: YAML rule — call_expression inside (stopBy:end) method_definition matching symbol. Byte-range dedup. Recurse with cycle detection.
+
+## Verification
+```bash
+npm test -- --run packages/core/src/tools/structural-analysis.test.ts
+npm run test && npm run typecheck && npm run lint
+```
+
+---
+
+# Phase P10: structural_analysis — References, Dependencies, Exports
+
+## Phase ID
+`PLAN-20260211-ASTGREP.P10`
+
+## Prerequisites
+- Phase P09 completed
+
+## Requirements Implemented
+### REQ-SA-REFS-001–003, REQ-SA-DEPS-001/002, REQ-SA-EXPORTS-001
+
+Tests and implementation together — each mode is a straightforward set of queries with no recursion or complex state.
+
+## Implementation Tasks
+
+### Files to Modify
+- `packages/core/src/tools/structural-analysis.test.ts`
+  - MUST include: `@plan PLAN-20260211-ASTGREP.P10`
+  - **References**: categorized results, counts, dedup, heuristic label
+  - **Dependencies**: all import forms, re-exports, CommonJS (JS/TS), reverse mode
+  - **Exports**: all export forms
+
+- `packages/core/src/tools/structural-analysis.ts`
+  - MUST include: `@plan PLAN-20260211-ASTGREP.P10`
+  - `executeReferences()`, `executeDependencies()`, `executeExports()`
+
+## Verification
+```bash
+npm test -- --run packages/core/src/tools/structural-analysis.test.ts
+npm run test && npm run typecheck && npm run lint
+```
+
+---
+
+# Phase P11: Integration Tests
+
+## Phase ID
+`PLAN-20260211-ASTGREP.P11`
+
+## Prerequisites
+- Phase P10 completed
+
+## Requirements Implemented
+### REQ-INFRA-003 (test), REQ-INFRA-006 (test), REQ-INFRA-007 (test)
+
+## Implementation Tasks
+
+### Files to Modify
+- `packages/core/src/tools/ast-grep.test.ts`
+  - MUST include: `@plan PLAN-20260211-ASTGREP.P11`
+  - Integration: pattern `registerCoreTool($TOOL, $$$REST)` against config.ts → finds registrations
+  - Integration: pattern on tools/ → finds BaseDeclarativeTool subclasses
+
+- `packages/core/src/tools/structural-analysis.test.ts`
+  - MUST include: `@plan PLAN-20260211-ASTGREP.P11`
+  - Integration: callers of `createToolRegistry` → finds `initialize`
+  - Integration: hierarchy of `ContentGenerator` → finds implementations
+
+## Verification
+```bash
+npm run test && npm run typecheck && npm run lint
+```
+
+---
+
+# Phase P12: Graceful Degradation, Timeouts, Final Cleanup
+
+## Phase ID
+`PLAN-20260211-ASTGREP.P12`
+
+## Prerequisites
+- Phase P11 completed
+
+## Requirements Implemented
+### REQ-INFRA-003, REQ-INFRA-006, REQ-INFRA-007
+
+## Implementation Tasks
+
+### Graceful Degradation (REQ-INFRA-003)
+- Wrap both tool registrations in config.ts in try/catch — if @ast-grep/napi fails, skip registration
+
+### Timeouts (REQ-INFRA-006)
+- ast_grep: 30s timeout
+- structural_analysis: 60s timeout
+- On timeout: partial results with truncated=true
+
+### Cleanup
+- Remove `@plan` markers from production code
+- Verify no TODO/FIXME/HACK in production files
+
+### Full Verification
+```bash
+npm run test
+npm run lint
+npm run typecheck
+npm run format
+npm run build
+node scripts/start.js --profile-load synthetic --keyfile ~/.llxprt/keys/.synthetic2_key "write me a haiku and nothing else"
+
+# Deferred implementation detection
+grep -rn -E "(TODO|FIXME|HACK|STUB|XXX)" packages/core/src/tools/ast-grep.ts packages/core/src/tools/structural-analysis.ts packages/core/src/utils/ast-grep-utils.ts
+# Expected: No matches
+
+# Feature reachability
+grep 'AstGrepTool' packages/core/src/config/config.ts
+grep 'StructuralAnalysisTool' packages/core/src/config/config.ts
+```
+
+---
+
+## Execution Tracker
+
+| Phase | ID | Status | Description |
+|-------|-----|--------|-------------|
+| P01 | P01 | ⬜ | Preflight verification |
+| P02 | P02 | ⬜ | Shared AST utilities — tests |
+| P03 | P03 | ⬜ | Shared AST utilities — implementation |
+| P04 | P04 | ⬜ | ast_grep tool — tests |
+| P05 | P05 | ⬜ | ast_grep tool — implementation |
+| P06 | P06 | ⬜ | structural_analysis — defs + hierarchy tests |
+| P07 | P07 | ⬜ | structural_analysis — defs + hierarchy implementation |
+| P08 | P08 | ⬜ | structural_analysis — callers + callees tests |
+| P09 | P09 | ⬜ | structural_analysis — callers + callees implementation |
+| P10 | P10 | ⬜ | References + dependencies + exports (tests + impl) |
+| P11 | P11 | ⬜ | Integration tests |
+| P12 | P12 | ⬜ | Graceful degradation, timeouts, cleanup |

--- a/project-plans/issue1130/overview.md
+++ b/project-plans/issue1130/overview.md
@@ -1,0 +1,263 @@
+# Issue #1130: AST-Grep Tooling
+
+## Overview
+
+Two new tools that give the LLM structural/semantic code understanding beyond what text-based grep provides. These tools are for the LLM to use during code analysis, not user-facing.
+
+**ast-grep** operates on syntax trees (via tree-sitter), not text. It matches code *structure* — a pattern like `$OBJ.getAsyncTaskManager()` matches only actual method calls, not comments, strings, or type annotations containing that text. It also captures metavariables: searching for `registerCoreTool($TOOL, $$$REST)` returns each match *and* extracts the `$TOOL` argument as structured data.
+
+---
+
+## Tool 1: `ast_grep`
+
+The raw ast-grep primitive exposed as a tool call.
+
+### Purpose
+
+Structural code search. The LLM uses this when it needs to find code patterns that regex can't express cleanly — specific call shapes, class declarations matching a structure, try/catch blocks, assignments to a property, etc.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `pattern` | string | yes (or `rule`) | ast-grep pattern string, e.g. `$OBJ.getAsyncTaskManager()`, `class $NAME extends $PARENT { $$$BODY }` |
+| `rule` | object | yes (or `pattern`) | YAML rule for complex queries using `kind`, `has`, `inside`, `stopBy`, `regex` etc. Needed for things pattern syntax can't express (e.g. finding method definitions by name, matching type annotations) |
+| `language` | string | yes | `typescript`, `python`, `rust`, `go`, `java`, etc. |
+| `path` | string | no | Directory or file to search. Defaults to workspace root. |
+| `globs` | string[] | no | File glob patterns to include/exclude (e.g. `["*.ts", "!*.test.ts"]`) |
+| `maxResults` | number | no | Cap the number of returned matches. Default 100. |
+
+### Returns
+
+- `truncated` — boolean, true if results were capped by `maxResults`
+- `totalMatches` — total match count (even if truncated)
+- `matches` — array, each containing:
+  - `file` — file path (relative to workspace root)
+  - `startLine`, `startCol`, `endLine`, `endCol` — precise location
+  - `text` — matched source text
+  - `nodeKind` — the AST node type of the match (e.g. `call_expression`, `class_declaration`)
+  - `metaVariables` — captured `$NAME`, `$OBJ`, `$$$ARGS` etc. as structured key/value pairs
+
+### What it handles well
+
+- **Method/function calls**: `$OBJ.foo($$$ARGS)` — finds only actual calls, not definitions or comments
+- **Optional chaining calls**: `$OBJ?.foo?.($$$ARGS)`
+- **Class hierarchy**: `class $NAME extends $PARENT { $$$BODY }` — extracts class name and parent
+- **Interface implementations**: `class $NAME implements $IFACE { $$$BODY }`
+- **Assignments**: `this.toolRegistry = $VALUE`
+- **Imports**: `import { $$$NAMES } from $SOURCE`
+- **Structural patterns**: `try { $$$TRYBLOCK } catch ($ERR) { $$$CATCHBLOCK }`
+- **Complex queries via YAML rules**: find method definitions by name, match type annotations, combine `kind` + `has` + `inside` + `regex`
+
+### What it doesn't handle
+
+- Patterns that produce multiple AST nodes (e.g. `async $METHOD(...)` fails — `async` is a separate node)
+- String literal internals are not tokenized as separate metavariable-friendly nodes — `from '$PATH'` won't work. Match the whole string node as `$SOURCE` instead.
+- Semantic analysis: no type resolution, no following through interfaces, no generic inference
+- Method definition matching is grammar-specific — TS/JS has regular methods, arrow functions assigned to consts, class fields, object literal methods, etc. Each has a different AST shape. YAML rules with `kind` are more reliable than pattern syntax for this.
+
+### Naming
+
+`ast_grep` — named by function (structural code search), not by the underlying binary (`sg`). Consistent with existing tool naming (`search_file_content` wraps ripgrep, `read_file` wraps fs).
+
+---
+
+## Tool 2: `structural_analysis`
+
+Higher-level analysis tool that chains multiple ast-grep queries internally to answer structural questions about code. This is syntax-graph analysis (AST-based, non-type-resolving) — not full semantic static analysis.
+
+### Purpose
+
+The LLM uses this when it needs to understand code relationships — call graphs, type hierarchies, symbol references, module dependencies. Each of these requires multiple ast-grep hops that the tool handles internally, returning assembled results.
+
+### Parameters
+
+Parameters are mode-specific. Common parameters:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `mode` | string | yes | One of: `callers`, `callees`, `definitions`, `hierarchy`, `references`, `dependencies`, `exports` |
+| `language` | string | yes | `typescript`, `python`, etc. |
+| `path` | string | no | Directory or file scope. Defaults to workspace root. |
+
+Symbol-scoped modes (`callers`, `callees`, `definitions`, `hierarchy`, `references`):
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `symbol` | string | yes | The function, method, class, or interface name to analyze |
+| `depth` | number | no | For `callers`/`callees`: how many levels to recurse. Default 1. Max 5. |
+| `maxNodes` | number | no | Max nodes to visit during recursive traversal. Default 50. Prevents explosion on common names like `get`. |
+
+File/module-scoped modes (`dependencies`, `exports`):
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `target` | string | yes | File or directory to analyze |
+| `reverse` | boolean | no | For `dependencies`: also find what imports the target. Default false. |
+
+All modes return a `truncated: boolean` flag indicating whether results were capped by limits.
+
+### Modes
+
+#### `definitions` — Where is this symbol defined?
+
+Finds the definition site(s) of a function, class, interface, type alias, or const. This is often the first hop before callers/callees.
+
+**How it works internally:** YAML rules matching `method_definition`, `function_declaration`, `class_declaration`, `interface_declaration`, `type_alias_declaration`, `variable_declarator` with `property_identifier` or `identifier` matching the symbol name.
+
+#### `callers` — Who calls this function/method?
+
+Finds all method/function definitions that contain a call to the given symbol. With `depth > 1`, recursively finds callers of callers. Includes cycle detection and early termination at `maxNodes`.
+
+Each caller result includes the containing method name AND the specific call-site line (`via:`) that links the caller to the callee, so the LLM can verify the connection.
+
+**How it works internally:** YAML rule — find `method_definition` nodes that `has` (with `stopBy: end`) a `call_expression` matching `$OBJ.<symbol>()`. Also matches direct calls `<symbol>()` and optional chaining `$OBJ?.<symbol>?.()`. For each result, extract the containing method name and recurse.
+
+**Example output (depth 2):**
+```
+createToolRegistry()
+  ← initialize()  config.ts:823
+    via: this.toolRegistry = await this.createToolRegistry();
+    ← getPrompt()  prompt-service.ts:189
+      via: await this.initialize();
+    ← loadPrompt()  prompt-service.ts:302
+      via: await this.initialize();
+```
+
+#### `callees` — What does this function/method call?
+
+Finds all call expressions inside the given function/method definition. Deduplicates chained subcalls — if `a.b().c()` is a call, `a.b()` is not listed separately. With `depth > 1`, recursively traces what those callees call. Includes cycle detection.
+
+**How it works internally:** YAML rule — find `call_expression` nodes `inside` (with `stopBy: end`) a `method_definition` whose `property_identifier` matches the symbol. Deduplication: for each match, discard calls whose byte range is fully contained within another match's byte range (keeping only outermost calls).
+
+**Example output:**
+```
+initialize()
+  → Error('Config was already initialized')  config.ts:825
+  → IdeClient.getInstance()  config.ts:828
+  → this.getFileService()  config.ts:830
+  → this.getGitService()  config.ts:832
+  → this.createToolRegistry()  config.ts:835
+  → Promise.all([...)  config.ts:841
+```
+
+#### `hierarchy` — Class/interface inheritance tree
+
+For a class: finds what it extends and implements, and what extends/implements it.
+For an interface: finds all classes that implement it.
+
+**How it works internally:** Combines `class $NAME extends $PARENT` and `class $NAME implements $IFACE` patterns across the codebase, then assembles the tree.
+
+**Example output:**
+```
+BaseDeclarativeTool
+  ← EditTool
+  ← ShellTool
+  ← RipGrepTool
+  ← GrepTool
+  ← ReadFileTool
+  ← WriteFileTool
+  ← ASTEditTool
+  ... (52 subclasses)
+```
+
+#### `references` — All structural references to a symbol
+
+Finds every place a symbol appears in a structurally meaningful way. Unlike text grep, this excludes comments and string literals.
+
+Categories searched:
+- **Method calls on instances**: calls on variables whose name matches or contains the symbol (e.g. `toolRegistry.register()`)
+- **Direct calls**: the symbol used as a function/method name (e.g. `$OBJ.createToolRegistry()`)
+- **Instantiations**: `new_expression` matches (e.g. `new ToolRegistry(...)`)
+- **Type annotations**: `type_annotation` containing the identifier
+- **Extends/implements**: class heritage clauses
+- **Imports**: import specifiers
+- **Re-exports**: `export { X } from` statements
+
+**How it works internally:** Runs multiple ast-grep queries per category, deduplicates, and groups results.
+
+**Example output:**
+```
+ToolRegistry — 135 references
+  Method calls on instances (75):
+    tool-registry.test.ts:142  toolRegistry.registerTool(tool)
+    tool-registry.test.ts:143  toolRegistry.getTool('mock-tool')
+    ...
+  Instantiations (6):
+    config.ts:1978        new ToolRegistry(this)
+    executor.ts:83        new ToolRegistry(runtimeContext)
+    ...
+  Type annotations (32):
+    coreToolScheduler.ts:384   : ToolRegistry
+    subagent.ts:150            : ToolRegistry
+    ...
+  Imports (22):
+    config.ts:15           import { ToolRegistry } from '../tools/tool-registry.js'
+    ...
+```
+
+#### `dependencies` — Import/export graph
+
+For a given file or directory, maps what it imports from where. With `reverse: true`, also finds what imports the target.
+
+Import forms matched:
+- Named imports: `import { X } from 'y'`
+- Default imports: `import X from 'y'`
+- Namespace imports: `import * as X from 'y'`
+- Side-effect imports: `import 'y'`
+- Dynamic imports: `import('y')`
+- Re-exports: `export { X } from 'y'`
+- CommonJS (when applicable): `require('y')`, `module.exports`
+
+#### `exports` — Module surface area
+
+Lists all exports from a file or directory — what symbols a module makes available.
+
+---
+
+## Key Limitations (both tools)
+
+These tools operate on **syntax trees, not semantics**. They match by name and structure, not by resolved types.
+
+- **No cross-interface dispatch**: if `foo(x: SomeInterface)` calls `x.bar()`, the tools can find the call to `bar()` but can't resolve which concrete implementation of `bar()` will run.
+- **No type alias resolution**: searching for `MyType` won't find usages of a type alias that points to `MyType`.
+- **No generic inference**: can't follow type parameters through generic functions.
+- **Name-based matching**: `callers` of `get()` will find ALL methods named `get`, not just `SettingsService.get()`. Scoping by file/directory helps, but it's not the same as a language server. The `maxNodes` limit prevents this from becoming a performance problem.
+- **Grammar-specific method shapes**: In TypeScript/JavaScript, functions can be declared as methods, arrow functions assigned to variables, class fields, or object literal methods. Each has a different AST node kind. The tools handle common forms but may miss unusual declaration patterns.
+- **Instance method calls are heuristic**: The "method calls on instances" category in references mode matches by variable name pattern, not by resolved type. This works well for distinctively named variables but can produce false positives for generic names.
+- **Hierarchy is syntax-only**: The `hierarchy` mode finds `extends` and `implements` clauses. It does not detect mixin patterns, decorator-based composition (e.g. Angular `@Component`), or runtime composition via `Object.assign`/spread.
+
+These limitations are acceptable for the current scope. The tools provide 80-90% of the insight a language server would, at a fraction of the complexity, and across any language tree-sitter supports.
+
+---
+
+## Relationship to Issue #438 (LSP Support)
+
+Issue #438 proposes LSP server integration for edit validation (lint, type-check without full build). LSP would also enable type-resolved analysis: precise "find references," "go to implementation," and cross-interface dispatch.
+
+**These tools are complementary to LSP, not competing:**
+
+| Capability | ast-grep tools (this issue) | LSP (issue #438) |
+|---|---|---|
+| Cross-language support | Yes (any tree-sitter grammar) | No (per-language servers) |
+| Pattern matching | Yes (`try/catch`, structural queries) | No |
+| Speed (full codebase scan) | Fast (seconds) | Slow (requires loaded project) |
+| Type resolution | No | Yes |
+| Interface dispatch | No | Yes |
+| Setup complexity | Low (single binary) | High (server lifecycle, config) |
+
+**Upgrade path:** When LSP lands, `structural_analysis` can use LSP for type-resolved queries where available (precise references, go-to-implementation) and fall back to ast-grep for pattern matching, cross-language search, and environments where no LSP is configured.
+
+---
+
+## Relationship to Existing Tools
+
+| Tool | Purpose | When the LLM uses it |
+|------|---------|---------------------|
+| `search_file_content` (ripgrep) | Text regex search | "Find lines containing this string" |
+| `ast_grep` (new) | Structural pattern search | "Find all calls matching this shape" / "Find classes extending X" |
+| `structural_analysis` (new) | Multi-hop code analysis | "Who calls this method?" / "What's the class hierarchy?" |
+| `ast_read_file` (existing) | Context-enhanced file reading | "Read this file with AST declarations from related files" |
+| `ast_edit` (existing) | Context-enhanced editing | "Edit this file with AST validation" |
+
+`ast_grep` and `structural_analysis` are complementary to ripgrep, not replacements. Ripgrep is still the right tool for text search. The new tools handle structural questions that regex can't express.

--- a/project-plans/issue1130/requirements.md
+++ b/project-plans/issue1130/requirements.md
@@ -1,0 +1,246 @@
+# Issue #1130: Requirements (EARS Format)
+
+Requirements for two new LLM-facing tools: `ast_grep` and `structural_analysis`.
+
+EARS patterns used:
+- **Ubiquitous**: The [system] shall [behavior].
+- **Event-driven**: When [trigger], the [system] shall [behavior].
+- **State-driven**: While [state], the [system] shall [behavior].
+- **Unwanted behavior**: If [condition], then the [system] shall [behavior].
+- **Optional**: Where [feature], the [system] shall [behavior].
+
+---
+
+## REQ-ASTGREP: ast_grep Tool
+
+### REQ-ASTGREP-001: Tool Registration
+
+The `ast_grep` tool shall be registered as a core tool in the tool registry, available to the LLM alongside existing tools like `search_file_content` and `read_file`.
+
+### REQ-ASTGREP-002: Pattern Search
+
+When the LLM invokes `ast_grep` with a `pattern` parameter and a `language` parameter, the tool shall execute an ast-grep structural pattern search against the target path and return all matching AST nodes according to ast-grep's matching semantics.
+
+### REQ-ASTGREP-003: YAML Rule Search
+
+When the LLM invokes `ast_grep` with a `rule` parameter (containing `kind`, `has`, `inside`, `stopBy`, or `regex` fields) and a `language` parameter, the tool shall execute an ast-grep YAML rule search against the target path and return all matching AST nodes.
+
+### REQ-ASTGREP-004: Mutually Exclusive Input
+
+When the LLM provides both `pattern` and `rule` parameters, the tool shall return an error indicating that exactly one of `pattern` or `rule` must be provided. When neither is provided, the tool shall also return an error.
+
+### REQ-ASTGREP-005: Default Path
+
+When the LLM does not provide a `path` parameter, or provides an empty string, the tool shall default to the workspace root directory.
+
+### REQ-ASTGREP-006: Workspace Boundary
+
+If the resolved `path` is outside the workspace root, then the tool shall return an error and not execute the search.
+
+### REQ-ASTGREP-007: Match Result Format
+
+The tool shall return each match with the following fields: `file` (path relative to workspace root), `startLine`, `startCol`, `endLine`, `endCol`, `text` (matched source text), `nodeKind` (AST node type), and `metaVariables` (captured pattern variables as key-value pairs).
+
+### REQ-ASTGREP-008: Result Limit
+
+Where the `maxResults` parameter is provided, the tool shall return at most that many matches. The default limit shall be 100. When results are truncated, the response shall include `truncated: true` and the total match count.
+
+### REQ-ASTGREP-009: Empty Results
+
+When a search returns zero matches, the tool shall return an empty array with `truncated: false`.
+
+### REQ-ASTGREP-010: Glob Filtering
+
+Where the `globs` parameter is provided, the tool shall include only files matching the specified glob patterns and exclude files matching negated patterns (prefixed with `!`).
+
+### REQ-ASTGREP-011: Error Handling for Invalid Patterns
+
+If the provided `pattern` cannot be parsed as a valid ast-grep pattern, then the tool shall return a clear error message including the ast-grep parse error text, not a stack trace.
+
+### REQ-ASTGREP-012: Error Handling for Unavailable Engine
+
+If the ast-grep engine (either `@ast-grep/napi` or the `sg` CLI) is not available, then the tool shall not be registered in the tool registry rather than failing at runtime.
+
+### REQ-ASTGREP-013: Language Parameter
+
+The `language` parameter shall be required when `path` targets a directory or multiple files. Where `path` points to a single file and `language` is not provided, the tool shall attempt to detect the language from the file extension. If detection fails, the tool shall return an error requesting a `language` parameter.
+
+### REQ-ASTGREP-014: Tool Description
+
+The tool's schema description shall clearly explain that it performs structural/AST-aware code search (not text search), mention metavariable capture, and distinguish itself from `search_file_content` (ripgrep).
+
+### REQ-ASTGREP-015: Cancellation Support
+
+While an ast_grep search is in progress, if the operation is cancelled via AbortSignal, the tool shall terminate the search and return a cancellation response.
+
+### REQ-ASTGREP-016: Per-File Error Handling
+
+If individual files within the search path cannot be parsed (permission denied, binary file, unsupported encoding), then the tool shall skip those files and continue searching remaining files, including a `skippedFiles` count in the response metadata.
+
+---
+
+## REQ-SA: structural_analysis Tool
+
+### REQ-SA-001: Tool Registration
+
+The `structural_analysis` tool shall be registered as a core tool in the tool registry, available to the LLM alongside `ast_grep` and other tools.
+
+### REQ-SA-002: Mode Parameter
+
+When the LLM invokes `structural_analysis`, it shall provide a `mode` parameter. The tool shall support these modes: `callers`, `callees`, `definitions`, `hierarchy`, `references`, `dependencies`, `exports`. When an unsupported mode is provided, the tool shall return an error listing the valid modes.
+
+### REQ-SA-003: Language Parameter
+
+The `structural_analysis` tool shall require a `language` parameter for all modes.
+
+### REQ-SA-004: Tool Description
+
+The tool's schema description shall clearly explain that it performs multi-hop AST-based code analysis (call graphs, hierarchies, references), that it is name-based (not type-resolved), and how it differs from `ast_grep` (which is single-query).
+
+### REQ-SA-005: Workspace Boundary
+
+If the resolved `path` or `target` is outside the workspace root, then the tool shall return an error and not execute the analysis.
+
+### REQ-SA-006: Cancellation Support
+
+While a structural_analysis operation is in progress, if the operation is cancelled via AbortSignal, the tool shall terminate and return a cancellation response with any partial results collected so far.
+
+### REQ-SA-007: Empty Results
+
+When any mode returns zero results, the tool shall return an empty result set with `truncated: false` and mode-appropriate structure (empty arrays for list modes, empty categories for references mode).
+
+### REQ-SA-008: Path Output Format
+
+All file paths in results shall be relative to the workspace root, consistent across all modes.
+
+---
+
+### Callers Mode
+
+### REQ-SA-CALLERS-001: Basic Caller Discovery
+
+When `mode` is `callers`, the tool shall find all function/method definitions that contain a call expression matching the given `symbol`.
+
+### REQ-SA-CALLERS-002: Call-Site Context
+
+Each caller result shall include the containing method name, file path, line number, AND the specific call-site line text (`via:`) that connects the caller to the callee. Where a method contains multiple calls to the target symbol, the result shall include the first matching call site.
+
+### REQ-SA-CALLERS-003: Recursive Depth
+
+Where the `depth` parameter is greater than 1, the tool shall recursively find callers of callers up to the specified depth. The default depth shall be 1 and the maximum shall be 5.
+
+### REQ-SA-CALLERS-004: Cycle Detection
+
+While traversing callers recursively, the tool shall track visited symbols by name+file and skip any symbol already visited at a given file scope, preventing infinite loops.
+
+### REQ-SA-CALLERS-005: Node Limit
+
+Where the `maxNodes` parameter is provided, the tool shall stop traversal after visiting that many unique symbols. The default shall be 50. When traversal is truncated, the tool shall return all results collected up to that point with `truncated: true`.
+
+### REQ-SA-CALLERS-006: Call Forms
+
+The callers search shall match member calls (`$OBJ.symbol()`), direct calls (`symbol()`), and optional chaining calls (`$OBJ?.symbol?.()`).
+
+---
+
+### Callees Mode
+
+### REQ-SA-CALLEES-001: Basic Callee Discovery
+
+When `mode` is `callees`, the tool shall find all call expressions inside the function/method definition matching the given `symbol`.
+
+### REQ-SA-CALLEES-002: Chained Call Deduplication
+
+The tool shall deduplicate chained subcalls by byte-range containment: if call A's source range fully contains call B's source range (B is a subexpression of A), only call A (the outermost) shall be returned.
+
+### REQ-SA-CALLEES-003: Recursive Depth
+
+Where the `depth` parameter is greater than 1, the tool shall recursively trace callees of callees, with cycle detection. Depth default is 1, max is 5.
+
+---
+
+### Definitions Mode
+
+### REQ-SA-DEFS-001: Symbol Definition Discovery
+
+When `mode` is `definitions`, the tool shall find definition sites for the given `symbol` by searching for: method definitions, function declarations, class declarations, interface declarations, type alias declarations, and const/variable declarators whose name matches the symbol.
+
+---
+
+### Hierarchy Mode
+
+### REQ-SA-HIER-001: Upward Hierarchy
+
+When `mode` is `hierarchy`, the tool shall find what the given class extends and what interfaces it implements.
+
+### REQ-SA-HIER-002: Downward Hierarchy
+
+When `mode` is `hierarchy`, the tool shall find all classes that extend or implement the given symbol.
+
+---
+
+### References Mode
+
+### REQ-SA-REFS-001: Categorized References
+
+When `mode` is `references`, the tool shall find all structural references to the given symbol, categorized into: method calls on instances, direct calls, instantiations, type annotations, extends/implements, and imports. Each category shall include a match count.
+
+### REQ-SA-REFS-002: Instance Method Call Heuristic
+
+For the "method calls on instances" category, the tool shall match calls on variables whose identifier name contains the symbol (case-insensitive substring match). This is a heuristic because ast-grep cannot resolve types. The output shall label this category to indicate it is heuristic-based.
+
+### REQ-SA-REFS-003: Deduplication
+
+The tool shall deduplicate results by file and line number within each category.
+
+---
+
+### Dependencies Mode
+
+### REQ-SA-DEPS-001: Import Graph
+
+When `mode` is `dependencies`, the tool shall find all imports in the target file/directory, including: named imports, default imports, namespace imports, side-effect imports, dynamic imports, and re-exports. For TypeScript/JavaScript only, the tool shall also match CommonJS `require()` calls.
+
+### REQ-SA-DEPS-002: Reverse Dependencies
+
+Where the `reverse` parameter is true, the tool shall also find all files in the workspace that import the target file.
+
+---
+
+### Exports Mode
+
+### REQ-SA-EXPORTS-001: Export Discovery
+
+When `mode` is `exports`, the tool shall list all exported symbols from the target file, including exported classes, functions, constants, interfaces, types, default exports, and re-exports.
+
+---
+
+## REQ-INFRA: Infrastructure Requirements
+
+### REQ-INFRA-001: AST Engine Integration
+
+The tools shall use `@ast-grep/napi` (the Node.js native bindings) as the primary ast-grep integration, sharing the engine with the existing `ast_edit` and `ast_read_file` tools in `packages/core/src/tools/ast-edit.ts`. Where `@ast-grep/napi` is unavailable, the `sg` CLI binary may be used as a fallback.
+
+### REQ-INFRA-002: Shared AST Utilities
+
+AST operations common to `ast_grep`, `structural_analysis`, `ast_edit`, and `ast_read_file` (language registration, query execution, error normalization) shall be factored into a shared utility module to avoid duplication and drift.
+
+### REQ-INFRA-003: Graceful Degradation
+
+If neither `@ast-grep/napi` nor the `sg` CLI is available, both tools shall be excluded from the tool registry (not registered) rather than registered and failing at runtime.
+
+### REQ-INFRA-004: Tool Defaults
+
+The tools shall have entries in the tool defaults configuration, following the pattern of existing tools (enable/disable, description override).
+
+### REQ-INFRA-005: No Test File Dependency
+
+The tools shall not depend on any test infrastructure for production functionality. Test files shall be separate from implementation files.
+
+### REQ-INFRA-006: Timeouts
+
+The `ast_grep` tool shall enforce a timeout of 30 seconds per invocation. The `structural_analysis` tool shall enforce a timeout of 60 seconds per invocation. When a timeout is reached, the tool shall return whatever results have been collected with `truncated: true` and a timeout indication.
+
+### REQ-INFRA-007: Existing Tool Compatibility
+
+The new tools shall not modify the behavior or registration of any existing tool. They shall coexist with `search_file_content`, `ast_edit`, `ast_read_file`, and all other registered tools.

--- a/project-plans/issue1130/toy-ast-grep.txt
+++ b/project-plans/issue1130/toy-ast-grep.txt
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2250,SC2292
+# toy-ast-grep.sh — Toy wrapper around sg (ast-grep) for testing
+# Usage:
+#   ./toy-ast-grep.sh pattern <pattern> <language> [path]
+#   ./toy-ast-grep.sh rule <rule-yaml-string> [path]
+#
+# Examples:
+#   ./toy-ast-grep.sh pattern '$OBJ.getAsyncTaskManager()' typescript packages/core/src/
+#   ./toy-ast-grep.sh pattern 'class $NAME extends $PARENT { $$$BODY }' typescript packages/core/src/tools/
+#   ./toy-ast-grep.sh pattern 'registerCoreTool($TOOL, $$$REST)' typescript packages/core/src/config/config.ts
+
+set -euo pipefail
+
+MODE="${1:?Usage: toy-ast-grep.sh <pattern|rule> ...}"
+shift
+
+if [ "$MODE" = "pattern" ]; then
+    PATTERN="${1:?pattern string required}"
+    LANG="${2:?language required}"
+    SEARCH_PATH="${3:-.}"
+
+    echo "=== ast_grep pattern search ==="
+    echo "Pattern: $PATTERN"
+    echo "Language: $LANG"
+    echo "Path: $SEARCH_PATH"
+    echo "---"
+
+    # Text output (human readable)
+    echo ""
+    echo "## Matches:"
+    sg --pattern "$PATTERN" --lang "$LANG" "$SEARCH_PATH" 2>&1 || true
+
+    echo ""
+    echo "## Structured (JSON metavariables):"
+    sg --pattern "$PATTERN" --lang "$LANG" --json "$SEARCH_PATH" 2>/dev/null | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+print(f'Total matches: {len(data)}')
+for m in data:
+    f = m.get('file', '?')
+    start = m.get('range', {}).get('start', {})
+    line = start.get('line', '?')
+    col = start.get('col', start.get('column', '?'))
+    end = m.get('range', {}).get('end', {})
+    end_line = end.get('line', '?')
+    end_col = end.get('col', end.get('column', '?'))
+    text = m.get('text', '').split(chr(10))[0][:100]
+    node_kind = m.get('nodeKind', m.get('kind', ''))
+
+    # Extract metavariables
+    mv = m.get('metaVariables', {})
+    singles = mv.get('single', {})
+    multis = mv.get('multi', {})
+    mv_parts = []
+    for k, v in singles.items():
+        mv_parts.append(f'{k}={v.get(\"text\", \"?\")[:40]}')
+    for k, v in multis.items():
+        texts = [i.get('text', '?')[:20] for i in (v if isinstance(v, list) else [])]
+        mv_parts.append(f'{k}=[{\", \".join(texts)}]')
+    mv_str = ', '.join(mv_parts) if mv_parts else '(none)'
+
+    print(f'  {f}:{line}:{col}-{end_line}:{end_col}  {text}')
+    if mv_str != '(none)':
+        print(f'    metaVars: {mv_str}')
+" 2>&1 || echo "(no matches or parse error)"
+
+elif [ "$MODE" = "rule" ]; then
+    RULE_CONTENT="${1:?rule YAML content required}"
+    SEARCH_PATH="${2:-.}"
+
+    # Write rule to temp file
+    RULE_FILE=$(mktemp /tmp/ast-grep-rule-XXXXXX.yaml)
+    echo "$RULE_CONTENT" > "$RULE_FILE"
+
+    echo "=== ast_grep rule search ==="
+    echo "Rule file: $RULE_FILE"
+    echo "Path: $SEARCH_PATH"
+    echo "---"
+
+    echo ""
+    echo "## Matches:"
+    sg scan --rule "$RULE_FILE" "$SEARCH_PATH" 2>&1 || true
+
+    echo ""
+    echo "## Structured (JSON):"
+    sg scan --rule "$RULE_FILE" --json "$SEARCH_PATH" 2>/dev/null | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+print(f'Total matches: {len(data)}')
+for m in data:
+    f = m.get('file', '?')
+    start = m.get('range', {}).get('start', {})
+    line = start.get('line', '?')
+    text = m.get('text', '').split(chr(10))[0][:100]
+    print(f'  {f}:{line}  {text}')
+" 2>&1 || echo "(no matches or parse error)"
+
+    rm -f "$RULE_FILE"
+else
+    echo "Unknown mode: $MODE (use 'pattern' or 'rule')"
+    exit 1
+fi

--- a/project-plans/issue1130/toy-structural-analysis.txt
+++ b/project-plans/issue1130/toy-structural-analysis.txt
@@ -1,0 +1,592 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2250,SC2292
+# toy-structural-analysis.sh — Toy multi-hop ast-grep analysis for testing
+# Usage:
+#   ./toy-structural-analysis.sh <mode> <symbol|target> <language> [path] [depth]
+#
+# Modes:
+#   callers <symbol> <lang> [path] [depth]     — who calls this method?
+#   callees <symbol> <lang> [path] [depth]     — what does this method call?
+#   definitions <symbol> <lang> [path]         — where is this symbol defined?
+#   hierarchy <symbol> <lang> [path]           — class/interface inheritance tree
+#   references <symbol> <lang> [path]          — all structural references
+#   dependencies <file> <lang>                 — import graph for a file
+#   exports <file> <lang>                      — what does a file export?
+#
+# Examples:
+#   ./toy-structural-analysis.sh callers getAsyncTaskManager typescript packages/core/src/ 2
+#   ./toy-structural-analysis.sh callees getAsyncTaskManager typescript packages/core/src/config/config.ts
+#   ./toy-structural-analysis.sh hierarchy BaseDeclarativeTool typescript packages/core/src/tools/
+#   ./toy-structural-analysis.sh references ToolRegistry typescript packages/core/src/
+#   ./toy-structural-analysis.sh dependencies packages/core/src/config/config.ts typescript
+
+set -euo pipefail
+
+MODE="${1:?Usage: toy-structural-analysis.sh <mode> <symbol|target> <language> [path] [depth]}"
+SYMBOL="${2:?symbol or target file required}"
+LANG="${3:?language required}"
+SEARCH_PATH="${4:-.}"
+DEPTH="${5:-1}"
+
+# Uppercase first letter of LANG (bash 3.2 compatible)
+LANG_UPPER="$(echo "$LANG" | awk '{print toupper(substr($0,1,1)) tolower(substr($0,2))}')"
+
+# Helper: run a YAML rule and extract JSON results
+run_rule() {
+    local rule_content="$1"
+    local search_path="$2"
+    local rule_file
+    rule_file=$(mktemp /tmp/sa-rule-XXXXXX.yaml)
+    echo "$rule_content" > "$rule_file"
+    sg scan --rule "$rule_file" --json "$search_path" 2>/dev/null || echo "[]"
+    rm -f "$rule_file"
+}
+
+case "$MODE" in
+
+callers)
+    echo "=== structural_analysis: callers of $SYMBOL (depth $DEPTH) ==="
+    echo ""
+
+    VISITED_FILE=$(mktemp /tmp/sa-visited-XXXXXX.txt)
+    QUEUE_FILE=$(mktemp /tmp/sa-queue-XXXXXX.txt)
+    OUTPUT_FILE=$(mktemp /tmp/sa-output-XXXXXX.txt)
+    cleanup_callers() { rm -f "$VISITED_FILE" "$QUEUE_FILE" "$OUTPUT_FILE"; }
+    trap cleanup_callers EXIT
+
+    echo "${SYMBOL}:0" > "$QUEUE_FILE"
+
+    while [ -s "$QUEUE_FILE" ]; do
+        entry=$(head -1 "$QUEUE_FILE")
+        tail -n +2 "$QUEUE_FILE" > "${QUEUE_FILE}.tmp" && mv "${QUEUE_FILE}.tmp" "$QUEUE_FILE"
+
+        current=$(echo "$entry" | cut -d: -f1)
+        current_depth=$(echo "$entry" | cut -d: -f2)
+
+        if grep -qx "$current" "$VISITED_FILE" 2>/dev/null; then continue; fi
+        echo "$current" >> "$VISITED_FILE"
+        if [ "$current_depth" -ge "$DEPTH" ]; then continue; fi
+
+        # Find call sites for context
+        CALL_SITES_FILE=$(mktemp /tmp/sa-cs-XXXXXX.json)
+        sg --pattern "\$OBJ.${current}(\$\$\$ARGS)" --lang "$LANG" --json "$SEARCH_PATH" > "$CALL_SITES_FILE" 2>/dev/null || echo "[]" > "$CALL_SITES_FILE"
+
+        # Find containing methods
+        METHODS_FILE=$(mktemp /tmp/sa-mt-XXXXXX.json)
+        RULE="id: find-callers
+language: ${LANG_UPPER}
+rule:
+  kind: method_definition
+  has:
+    stopBy: end
+    kind: call_expression
+    pattern: \$OBJ.${current}(\$\$\$ARGS)"
+        run_rule "$RULE" "$SEARCH_PATH" > "$METHODS_FILE"
+
+        # Process results: print output and collect queue entries
+        python3 -c "
+import json, sys, re
+
+depth = int(sys.argv[1])
+methods_file = sys.argv[2]
+callsites_file = sys.argv[3]
+queue_file = sys.argv[4]
+visited_file = sys.argv[5]
+max_depth = int(sys.argv[6])
+
+with open(methods_file) as f:
+    methods = json.load(f)
+with open(callsites_file) as f:
+    call_sites = json.load(f)
+
+# Read visited set
+visited = set()
+try:
+    with open(visited_file) as f:
+        visited = set(line.strip() for line in f)
+except: pass
+
+# Index call sites by file
+site_by_file = {}
+for cs in call_sites:
+    cf = cs.get('file', '')
+    ln = cs.get('range', {}).get('start', {}).get('line', 0)
+    site_by_file.setdefault(cf, []).append({
+        'line': ln,
+        'text': cs.get('lines', cs.get('text', '')).strip()[:80]
+    })
+
+queue_entries = []
+for m in methods:
+    text = m.get('text', '')
+    first_line = text.split(chr(10))[0].strip()
+    match = re.match(r'(?:async\s+)?(\w+)\s*[\(<]', first_line)
+    method_name = match.group(1) if match else first_line[:40]
+    mf = m.get('file', '?')
+    f_short = mf.split('/')[-1]
+    m_start = m.get('range', {}).get('start', {}).get('line', 0)
+    m_end = m.get('range', {}).get('end', {}).get('line', 0)
+
+    # Find the specific call site within this method
+    via = ''
+    for site in site_by_file.get(mf, []):
+        if m_start <= site['line'] <= m_end:
+            via = site['text']
+            break
+
+    indent = '  ' * (depth + 1)
+    print(f'{indent}← {method_name}()  {f_short}:{m_start}')
+    if via:
+        print(f'{indent}  via: {via}')
+
+    next_depth = depth + 1
+    if method_name not in visited and next_depth < max_depth:
+        queue_entries.append(f'{method_name}:{next_depth}')
+
+# Append to queue file
+if queue_entries:
+    with open(queue_file, 'a') as f:
+        for qe in queue_entries:
+            f.write(qe + chr(10))
+" "$current_depth" "$METHODS_FILE" "$CALL_SITES_FILE" "$QUEUE_FILE" "$VISITED_FILE" "$DEPTH"
+
+        rm -f "$CALL_SITES_FILE" "$METHODS_FILE"
+    done
+    ;;
+
+callees)
+    echo "=== structural_analysis: callees of $SYMBOL (depth $DEPTH) ==="
+    echo ""
+
+    # Find what the method calls, deduplicating chained subcalls
+    RULE="id: find-callees
+language: ${LANG_UPPER}
+rule:
+  kind: call_expression
+  inside:
+    stopBy: end
+    kind: method_definition
+    has:
+      kind: property_identifier
+      regex: \"^${SYMBOL}\$\""
+
+    RESULTS=$(run_rule "$RULE" "$SEARCH_PATH")
+
+    echo "$RESULTS" | python3 -c "
+import json, sys
+
+data = json.load(sys.stdin)
+
+# Deduplicate: if call A contains call B (by byte range), keep only A (the outermost)
+# Sort by start offset descending so we process inner calls first
+calls = []
+for m in data:
+    start = m.get('range', {}).get('byteOffset', {}).get('start', 0)
+    end = m.get('range', {}).get('byteOffset', {}).get('end', 0)
+    calls.append({
+        'start': start,
+        'end': end,
+        'text': m.get('text', '').split(chr(10))[0].strip()[:80],
+        'file': m.get('file', '?').split('/')[-1],
+        'line': m.get('range', {}).get('start', {}).get('line', '?'),
+        'full_text': m.get('text', '')
+    })
+
+# Sort by range size descending (largest/outermost first)
+calls.sort(key=lambda c: -(c['end'] - c['start']))
+
+# Keep only calls that aren't contained within another kept call
+kept = []
+for c in calls:
+    is_subcall = False
+    for k in kept:
+        if k['start'] <= c['start'] and c['end'] <= k['end']:
+            is_subcall = True
+            break
+    if not is_subcall:
+        kept.append(c)
+
+# Sort by line number for display
+kept.sort(key=lambda c: (c['file'], c['line']))
+
+for c in kept:
+    print(f'  → {c[\"text\"]}  {c[\"file\"]}:{c[\"line\"]}')
+" 2>/dev/null
+    ;;
+
+definitions)
+    echo "=== structural_analysis: definitions of $SYMBOL ==="
+    echo ""
+
+    # Search for method definitions
+    RULE1="id: find-method-def
+language: ${LANG_UPPER}
+rule:
+  kind: method_definition
+  has:
+    kind: property_identifier
+    regex: \"^${SYMBOL}\$\""
+
+    # Search for function declarations
+    RULE2="id: find-func-def
+language: ${LANG_UPPER}
+rule:
+  kind: function_declaration
+  has:
+    kind: identifier
+    regex: \"^${SYMBOL}\$\""
+
+    # Search for class declarations
+    RULE3="id: find-class-def
+language: ${LANG_UPPER}
+rule:
+  kind: class_declaration
+  has:
+    kind: type_identifier
+    regex: \"^${SYMBOL}\$\""
+
+    # Search for interface declarations
+    RULE4="id: find-iface-def
+language: ${LANG_UPPER}
+rule:
+  kind: interface_declaration
+  has:
+    kind: type_identifier
+    regex: \"^${SYMBOL}\$\""
+
+    for RULE in "$RULE1" "$RULE2" "$RULE3" "$RULE4"; do
+        RESULTS=$(run_rule "$RULE" "$SEARCH_PATH")
+        echo "$RESULTS" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for m in data:
+    text = m.get('text', '').split(chr(10))[0].strip()[:100]
+    f = m.get('file', '?')
+    line = m.get('range', {}).get('start', {}).get('line', '?')
+    kind = m.get('ruleId', '').replace('find-', '').replace('-def', '')
+    print(f'  [{kind}] {f}:{line}  {text}')
+" 2>/dev/null
+    done
+    ;;
+
+hierarchy)
+    echo "=== structural_analysis: hierarchy of $SYMBOL ==="
+    echo ""
+
+    # What does SYMBOL extend?
+    echo "Extends:"
+    sg --pattern "class ${SYMBOL} extends \$PARENT { \$\$\$BODY }" --lang "$LANG" --json "$SEARCH_PATH" 2>/dev/null | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for m in data:
+    parent = m.get('metaVariables',{}).get('single',{}).get('PARENT',{}).get('text','?')
+    f = m.get('file','?').split('/')[-1]
+    line = m.get('range',{}).get('start',{}).get('line','?')
+    print(f'  → {parent}  {f}:{line}')
+" 2>/dev/null || true
+
+    # What does SYMBOL implement?
+    echo ""
+    echo "Implements:"
+    sg --pattern "class ${SYMBOL} implements \$IFACE { \$\$\$BODY }" --lang "$LANG" --json "$SEARCH_PATH" 2>/dev/null | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for m in data:
+    iface = m.get('metaVariables',{}).get('single',{}).get('IFACE',{}).get('text','?')
+    f = m.get('file','?').split('/')[-1]
+    line = m.get('range',{}).get('start',{}).get('line','?')
+    print(f'  → {iface}  {f}:{line}')
+" 2>/dev/null || true
+
+    # What extends SYMBOL?
+    echo ""
+    echo "Extended by:"
+    sg --pattern "class \$NAME extends ${SYMBOL} { \$\$\$BODY }" --lang "$LANG" --json "$SEARCH_PATH" 2>/dev/null | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for m in data:
+    name = m.get('metaVariables',{}).get('single',{}).get('NAME',{}).get('text','?')
+    f = m.get('file','?').split('/')[-1]
+    line = m.get('range',{}).get('start',{}).get('line','?')
+    print(f'  ← {name}  {f}:{line}')
+" 2>/dev/null || true
+
+    # What implements SYMBOL?
+    echo ""
+    echo "Implemented by:"
+    sg --pattern "class \$NAME implements ${SYMBOL} { \$\$\$BODY }" --lang "$LANG" --json "$SEARCH_PATH" 2>/dev/null | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for m in data:
+    name = m.get('metaVariables',{}).get('single',{}).get('NAME',{}).get('text','?')
+    f = m.get('file','?').split('/')[-1]
+    line = m.get('range',{}).get('start',{}).get('line','?')
+    print(f'  ← {name}  {f}:{line}')
+" 2>/dev/null || true
+    ;;
+
+references)
+    echo "=== structural_analysis: references to $SYMBOL ==="
+    echo ""
+
+    # Method calls ON instances of symbol (e.g. registry.register() where registry is a ToolRegistry)
+    # We match: variableName.method() where variableName contains the symbol (case-insensitive)
+    # This is best-effort since ast-grep can't resolve types
+    echo "Method calls (on variables named like ${SYMBOL}):"
+    RULE_MCALLS="id: method-calls-on
+language: ${LANG_UPPER}
+rule:
+  kind: call_expression
+  has:
+    kind: member_expression
+    has:
+      kind: identifier
+      regex: \"(?i)${SYMBOL}\""
+    MCALL_RESULTS=$(run_rule "$RULE_MCALLS" "$SEARCH_PATH")
+    echo "$MCALL_RESULTS" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+# Deduplicate by file:line
+seen = set()
+matches = []
+for m in data:
+    f = m.get('file','?').split('/')[-1]
+    line = m.get('range',{}).get('start',{}).get('line','?')
+    key = f'{f}:{line}'
+    if key not in seen:
+        seen.add(key)
+        text = m.get('text','').split(chr(10))[0].strip()[:80]
+        matches.append(f'    {f}:{line}  {text}')
+print(f'  ({len(matches)} matches)')
+for m in matches[:10]:
+    print(m)
+if len(matches) > 10: print(f'    ... and {len(matches)-10} more')
+" 2>/dev/null || true
+
+    # Function/method calls TO symbol (e.g. someObj.ToolRegistry() — rare but valid for factories)
+    echo ""
+    echo "Direct calls (as function/method name):"
+    sg --pattern "\$OBJ.${SYMBOL}(\$\$\$ARGS)" --lang "$LANG" --json "$SEARCH_PATH" 2>/dev/null | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+print(f'  ({len(data)} matches)')
+for m in data[:10]:
+    f = m.get('file','?').split('/')[-1]
+    line = m.get('range',{}).get('start',{}).get('line','?')
+    text = m.get('text','')[:80]
+    print(f'    {f}:{line}  {text}')
+if len(data) > 10: print(f'    ... and {len(data)-10} more')
+" 2>/dev/null || true
+
+    # Instantiations
+    echo ""
+    echo "Instantiations:"
+    sg --pattern "new ${SYMBOL}(\$\$\$ARGS)" --lang "$LANG" --json "$SEARCH_PATH" 2>/dev/null | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+print(f'  ({len(data)} matches)')
+for m in data[:10]:
+    f = m.get('file','?').split('/')[-1]
+    line = m.get('range',{}).get('start',{}).get('line','?')
+    text = m.get('text','')[:80]
+    print(f'    {f}:{line}  {text}')
+" 2>/dev/null || true
+
+    # Type annotations
+    echo ""
+    echo "Type annotations:"
+    RULE_TYPES="id: type-refs
+language: ${LANG_UPPER}
+rule:
+  kind: type_annotation
+  has:
+    kind: type_identifier
+    regex: \"^${SYMBOL}\$\""
+    TYPE_RESULTS=$(run_rule "$RULE_TYPES" "$SEARCH_PATH")
+    echo "$TYPE_RESULTS" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+print(f'  ({len(data)} matches)')
+for m in data[:10]:
+    f = m.get('file','?').split('/')[-1]
+    line = m.get('range',{}).get('start',{}).get('line','?')
+    text = m.get('text','')[:80]
+    print(f'    {f}:{line}  {text}')
+if len(data) > 10: print(f'    ... and {len(data)-10} more')
+" 2>/dev/null || true
+
+    # Extends / Implements
+    echo ""
+    echo "Extends/Implements:"
+    python3 -c "
+import json, subprocess, sys
+
+symbol = '${SYMBOL}'
+lang = '${LANG}'
+path = '${SEARCH_PATH}'
+results = []
+
+# Classes extending symbol
+try:
+    out = subprocess.check_output(
+        ['sg', '--pattern', f'class \$NAME extends {symbol} {{ \$\$\$BODY }}', '--lang', lang, '--json', path],
+        stderr=subprocess.DEVNULL
+    )
+    for m in json.loads(out):
+        name = m.get('metaVariables',{}).get('single',{}).get('NAME',{}).get('text','?')
+        f = m.get('file','?').split('/')[-1]
+        line = m.get('range',{}).get('start',{}).get('line','?')
+        results.append(f'    {f}:{line}  class {name} extends {symbol}')
+except: pass
+
+# Classes implementing symbol
+try:
+    out = subprocess.check_output(
+        ['sg', '--pattern', f'class \$NAME implements {symbol} {{ \$\$\$BODY }}', '--lang', lang, '--json', path],
+        stderr=subprocess.DEVNULL
+    )
+    for m in json.loads(out):
+        name = m.get('metaVariables',{}).get('single',{}).get('NAME',{}).get('text','?')
+        f = m.get('file','?').split('/')[-1]
+        line = m.get('range',{}).get('start',{}).get('line','?')
+        results.append(f'    {f}:{line}  class {name} implements {symbol}')
+except: pass
+
+print(f'  ({len(results)} matches)')
+for r in results[:10]:
+    print(r)
+if len(results) > 10: print(f'    ... and {len(results)-10} more')
+" 2>/dev/null || true
+
+    # Imports
+    echo ""
+    echo "Imports:"
+    sg --pattern "import { \$\$\$NAMES } from \$SOURCE" --lang "$LANG" --json "$SEARCH_PATH" 2>/dev/null | python3 -c "
+import json, sys
+symbol = '${SYMBOL}'
+data = json.load(sys.stdin)
+matches = []
+for m in data:
+    multi = m.get('metaVariables',{}).get('multi',{})
+    names = multi.get('NAMES', [])
+    name_texts = [n.get('text','') for n in (names if isinstance(names, list) else [])]
+    if any(symbol in t for t in name_texts):
+        f = m.get('file','?').split('/')[-1]
+        line = m.get('range',{}).get('start',{}).get('line','?')
+        source = m.get('metaVariables',{}).get('single',{}).get('SOURCE',{}).get('text','?')
+        matches.append(f'    {f}:{line}  from {source}')
+print(f'  ({len(matches)} matches)')
+for m in matches[:10]:
+    print(m)
+if len(matches) > 10: print(f'    ... and {len(matches)-10} more')
+" 2>/dev/null || true
+    ;;
+
+dependencies)
+    echo "=== structural_analysis: dependencies of $SYMBOL ==="
+    echo ""
+
+    if [ ! -f "$SYMBOL" ]; then
+        echo "Error: $SYMBOL is not a file"
+        exit 1
+    fi
+
+    echo "Imports:"
+    sg --pattern "import { \$\$\$NAMES } from \$SOURCE" --lang "$LANG" --json "$SYMBOL" 2>/dev/null | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for m in data:
+    source = m.get('metaVariables',{}).get('single',{}).get('SOURCE',{}).get('text','?')
+    multi = m.get('metaVariables',{}).get('multi',{})
+    names = multi.get('NAMES', [])
+    name_texts = [n.get('text','') for n in (names if isinstance(names, list) else []) if n.get('text','').strip() not in (',', '')]
+    print(f'  {source}  [{chr(44).join(n.strip() for n in name_texts)}]')
+" 2>/dev/null || true
+
+    # Default imports
+    echo ""
+    echo "Default imports:"
+    sg --pattern "import \$NAME from \$SOURCE" --lang "$LANG" --json "$SYMBOL" 2>/dev/null | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for m in data:
+    source = m.get('metaVariables',{}).get('single',{}).get('SOURCE',{}).get('text','?')
+    name = m.get('metaVariables',{}).get('single',{}).get('NAME',{}).get('text','?')
+    print(f'  {source}  [{name}]')
+" 2>/dev/null || true
+
+    # Namespace imports
+    echo ""
+    echo "Namespace imports:"
+    sg --pattern "import * as \$NAME from \$SOURCE" --lang "$LANG" --json "$SYMBOL" 2>/dev/null | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for m in data:
+    source = m.get('metaVariables',{}).get('single',{}).get('SOURCE',{}).get('text','?')
+    name = m.get('metaVariables',{}).get('single',{}).get('NAME',{}).get('text','?')
+    print(f'  {source}  [* as {name}]')
+" 2>/dev/null || true
+    ;;
+
+exports)
+    echo "=== structural_analysis: exports of $SYMBOL ==="
+    echo ""
+
+    if [ ! -f "$SYMBOL" ]; then
+        echo "Error: $SYMBOL is not a file"
+        exit 1
+    fi
+
+    echo "Exported declarations:"
+    sg --pattern "export class \$NAME" --lang "$LANG" --json "$SYMBOL" 2>/dev/null | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for m in data:
+    name = m.get('metaVariables',{}).get('single',{}).get('NAME',{}).get('text','?')
+    line = m.get('range',{}).get('start',{}).get('line','?')
+    print(f'  class {name}  line {line}')
+" 2>/dev/null || true
+
+    sg --pattern "export function \$NAME(\$\$\$ARGS)" --lang "$LANG" --json "$SYMBOL" 2>/dev/null | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for m in data:
+    name = m.get('metaVariables',{}).get('single',{}).get('NAME',{}).get('text','?')
+    line = m.get('range',{}).get('start',{}).get('line','?')
+    print(f'  function {name}  line {line}')
+" 2>/dev/null || true
+
+    sg --pattern "export const \$NAME" --lang "$LANG" --json "$SYMBOL" 2>/dev/null | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for m in data:
+    name = m.get('metaVariables',{}).get('single',{}).get('NAME',{}).get('text','?')
+    line = m.get('range',{}).get('start',{}).get('line','?')
+    print(f'  const {name}  line {line}')
+" 2>/dev/null || true
+
+    sg --pattern "export interface \$NAME" --lang "$LANG" --json "$SYMBOL" 2>/dev/null | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for m in data:
+    name = m.get('metaVariables',{}).get('single',{}).get('NAME',{}).get('text','?')
+    line = m.get('range',{}).get('start',{}).get('line','?')
+    print(f'  interface {name}  line {line}')
+" 2>/dev/null || true
+
+    sg --pattern "export type \$NAME" --lang "$LANG" --json "$SYMBOL" 2>/dev/null | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for m in data:
+    name = m.get('metaVariables',{}).get('single',{}).get('NAME',{}).get('text','?')
+    line = m.get('range',{}).get('start',{}).get('line','?')
+    print(f'  type {name}  line {line}')
+" 2>/dev/null || true
+    ;;
+
+*)
+    echo "Unknown mode: $MODE"
+    echo "Modes: callers, callees, definitions, hierarchy, references, dependencies, exports"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

Adds two new AST-based code analysis tools that leverage `@ast-grep/napi` for structural code understanding, complementing existing text-based ripgrep search.

closes #1130

## New Tools

### ast_grep (single-query structural search)

Pattern-based AST matching with metavariable capture. Unlike ripgrep (text/regex), this understands code grammar -- it knows the difference between a function call, a declaration, and a comment.

**Parameters:** `pattern`, `rule`, `language`, `path`, `globs`, `maxResults`

**Example patterns:**
- \`\$OBJ.getAsyncTaskManager()\` -- find all calls to a method on any receiver
- \`registerCoreTool(\$TOOL, \$\$\$REST)\` -- find all tool registrations, capturing the tool class name
- \`try { \$\$\$T } catch (\$E) { \$\$\$C }\` -- find all try/catch blocks regardless of content
- \`class \$NAME extends BaseDeclarativeTool<\$\$\$TYPES> { \$\$\$BODY }\` -- find all tool class declarations

Returns matches with file, line, AST node kind, matched text, and extracted metavariable values.

### structural_analysis (multi-hop relationship analysis)

7 analysis modes for understanding code relationships:

| Mode | What it does |
|------|-------------|
| `definitions` | Find class/function/type definitions by name |
| `hierarchy` | Parent classes, interfaces, subclasses, implementors |
| `callers` | Who calls a method (recursive with depth/maxNodes/cycle detection) |
| `callees` | What a method calls (with chained-call deduplication) |
| `references` | Categorized symbol usage: calls, instantiations, type annotations, imports, heritage |
| `dependencies` | Module import/export graph with optional reverse lookup |
| `exports` | Enumerate exported symbols by kind (class, function, const, interface, type, reexport) |

**Key features:**
- Recursive call graph traversal with configurable depth (max 5) and node budget
- Cycle detection to prevent infinite loops
- Name-based analysis (not type-resolved) -- see design docs for limitations

## Shared Utilities

Extracted `LANGUAGE_MAP`, `getAstLanguage()`, `resolveLanguageFromPath()`, `parseSource()` and other ast-grep helpers from `ast-edit.ts` into `packages/core/src/utils/ast-grep-utils.ts` to share between ast-edit and the new tools without duplication.

## Files Changed

| File | Change |
|------|--------|
| `packages/core/src/utils/ast-grep-utils.ts` | NEW: Shared ast-grep utilities |
| `packages/core/src/utils/ast-grep-utils.test.ts` | NEW: 19 tests |
| `packages/core/src/tools/ast-grep.ts` | NEW: AstGrepTool |
| `packages/core/src/tools/ast-grep.test.ts` | NEW: 15 tests |
| `packages/core/src/tools/structural-analysis.ts` | NEW: StructuralAnalysisTool (7 modes) |
| `packages/core/src/tools/structural-analysis.test.ts` | NEW: 21 tests |
| `packages/core/src/tools/ast-edit.ts` | Refactored to import from shared utils |
| `packages/core/src/tools/tool-names.ts` | Added AST_GREP_TOOL and STRUCTURAL_ANALYSIS_TOOL |
| `packages/core/src/config/config.ts` | Import and register both new tools |
| `project-plans/issue1130/` | Design docs, EARS requirements, implementation plan, prototypes |

## Test Results

- 64/64 AST-related tests pass (utils: 19, ast-grep: 15, structural-analysis: 21, ast-edit: 9)
- Full test suite passes
- Lint clean, no new typecheck errors, build passes
- Smoke test passes