### PR TITLE
fix(oauth): eliminate dual-refresh race in Anthropic token handling

### DIFF
--- a/packages/cli/src/auth/anthropic-oauth-provider.no-refresh-on-gettoken.spec.ts
+++ b/packages/cli/src/auth/anthropic-oauth-provider.no-refresh-on-gettoken.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Issue #1378: Verify AnthropicOAuthProvider.getToken() does NOT trigger
+ * provider-level refresh. OAuthManager owns all refresh operations.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AnthropicOAuthProvider } from './anthropic-oauth-provider.js';
+import type { OAuthToken, TokenStore } from '@vybestack/llxprt-code-core';
+
+function expiredToken(): OAuthToken {
+  return {
+    access_token: 'expired-access-token',
+    refresh_token: 'refresh-token',
+    expiry: Math.floor(Date.now() / 1000) - 60, // expired 60s ago
+    token_type: 'Bearer',
+    scope: null,
+  };
+}
+
+function validToken(): OAuthToken {
+  return {
+    access_token: 'valid-access-token',
+    refresh_token: 'refresh-token',
+    expiry: Math.floor(Date.now() / 1000) + 3600, // valid for 1h
+    token_type: 'Bearer',
+    scope: null,
+  };
+}
+
+describe('AnthropicOAuthProvider.getToken() - no provider-level refresh (Issue #1378)', () => {
+  let tokenStore: TokenStore;
+
+  beforeEach(() => {
+    tokenStore = {
+      saveToken: vi.fn(async () => undefined),
+      getToken: vi.fn(async () => null),
+      removeToken: vi.fn(async () => undefined),
+      listProviders: vi.fn(async () => []),
+      listBuckets: vi.fn(async () => ['default']),
+      getBucketStats: vi.fn(async () => null),
+      acquireRefreshLock: vi.fn(async () => true),
+      releaseRefreshLock: vi.fn(async () => undefined),
+    } satisfies TokenStore;
+  });
+
+  it('returns expired token without attempting refresh', async () => {
+    const expired = expiredToken();
+    vi.mocked(tokenStore.getToken).mockResolvedValue(expired);
+
+    const provider = new AnthropicOAuthProvider(tokenStore);
+    const deviceFlow = (
+      provider as unknown as {
+        deviceFlow: {
+          refreshToken: (refreshToken: string) => Promise<OAuthToken>;
+        };
+      }
+    ).deviceFlow;
+    deviceFlow.refreshToken = vi.fn(async () => validToken());
+
+    const result = await provider.getToken();
+
+    // getToken() should return the expired token as-is
+    expect(result).toEqual(expired);
+    // deviceFlow.refreshToken should NOT be called
+    expect(deviceFlow.refreshToken).not.toHaveBeenCalled();
+    // tokenStore.acquireRefreshLock should NOT be called from getToken()
+    expect(tokenStore.acquireRefreshLock).not.toHaveBeenCalled();
+    // tokenStore.saveToken should NOT be called from getToken()
+    expect(tokenStore.saveToken).not.toHaveBeenCalled();
+  });
+
+  it('returns valid token directly from store', async () => {
+    const valid = validToken();
+    vi.mocked(tokenStore.getToken).mockResolvedValue(valid);
+
+    const provider = new AnthropicOAuthProvider(tokenStore);
+
+    const result = await provider.getToken();
+
+    expect(result).toEqual(valid);
+    expect(tokenStore.acquireRefreshLock).not.toHaveBeenCalled();
+  });
+
+  it('returns null when no token exists', async () => {
+    vi.mocked(tokenStore.getToken).mockResolvedValue(null);
+
+    const provider = new AnthropicOAuthProvider(tokenStore);
+
+    const result = await provider.getToken();
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when no token store is configured', async () => {
+    const provider = new AnthropicOAuthProvider(undefined);
+
+    const result = await provider.getToken();
+
+    expect(result).toBeNull();
+  });
+});

--- a/packages/cli/src/auth/anthropic-oauth-provider.ts
+++ b/packages/cli/src/auth/anthropic-oauth-provider.ts
@@ -414,15 +414,8 @@ export class AnthropicOAuthProvider implements OAuthProvider {
     }
 
     return this.errorHandler.handleGracefully(
-      async () => {
-        // @pseudocode line 72: Return token from store, but check if refresh is needed
-        const token = await this._tokenStore!.getToken('anthropic');
-        if (token && this.isTokenExpired(token)) {
-          // Token is expired or near expiry, try to refresh
-          return await this.refreshIfNeeded();
-        }
-        return token;
-      },
+      // Issue #1378: Return token as-is; OAuthManager owns all refresh operations
+      async () => this._tokenStore!.getToken('anthropic'),
       null, // Return null on error
       this.name,
       'getToken',
@@ -442,6 +435,11 @@ export class AnthropicOAuthProvider implements OAuthProvider {
    * 4. If lock not acquired, wait and re-check disk
    */
   async refreshIfNeeded(): Promise<OAuthToken | null> {
+    // Issue #1378: OAuthManager should handle all refresh operations
+    this.logger.debug(
+      () =>
+        'refreshIfNeeded() called directly on provider (deprecated: OAuthManager should handle refresh)',
+    );
     await this.ensureInitialized();
     if (!this._tokenStore) {
       return null;


### PR DESCRIPTION
## Summary

Fixes #1378

Eliminates a race condition in Anthropic OAuth token refresh that caused token revocation and forced re-authentication, especially when multiple sessions or subagents share the same default bucket.

## Root Cause

`AnthropicOAuthProvider.getToken()` had its own refresh logic: when it detected an expired token, it called `refreshIfNeeded()`, which acquired its own lock and called `deviceFlow.refreshToken()` directly. Meanwhile, `OAuthManager.getOAuthToken()` also performed refresh with its own cross-process locking via `provider.refreshToken()`.

When multiple sessions/subagents shared the same bucket (especially \`default\`), both paths could race on the same single-use refresh token. Anthropic detected this as refresh token replay and revoked the session.

**OpenAI/Codex did NOT have this problem** because \`CodexOAuthProvider.getToken()\` simply returns the stored token without any refresh logic -- all refresh goes exclusively through OAuthManager.

## Changes

### Production Fix
- **\`AnthropicOAuthProvider.getToken()\`**: Removed the expired-token check and \`refreshIfNeeded()\` call. Now simply returns the stored token as-is (matching the CodexOAuthProvider pattern). OAuthManager is the sole authority for token refresh with proper cross-process locking.
- **\`AnthropicOAuthProvider.refreshIfNeeded()\`**: Added deprecation debug log. Method preserved for backward compatibility.

### Tests
- **New**: \`anthropic-oauth-provider.no-refresh-on-gettoken.spec.ts\` -- 4 tests proving \`getToken()\` does NOT trigger provider-level refresh (expired token returned as-is, valid token returned, null cases)
- **Extended**: \`oauth-manager.refresh-race.spec.ts\` -- New test proving OAuthManager is the sole refresh authority and does not use \`provider.getToken()\` for refresh

## Verification
- All tests pass (npm run test)
- Lint clean (npm run lint)
- Type check clean (npm run typecheck)
- Format clean (npm run format)
- Build successful (npm run build)
- Smoke test passed (haiku generated)