### PR TITLE
refactor: extract shared OpenAI-compatible tooling utilities

### DIFF
--- a/packages/core/src/providers/openai-vercel/toolIdUtils.ts
+++ b/packages/core/src/providers/openai-vercel/toolIdUtils.ts
@@ -17,69 +17,10 @@
 /**
  * @plan PLAN-20251127-OPENAIVERCEL.P04a
  * @requirement REQ-OV-004
- * @description Tool ID normalization utility functions
+ * @description Tool ID normalization utility functions - re-exports from shared utils
  */
 
-const SANITIZE_PATTERN = /[^a-zA-Z0-9_-]/g;
-
-function sanitizeSuffix(suffix: string): string {
-  return suffix.replace(SANITIZE_PATTERN, '');
-}
-
-/**
- * Normalizes various tool ID formats to OpenAI format (call_xxx)
- * - hist_tool_xxx → call_xxx
- * - toolu_xxx → call_xxx
- * - call_xxx → call_xxx (unchanged)
- * - unknown → call_unknown
- */
-export function normalizeToOpenAIToolId(id: string): string {
-  if (!id) {
-    return 'call_';
-  }
-
-  if (id.startsWith('call_')) {
-    const suffix = id.substring('call_'.length);
-    return `call_${sanitizeSuffix(suffix)}`;
-  }
-
-  let suffix = '';
-  if (id.startsWith('hist_tool_')) {
-    suffix = id.substring('hist_tool_'.length);
-  } else if (id.startsWith('toolu_')) {
-    suffix = id.substring('toolu_'.length);
-  } else {
-    suffix = id;
-  }
-
-  return `call_${sanitizeSuffix(suffix)}`;
-}
-
-/**
- * Normalizes various tool ID formats to history format (hist_tool_xxx)
- * - call_xxx → hist_tool_xxx
- * - toolu_xxx → hist_tool_xxx
- * - hist_tool_xxx → hist_tool_xxx (unchanged)
- */
-export function normalizeToHistoryToolId(id: string): string {
-  if (!id) {
-    return 'hist_tool_';
-  }
-
-  if (id.startsWith('hist_tool_')) {
-    const suffix = id.substring('hist_tool_'.length);
-    return `hist_tool_${sanitizeSuffix(suffix)}`;
-  }
-
-  if (id.startsWith('call_')) {
-    const suffix = id.substring('call_'.length);
-    return `hist_tool_${sanitizeSuffix(suffix)}`;
-  }
-
-  if (id.startsWith('toolu_')) {
-    const suffix = id.substring('toolu_'.length);
-    return `hist_tool_${sanitizeSuffix(suffix)}`;
-  }
-
-  return `hist_tool_${sanitizeSuffix(id)}`;
-}
+export {
+  normalizeToOpenAIToolId,
+  normalizeToHistoryToolId,
+} from '../utils/toolIdNormalization.js';

--- a/packages/core/src/providers/openai/__tests__/OpenAIProvider.thinkTags.test.ts
+++ b/packages/core/src/providers/openai/__tests__/OpenAIProvider.thinkTags.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for OpenAI provider <think> tag extraction and text sanitization.
+ * Tests for think tag extraction and text sanitization shared utilities.
  *
  * These tests verify:
  * - Bug #1: Kimi-K2 text content should be sanitized (think tags stripped from text)
@@ -9,25 +9,12 @@
  * @plan PLAN-20251202-THINKING.P16
  * @requirement REQ-THINK-003
  */
-import { describe, it, expect, beforeEach } from 'vitest';
-import { OpenAIProvider } from '../OpenAIProvider';
-import type { ThinkingBlock } from '../../../services/history/IContent';
+import { describe, it, expect } from 'vitest';
+import { extractThinkTagsAsBlock } from '../../utils/thinkingExtraction';
+import { sanitizeProviderText } from '../../utils/textSanitizer';
 
 describe('OpenAIProvider think tag handling @plan:PLAN-20251202-THINKING.P16', () => {
-  let provider: OpenAIProvider;
-
-  beforeEach(() => {
-    provider = new OpenAIProvider('test-api-key', 'https://api.openai.com/v1');
-  });
-
   describe('extractThinkTagsAsBlock @requirement:REQ-THINK-003', () => {
-    const extractThinkTagsAsBlock = (text: string): ThinkingBlock | null =>
-      (
-        provider as unknown as {
-          extractThinkTagsAsBlock: (text: string) => ThinkingBlock | null;
-        }
-      ).extractThinkTagsAsBlock(text);
-
     it('should extract single <think> tag content', () => {
       const text =
         '<think>Let me analyze this problem carefully.</think>Here is my answer.';
@@ -164,13 +151,6 @@ Third line with conclusion.
   });
 
   describe('sanitizeProviderText @requirement:REQ-THINK-003', () => {
-    const sanitizeProviderText = (text: unknown): string =>
-      (
-        provider as unknown as {
-          sanitizeProviderText: (text: unknown) => string;
-        }
-      ).sanitizeProviderText(text);
-
     it('should strip <think> tags and their content', () => {
       const text = '<think>Some thinking here.</think>Visible content remains.';
       const result = sanitizeProviderText(text);
@@ -288,13 +268,6 @@ Third line with conclusion.
      * causing <think> tags to leak into the visible output.
      */
     it('should sanitize text content for Kimi-K2 model (removing think tags)', () => {
-      const sanitizeProviderText = (text: unknown): string =>
-        (
-          provider as unknown as {
-            sanitizeProviderText: (text: unknown) => string;
-          }
-        ).sanitizeProviderText(text);
-
       // Simulate Kimi-K2 response with think tags in content
       const kimiContent =
         '<think>Let me analyze the code.</think>The code looks correct.';
@@ -310,13 +283,6 @@ Third line with conclusion.
     });
 
     it('should handle fragmented think tags from Synthetic API in Kimi-K2 content', () => {
-      const sanitizeProviderText = (text: unknown): string =>
-        (
-          provider as unknown as {
-            sanitizeProviderText: (text: unknown) => string;
-          }
-        ).sanitizeProviderText(text);
-
       // Synthetic API sends fragmented think tags token-by-token
       const fragmentedContent =
         '<think>The</think><think>user</think><think>asks</think>Here is the answer.';

--- a/packages/core/src/providers/utils/contentPreview.test.ts
+++ b/packages/core/src/providers/utils/contentPreview.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { getContentPreview } from './contentPreview.js';
+
+describe('getContentPreview', () => {
+  it('returns undefined for null or undefined', () => {
+    expect(getContentPreview(null)).toBeUndefined();
+    expect(getContentPreview(undefined)).toBeUndefined();
+  });
+
+  it('returns short strings as-is', () => {
+    expect(getContentPreview('hello')).toBe('hello');
+  });
+
+  it('truncates long strings with ellipsis', () => {
+    const long = 'a'.repeat(300);
+    const result = getContentPreview(long);
+    expect(result?.length).toBeLessThan(210);
+    expect(result).toContain('…');
+  });
+
+  it('respects custom maxLength', () => {
+    const result = getContentPreview('abcdefgh', 5);
+    expect(result).toBe('abcde…');
+  });
+
+  it('handles arrays of text parts', () => {
+    const content = [
+      { type: 'text', text: 'hello' },
+      { type: 'text', text: 'world' },
+    ];
+    expect(getContentPreview(content)).toBe('hello\nworld');
+  });
+
+  it('serializes non-text array parts as JSON', () => {
+    const content = [{ type: 'image', url: 'http://example.com' }];
+    const result = getContentPreview(content);
+    expect(result).toContain('image');
+    expect(result).toContain('example.com');
+  });
+
+  it('serializes plain objects as JSON', () => {
+    const result = getContentPreview({ key: 'value' });
+    expect(result).toBe('{"key":"value"}');
+  });
+
+  it('handles unserializable content gracefully', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(getContentPreview(circular)).toBe('[unserializable content]');
+  });
+});

--- a/packages/core/src/providers/utils/contentPreview.ts
+++ b/packages/core/src/providers/utils/contentPreview.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2025 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Get a short preview of a message's content for debug logging.
+ *
+ * Handles strings, arrays of content parts, and arbitrary objects.
+ * Truncates to maxLength with an ellipsis when content exceeds the limit.
+ */
+export function getContentPreview(
+  content: unknown,
+  maxLength = 200,
+): string | undefined {
+  if (content === null || content === undefined) {
+    return undefined;
+  }
+
+  if (typeof content === 'string') {
+    if (content.length <= maxLength) {
+      return content;
+    }
+    return `${content.slice(0, maxLength)}…`;
+  }
+
+  if (Array.isArray(content)) {
+    const textParts = (content as unknown[]).map((part) => {
+      if (
+        typeof part === 'object' &&
+        part !== null &&
+        'type' in part &&
+        (part as { type?: string }).type === 'text'
+      ) {
+        return (part as { text?: string }).text ?? '';
+      }
+      try {
+        return JSON.stringify(part);
+      } catch {
+        return '[unserializable part]';
+      }
+    });
+    const joined = textParts.join('\n');
+    if (joined.length <= maxLength) {
+      return joined;
+    }
+    return `${joined.slice(0, maxLength)}…`;
+  }
+
+  try {
+    const serialized = JSON.stringify(content);
+    if (serialized.length <= maxLength) {
+      return serialized;
+    }
+    return `${serialized.slice(0, maxLength)}…`;
+  } catch {
+    return '[unserializable content]';
+  }
+}

--- a/packages/core/src/providers/utils/qwenEndpoint.test.ts
+++ b/packages/core/src/providers/utils/qwenEndpoint.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { isQwenBaseURL } from './qwenEndpoint.js';
+
+describe('isQwenBaseURL', () => {
+  it('returns false for undefined or empty', () => {
+    expect(isQwenBaseURL(undefined)).toBe(false);
+    expect(isQwenBaseURL('')).toBe(false);
+    expect(isQwenBaseURL('  ')).toBe(false);
+  });
+
+  it('detects dashscope.aliyuncs.com', () => {
+    expect(isQwenBaseURL('https://dashscope.aliyuncs.com/v1')).toBe(true);
+    expect(isQwenBaseURL('https://sub.dashscope.aliyuncs.com')).toBe(true);
+  });
+
+  it('detects portal.qwen.ai', () => {
+    expect(isQwenBaseURL('https://portal.qwen.ai/api')).toBe(true);
+    expect(isQwenBaseURL('https://sub.qwen.ai')).toBe(true);
+  });
+
+  it('detects api.qwen.com', () => {
+    expect(isQwenBaseURL('https://api.qwen.com/v1')).toBe(true);
+    expect(isQwenBaseURL('https://sub.qwen.com')).toBe(true);
+  });
+
+  it('returns false for non-Qwen URLs', () => {
+    expect(isQwenBaseURL('https://api.openai.com/v1')).toBe(false);
+    expect(isQwenBaseURL('https://api.anthropic.com')).toBe(false);
+    expect(isQwenBaseURL('https://api.cerebras.ai')).toBe(false);
+  });
+
+  it('handles URLs without protocol', () => {
+    expect(isQwenBaseURL('dashscope.aliyuncs.com')).toBe(true);
+    expect(isQwenBaseURL('api.qwen.com')).toBe(true);
+  });
+
+  it('handles malformed URLs gracefully', () => {
+    expect(isQwenBaseURL('not a url at all')).toBe(false);
+  });
+});

--- a/packages/core/src/providers/utils/qwenEndpoint.ts
+++ b/packages/core/src/providers/utils/qwenEndpoint.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2025 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Detect whether a base URL points to a Qwen/DashScope endpoint.
+ *
+ * Covers dashscope.aliyuncs.com, portal.qwen.ai, api.qwen.com, and
+ * their subdomains.
+ */
+export function isQwenBaseURL(baseURL: string | undefined): boolean {
+  const candidate = baseURL?.trim();
+  if (!candidate) return false;
+
+  const normalized = candidate.includes('://')
+    ? candidate
+    : `https://${candidate}`;
+
+  try {
+    const hostname = new URL(normalized).hostname.toLowerCase();
+    return (
+      hostname === 'dashscope.aliyuncs.com' ||
+      hostname.endsWith('.dashscope.aliyuncs.com') ||
+      hostname === 'portal.qwen.ai' ||
+      hostname.endsWith('.qwen.ai') ||
+      hostname === 'api.qwen.com' ||
+      hostname.endsWith('.qwen.com')
+    );
+  } catch {
+    return false;
+  }
+}

--- a/packages/core/src/providers/utils/retryStrategy.test.ts
+++ b/packages/core/src/providers/utils/retryStrategy.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { shouldRetryOnStatus } from './retryStrategy.js';
+
+describe('shouldRetryOnStatus', () => {
+  it('retries on 429 status', () => {
+    expect(shouldRetryOnStatus({ status: 429 })).toBe(true);
+  });
+
+  it('retries on 500 status', () => {
+    expect(shouldRetryOnStatus({ status: 500 })).toBe(true);
+  });
+
+  it('retries on 503 status', () => {
+    expect(shouldRetryOnStatus({ status: 503 })).toBe(true);
+  });
+
+  it('does not retry on 200 status', () => {
+    expect(shouldRetryOnStatus({ status: 200 })).toBe(false);
+  });
+
+  it('does not retry on 400 status', () => {
+    expect(shouldRetryOnStatus({ status: 400 })).toBe(false);
+  });
+
+  it('does not retry on 401 status', () => {
+    expect(shouldRetryOnStatus({ status: 401 })).toBe(false);
+  });
+
+  it('detects 429 from error message', () => {
+    expect(shouldRetryOnStatus(new Error('Rate limit 429 exceeded'))).toBe(
+      true,
+    );
+  });
+
+  it('detects status from response.status', () => {
+    expect(shouldRetryOnStatus({ response: { status: 502 } })).toBe(true);
+  });
+
+  it('uses checkNetworkTransient callback when provided', () => {
+    const error = new Error('ECONNRESET');
+    const result = shouldRetryOnStatus(error, {
+      checkNetworkTransient: () => true,
+    });
+    expect(result).toBe(true);
+  });
+
+  it('does not call checkNetworkTransient when status retry applies', () => {
+    let called = false;
+    shouldRetryOnStatus(
+      { status: 500 },
+      {
+        checkNetworkTransient: () => {
+          called = true;
+          return true;
+        },
+      },
+    );
+    expect(called).toBe(false);
+  });
+});

--- a/packages/core/src/providers/utils/retryStrategy.ts
+++ b/packages/core/src/providers/utils/retryStrategy.ts
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2025 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DebugLogger } from '../../debug/index.js';
+
+export interface RetryOptions {
+  logger?: DebugLogger;
+  checkNetworkTransient?: (err: unknown) => boolean;
+}
+
+/**
+ * Determine whether an API error should be retried based on HTTP status codes.
+ *
+ * Retries on 429 (rate limit) and 5xx (server errors). Skips 200 status
+ * errors (streaming wrappers). Optionally checks for transient network
+ * errors via the provided callback.
+ */
+export function shouldRetryOnStatus(
+  error: unknown,
+  options?: RetryOptions,
+): boolean {
+  const logger = options?.logger;
+
+  if (
+    error &&
+    typeof error === 'object' &&
+    'status' in error &&
+    (error as { status?: number }).status === 200
+  ) {
+    return false;
+  }
+
+  let status: number | undefined;
+
+  if (error && typeof error === 'object' && 'status' in error) {
+    status = (error as { status?: number }).status;
+  }
+
+  if (!status && error && typeof error === 'object' && 'response' in error) {
+    const response = (error as { response?: { status?: number } }).response;
+    if (response && typeof response === 'object' && 'status' in response) {
+      status = response.status;
+    }
+  }
+
+  if (!status && error instanceof Error) {
+    if (error.message.includes('429')) {
+      status = 429;
+    }
+  }
+
+  logger?.debug(() => `shouldRetryOnStatus checking error:`, {
+    hasError: !!error,
+    errorType: error?.constructor?.name,
+    status,
+    errorMessage: error instanceof Error ? error.message : String(error),
+    errorKeys: error && typeof error === 'object' ? Object.keys(error) : [],
+    errorData:
+      error && typeof error === 'object' && 'error' in error
+        ? (error as { error?: unknown }).error
+        : undefined,
+  });
+
+  const shouldRetry = Boolean(
+    status === 429 || (status !== undefined && status >= 500 && status < 600),
+  );
+
+  if (!shouldRetry && options?.checkNetworkTransient?.(error)) {
+    logger?.debug(
+      () =>
+        `Will retry request due to network transient error: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return true;
+  }
+
+  if (shouldRetry) {
+    logger?.debug(() => `Will retry request due to status ${status}`);
+  }
+
+  return shouldRetry;
+}

--- a/packages/core/src/providers/utils/textSanitizer.test.ts
+++ b/packages/core/src/providers/utils/textSanitizer.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeProviderText } from './textSanitizer.js';
+
+describe('sanitizeProviderText', () => {
+  it('returns empty string for null or undefined', () => {
+    expect(sanitizeProviderText(null)).toBe('');
+    expect(sanitizeProviderText(undefined)).toBe('');
+  });
+
+  it('converts non-string input to string', () => {
+    expect(sanitizeProviderText(42)).toBe('42');
+    expect(sanitizeProviderText(true)).toBe('true');
+  });
+
+  it('strips <think>...</think> blocks', () => {
+    expect(sanitizeProviderText('before<think>hidden</think>after')).toBe(
+      'before after',
+    );
+  });
+
+  it('strips <thinking>...</thinking> blocks', () => {
+    expect(sanitizeProviderText('before<thinking>hidden</thinking>after')).toBe(
+      'before after',
+    );
+  });
+
+  it('strips <analysis>...</analysis> blocks', () => {
+    expect(sanitizeProviderText('before<analysis>hidden</analysis>after')).toBe(
+      'before after',
+    );
+  });
+
+  it('replaces with space to preserve word separation', () => {
+    const result = sanitizeProviderText('these<think>reasoning</think>5 items');
+    expect(result).toBe('these 5 items');
+  });
+
+  it('cleans up stray unmatched tags', () => {
+    expect(sanitizeProviderText('text<think>unclosed')).toBe('text unclosed');
+    expect(sanitizeProviderText('text</think>extra')).toBe('text extra');
+  });
+
+  it('preserves text without reasoning tags', () => {
+    expect(sanitizeProviderText(' 5 Biggest cities')).toBe(' 5 Biggest cities');
+  });
+
+  it('collapses whitespace only when tags were present', () => {
+    expect(sanitizeProviderText('a   b')).toBe('a   b');
+    expect(sanitizeProviderText('a<think>x</think>   b')).toBe('a b');
+  });
+
+  it('normalizes excessive newlines when tags present', () => {
+    const input = 'before<think>x</think>\n\n\n\nafter';
+    const result = sanitizeProviderText(input);
+    expect(result).not.toContain('\n\n\n');
+  });
+
+  it('preserves newlines in regular text', () => {
+    expect(sanitizeProviderText('line1\nline2')).toBe('line1\nline2');
+  });
+
+  it('is case-insensitive', () => {
+    expect(sanitizeProviderText('<THINK>hidden</THINK>visible')).toBe(
+      'visible',
+    );
+  });
+});

--- a/packages/core/src/providers/utils/textSanitizer.ts
+++ b/packages/core/src/providers/utils/textSanitizer.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2025 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DebugLogger } from '../../debug/index.js';
+
+/**
+ * Remove provider-specific thinking/reasoning markup from text.
+ *
+ * Strips <think>, <thinking>, and <analysis> tag blocks, replacing them with
+ * a single space to preserve word spacing (prevents "these<think>...</think>5"
+ * from becoming "these5"). Cleans up stray unmatched tags and collapses
+ * extra whitespace only when reasoning tags were present.
+ */
+export function sanitizeProviderText(
+  text: unknown,
+  logger?: DebugLogger,
+): string {
+  if (text === null || text === undefined) {
+    return '';
+  }
+
+  let str = typeof text === 'string' ? text : String(text);
+  const beforeLen = str.length;
+  const hadReasoningTags =
+    /<(?:think|thinking|analysis)>|<\/(?:think|thinking|analysis)>/i.test(str);
+
+  str = str.replace(/<think>[\s\S]*?<\/think>/gi, ' ');
+  str = str.replace(/<thinking>[\s\S]*?<\/thinking>/gi, ' ');
+  str = str.replace(/<analysis>[\s\S]*?<\/analysis>/gi, ' ');
+
+  str = str.replace(/<\/?(?:think|thinking|analysis)>/gi, ' ');
+
+  if (hadReasoningTags) {
+    str = str.replace(/[ \t]+/g, ' ');
+    str = str.replace(/\n{3,}/g, '\n\n');
+    str = str.replace(/^[ \t]+/, '');
+  }
+
+  const afterLen = str.length;
+  if (hadReasoningTags && afterLen !== beforeLen) {
+    logger?.debug(() => `Stripped reasoning tags`, {
+      beforeLen,
+      afterLen,
+    });
+  }
+
+  return str;
+}

--- a/packages/core/src/providers/utils/thinkingExtraction.test.ts
+++ b/packages/core/src/providers/utils/thinkingExtraction.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { extractThinkTagsAsBlock } from './thinkingExtraction.js';
+
+describe('extractThinkTagsAsBlock', () => {
+  it('returns null for empty input', () => {
+    expect(extractThinkTagsAsBlock('')).toBeNull();
+    expect(extractThinkTagsAsBlock(null as unknown as string)).toBeNull();
+    expect(extractThinkTagsAsBlock(undefined as unknown as string)).toBeNull();
+  });
+
+  it('returns null when no thinking tags found', () => {
+    expect(extractThinkTagsAsBlock('Hello world')).toBeNull();
+    expect(extractThinkTagsAsBlock('No tags here <b>bold</b>')).toBeNull();
+  });
+
+  it('extracts content from <think> tags', () => {
+    const result = extractThinkTagsAsBlock('<think>reasoning here</think>');
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe('thinking');
+    expect(result?.thought).toBe('reasoning here');
+    expect(result?.sourceField).toBe('think_tags');
+    expect(result?.isHidden).toBe(false);
+  });
+
+  it('extracts content from <thinking> tags', () => {
+    const result = extractThinkTagsAsBlock('<thinking>deep thought</thinking>');
+    expect(result?.thought).toBe('deep thought');
+  });
+
+  it('extracts content from <analysis> tags', () => {
+    const result = extractThinkTagsAsBlock(
+      '<analysis>analyzing the problem</analysis>',
+    );
+    expect(result?.thought).toBe('analyzing the problem');
+  });
+
+  it('combines multiple tag types with double newlines', () => {
+    const result = extractThinkTagsAsBlock(
+      '<think>first thought</think> text <thinking>second thought</thinking>',
+    );
+    expect(result?.thought).toBe('first thought\n\nsecond thought');
+  });
+
+  it('skips empty tag content', () => {
+    const result = extractThinkTagsAsBlock(
+      '<think></think><think>real thought</think>',
+    );
+    expect(result?.thought).toBe('real thought');
+  });
+
+  it('detects fragmented format and joins with spaces', () => {
+    const parts = Array.from(
+      { length: 10 },
+      (_, i) => `<think>word${i}</think>`,
+    ).join('');
+    const result = extractThinkTagsAsBlock(parts);
+    expect(result?.thought).toContain('word0 word1');
+  });
+
+  it('preserves internal newlines in standard format', () => {
+    const result = extractThinkTagsAsBlock(
+      '<think>line1\nline2\nline3</think>',
+    );
+    expect(result?.thought).toBe('line1\nline2\nline3');
+  });
+
+  it('is case-insensitive', () => {
+    const result = extractThinkTagsAsBlock('<THINK>upper case</THINK>');
+    expect(result?.thought).toBe('upper case');
+  });
+});

--- a/packages/core/src/providers/utils/thinkingExtraction.ts
+++ b/packages/core/src/providers/utils/thinkingExtraction.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2025 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ThinkingBlock } from '../../services/history/IContent.js';
+import type { DebugLogger } from '../../debug/index.js';
+
+/**
+ * Extract thinking content from <think>, <thinking>, or <analysis> tags
+ * and return it as a ThinkingBlock. Returns null if no thinking tags found.
+ *
+ * Must be called BEFORE sanitizeProviderText which strips these tags.
+ *
+ * Handles two formats:
+ * 1. Standard: <think>Full thinking paragraph here...</think>
+ * 2. Fragmented (Synthetic API): <think>word</think><think>word</think>...
+ *
+ * For fragmented format, joins with spaces. For standard, joins with newlines.
+ */
+export function extractThinkTagsAsBlock(
+  text: string,
+  logger?: DebugLogger,
+): ThinkingBlock | null {
+  if (!text) {
+    return null;
+  }
+
+  const thinkingParts: string[] = [];
+
+  const thinkMatches = text.matchAll(/<think>([\s\S]*?)<\/think>/gi);
+  for (const match of thinkMatches) {
+    const content = match[1];
+    if (content?.trim()) {
+      thinkingParts.push(content.trim());
+    }
+  }
+
+  const thinkingMatches = text.matchAll(/<thinking>([\s\S]*?)<\/thinking>/gi);
+  for (const match of thinkingMatches) {
+    const content = match[1];
+    if (content?.trim()) {
+      thinkingParts.push(content.trim());
+    }
+  }
+
+  const analysisMatches = text.matchAll(/<analysis>([\s\S]*?)<\/analysis>/gi);
+  for (const match of analysisMatches) {
+    const content = match[1];
+    if (content?.trim()) {
+      thinkingParts.push(content.trim());
+    }
+  }
+
+  if (thinkingParts.length === 0) {
+    return null;
+  }
+
+  const avgPartLength =
+    thinkingParts.reduce((sum, p) => sum + p.length, 0) / thinkingParts.length;
+  const isFragmented = thinkingParts.length > 5 && avgPartLength < 15;
+
+  const combinedThought = isFragmented
+    ? thinkingParts.join(' ')
+    : thinkingParts.join('\n\n');
+
+  logger?.debug(
+    () => `Extracted thinking from tags: ${combinedThought.length} chars`,
+    { tagCount: thinkingParts.length, isFragmented, avgPartLength },
+  );
+
+  return {
+    type: 'thinking',
+    thought: combinedThought,
+    sourceField: 'think_tags',
+    isHidden: false,
+  };
+}

--- a/packages/core/src/providers/utils/toolFormatDetection.test.ts
+++ b/packages/core/src/providers/utils/toolFormatDetection.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { detectToolFormat } from './toolFormatDetection.js';
+
+describe('detectToolFormat', () => {
+  it('detects kimi format for Kimi K2 models', () => {
+    expect(detectToolFormat('kimi-k2')).toBe('kimi');
+    expect(detectToolFormat('moonshot-v1-kimi-k2')).toBe('kimi');
+  });
+
+  it('detects mistral format for Mistral models', () => {
+    expect(detectToolFormat('mistral-large-latest')).toBe('mistral');
+    expect(detectToolFormat('mistral-small-latest')).toBe('mistral');
+  });
+
+  it('detects qwen format for GLM-4 models', () => {
+    expect(detectToolFormat('glm-4')).toBe('qwen');
+    expect(detectToolFormat('glm-4.5-flash')).toBe('qwen');
+    expect(detectToolFormat('GLM-4-Plus')).toBe('qwen');
+  });
+
+  it('detects qwen format for Qwen models', () => {
+    expect(detectToolFormat('qwen3-coder-plus')).toBe('qwen');
+    expect(detectToolFormat('qwen-turbo')).toBe('qwen');
+  });
+
+  it('defaults to openai format for standard models', () => {
+    expect(detectToolFormat('gpt-4o')).toBe('openai');
+    expect(detectToolFormat('gpt-4-turbo')).toBe('openai');
+    expect(detectToolFormat('o3-mini')).toBe('openai');
+  });
+
+  it('defaults to openai format for unknown models', () => {
+    expect(detectToolFormat('some-custom-model')).toBe('openai');
+  });
+});

--- a/packages/core/src/providers/utils/toolFormatDetection.ts
+++ b/packages/core/src/providers/utils/toolFormatDetection.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2025 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ToolFormat } from '../../tools/IToolFormatter.js';
+import { isKimiModel, isMistralModel } from '../../tools/ToolIdStrategy.js';
+import type { DebugLogger } from '../../debug/index.js';
+
+/**
+ * Auto-detect the tool format based on model name.
+ *
+ * Returns the appropriate ToolFormat for the given model so that tool IDs
+ * and invocation payloads match what the model endpoint expects.
+ */
+export function detectToolFormat(
+  modelName: string,
+  logger?: DebugLogger,
+): ToolFormat {
+  if (isKimiModel(modelName)) {
+    logger?.debug(
+      () => `Auto-detected 'kimi' format for K2 model: ${modelName}`,
+    );
+    return 'kimi';
+  }
+
+  if (isMistralModel(modelName)) {
+    logger?.debug(
+      () => `Auto-detected 'mistral' format for Mistral model: ${modelName}`,
+    );
+    return 'mistral';
+  }
+
+  const lowerModelName = modelName.toLowerCase();
+
+  if (lowerModelName.includes('glm-4')) {
+    logger?.debug(
+      () => `Auto-detected 'qwen' format for GLM-4.x model: ${modelName}`,
+    );
+    return 'qwen';
+  }
+
+  if (lowerModelName.includes('qwen')) {
+    logger?.debug(
+      () => `Auto-detected 'qwen' format for Qwen model: ${modelName}`,
+    );
+    return 'qwen';
+  }
+
+  logger?.debug(() => `Using default 'openai' format for model: ${modelName}`);
+  return 'openai';
+}

--- a/packages/core/src/providers/utils/toolIdNormalization.test.ts
+++ b/packages/core/src/providers/utils/toolIdNormalization.test.ts
@@ -19,7 +19,10 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { normalizeToOpenAIToolId } from './toolIdNormalization.js';
+import {
+  normalizeToOpenAIToolId,
+  normalizeToHistoryToolId,
+} from './toolIdNormalization.js';
 
 describe('normalizeToOpenAIToolId', () => {
   it('preserves call_ format unchanged', () => {
@@ -54,5 +57,39 @@ describe('normalizeToOpenAIToolId', () => {
 
   it('returns call_ for empty input', () => {
     expect(normalizeToOpenAIToolId('')).toBe('call_');
+  });
+
+  it('sanitizes invalid characters in suffix', () => {
+    expect(normalizeToOpenAIToolId('call_abc.123')).toBe('call_abc123');
+  });
+});
+
+describe('normalizeToHistoryToolId', () => {
+  it('preserves hist_tool_ format', () => {
+    expect(normalizeToHistoryToolId('hist_tool_abc123')).toBe(
+      'hist_tool_abc123',
+    );
+  });
+
+  it('converts call_XXX to hist_tool_XXX', () => {
+    expect(normalizeToHistoryToolId('call_abc123')).toBe('hist_tool_abc123');
+  });
+
+  it('converts toolu_XXX to hist_tool_XXX', () => {
+    expect(normalizeToHistoryToolId('toolu_abc123')).toBe('hist_tool_abc123');
+  });
+
+  it('prefixes unknown formats with hist_tool_', () => {
+    expect(normalizeToHistoryToolId('unknown_abc')).toBe(
+      'hist_tool_unknown_abc',
+    );
+  });
+
+  it('returns hist_tool_ for empty input', () => {
+    expect(normalizeToHistoryToolId('')).toBe('hist_tool_');
+  });
+
+  it('sanitizes invalid characters in suffix', () => {
+    expect(normalizeToHistoryToolId('call_abc.123')).toBe('hist_tool_abc123');
   });
 });

--- a/packages/core/src/providers/utils/toolNameNormalization.test.ts
+++ b/packages/core/src/providers/utils/toolNameNormalization.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeToolName } from './toolNameNormalization.js';
+
+describe('normalizeToolName', () => {
+  it('strips "functions" prefix from Kimi-style names', () => {
+    expect(normalizeToolName('functionslist_directory')).toBe('list_directory');
+    expect(normalizeToolName('functionssearch')).toBe('search');
+  });
+
+  it('strips "call_functions" prefix from Kimi-style names', () => {
+    expect(normalizeToolName('call_functionslist_directory6')).toBe(
+      'list_directory',
+    );
+    expect(normalizeToolName('call_functionsglob7')).toBe('glob');
+  });
+
+  it('lowercases normal names', () => {
+    expect(normalizeToolName('ReadFile')).toBe('readfile');
+    expect(normalizeToolName('run_shell_command')).toBe('run_shell_command');
+  });
+
+  it('handles empty/whitespace input', () => {
+    expect(normalizeToolName('')).toBe('');
+    expect(normalizeToolName('  ')).toBe('');
+  });
+
+  it('trims whitespace', () => {
+    expect(normalizeToolName('  glob  ')).toBe('glob');
+  });
+});

--- a/packages/core/src/providers/utils/toolNameNormalization.ts
+++ b/packages/core/src/providers/utils/toolNameNormalization.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2025 Vybestack LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Normalize tool name by stripping Kimi-K2 style prefixes.
+ *
+ * Handles malformed tool names where the model concatenates prefixes like
+ * "functions" or "call_functions" with the actual tool name:
+ * - "functionslist_directory" -> "list_directory"
+ * - "call_functionslist_directory6" -> "list_directory"
+ * - "call_functionsglob7" -> "glob"
+ */
+export function normalizeToolName(name: string): string {
+  let normalized = (name || '').trim();
+
+  const kimiPrefixMatch = /^(?:call_)?functions([a-z_]+[a-z])(\d*)$/i.exec(
+    normalized,
+  );
+  if (kimiPrefixMatch) {
+    normalized = kimiPrefixMatch[1];
+  }
+
+  return normalized.toLowerCase();
+}

--- a/packages/core/src/tools/ToolIdStrategy.ts
+++ b/packages/core/src/tools/ToolIdStrategy.ts
@@ -21,7 +21,7 @@ import type {
   ContentBlock,
 } from '../services/history/IContent.js';
 import type { ToolFormat } from './IToolFormatter.js';
-import { normalizeToOpenAIToolId } from '../providers/openai-vercel/toolIdUtils.js';
+import { normalizeToOpenAIToolId } from '../providers/utils/toolIdNormalization.js';
 import crypto from 'node:crypto';
 
 /**


### PR DESCRIPTION
Fixes #373

## Summary

Factors duplicated code from \`OpenAIProvider\` (4967 lines) and \`OpenAIVercelProvider\` (1967 lines) into shared pure-function utilities in \`packages/core/src/providers/utils/\`, reducing both providers significantly while enabling future OpenAI-compatible providers to reuse the same helpers.

## What Changed

### New Shared Utilities (7 files + 7 test files)

| Utility | Function | Purpose |
|---------|----------|---------|
| \`thinkingExtraction.ts\` | \`extractThinkTagsAsBlock\` | Parse think/thinking/analysis tags, detect fragmented vs standard format |
| \`textSanitizer.ts\` | \`sanitizeProviderText\` | Strip reasoning markup, preserve word spacing, collapse whitespace |
| \`toolFormatDetection.ts\` | \`detectToolFormat\` | Auto-detect kimi/mistral/qwen/openai format from model name |
| \`contentPreview.ts\` | \`getContentPreview\` | Truncate message content for debug logging |
| \`qwenEndpoint.ts\` | \`isQwenBaseURL\` | Detect Qwen/DashScope endpoint URLs |
| \`retryStrategy.ts\` | \`shouldRetryOnStatus\` | Shared 429/5xx retry logic with optional network transient check |
| \`toolNameNormalization.ts\` | \`normalizeToolName\` | Strip Kimi-K2 style prefixes from tool names |

### Consolidated Tool ID Normalization

- Added \`normalizeToHistoryToolId\` to the existing shared \`toolIdNormalization.ts\` (previously only had \`normalizeToOpenAIToolId\`)
- Made \`openai-vercel/toolIdUtils.ts\` a thin re-export layer from the shared location
- Updated \`ToolIdStrategy.ts\` and \`reasoningUtils.ts\` to import from the shared canonical location

### Provider Updates

- **OpenAIProvider**: Removed ~490 lines of private methods, now imports from shared utilities
- **OpenAIVercelProvider**: Removed ~370 lines of private methods/functions, now imports from shared utilities
- Both providers pass the same test suites with no behavior changes

## Test Coverage

All 7 new utility files have corresponding test files with 100% behavior coverage:
- thinkingExtraction: tag parsing, fragmented detection, case insensitivity
- textSanitizer: tag stripping, word spacing, whitespace handling
- toolFormatDetection: model-specific format detection
- contentPreview: string/array/object/null handling, truncation
- qwenEndpoint: URL pattern matching across Qwen endpoints
- retryStrategy: status code retry logic, network transient callback
- toolNameNormalization: Kimi prefix stripping, lowercasing
- toolIdNormalization: expanded with normalizeToHistoryToolId tests

## Verification

All pass:
- npm run test
- npm run lint
- npm run typecheck
- npm run format
- npm run build
- Smoke test (synthetic provider haiku generation)