### PR TITLE
fix(sandbox): compute correct --max-old-space-size for sandbox processes

### DIFF
--- a/packages/cli/src/gemini.provider-init.test.ts
+++ b/packages/cli/src/gemini.provider-init.test.ts
@@ -88,6 +88,8 @@ vi.mock('./utils/sandbox.js', () => ({
 
 vi.mock('./utils/bootstrap.js', () => ({
   shouldRelaunchForMemory: vi.fn(() => []),
+  computeSandboxMemoryArgs: vi.fn(() => ['--max-old-space-size=3072']),
+  parseDockerMemoryToMB: vi.fn(() => undefined),
   isDebugMode: vi.fn(() => false),
 }));
 

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -51,7 +51,12 @@ import { readStdin } from './utils/readStdin.js';
 import { basename } from 'node:path';
 import dns from 'node:dns';
 import { start_sandbox } from './utils/sandbox.js';
-import { shouldRelaunchForMemory, isDebugMode } from './utils/bootstrap.js';
+import {
+  shouldRelaunchForMemory,
+  isDebugMode,
+  computeSandboxMemoryArgs,
+  parseDockerMemoryToMB,
+} from './utils/bootstrap.js';
 import { relaunchAppInChildProcess } from './utils/relaunch.js';
 import chalk from 'chalk';
 import {
@@ -762,11 +767,28 @@ export async function main() {
 
   // hop into sandbox if we are outside and sandboxing is enabled
   if (!process.env.SANDBOX) {
-    // Memory relaunch was already handled at the top of main() before config loading
-    // Now only handle sandbox entry, which needs memory args passed to the sandbox process
-    const sandboxMemoryArgs = settings.merged.ui?.autoConfigureMaxOldSpaceSize
-      ? shouldRelaunchForMemory(config.getDebugMode())
-      : [];
+    // For sandbox, always compute memory args for the new process.
+    // Unlike shouldRelaunchForMemory() which compares against the host's current heap,
+    // computeSandboxMemoryArgs() always returns args because the sandbox starts fresh
+    // with Node.js default ~950MB heap.
+    let sandboxMemoryArgs: string[] = [];
+    if (settings.merged.ui?.autoConfigureMaxOldSpaceSize) {
+      const containerMemoryStr =
+        process.env.LLXPRT_SANDBOX_MEMORY ?? process.env.SANDBOX_MEMORY;
+      let containerMemoryMB: number | undefined;
+      if (containerMemoryStr) {
+        containerMemoryMB = parseDockerMemoryToMB(containerMemoryStr);
+      } else if (process.env.SANDBOX_FLAGS) {
+        const match = process.env.SANDBOX_FLAGS.match(/--memory[= ](\S+)/);
+        if (match) {
+          containerMemoryMB = parseDockerMemoryToMB(match[1]);
+        }
+      }
+      sandboxMemoryArgs = computeSandboxMemoryArgs(
+        config.getDebugMode(),
+        containerMemoryMB,
+      );
+    }
     const sandboxConfig = config.getSandbox();
     if (sandboxConfig) {
       // We intentionally omit the list of extensions here because extensions


### PR DESCRIPTION
## Summary

Sandbox containers were blowing their Node.js heap (~950MB default) because \`shouldRelaunchForMemory()\` was comparing the **host process's** current heap against host memory, returning empty args when the host already had enough heap. The sandbox then started with Node.js defaults, which OOMed during directory scanning for @ suggestions.

## Root Cause

In \`gemini.tsx\` line 767-769, the sandbox memory calculation used \`shouldRelaunchForMemory()\` which:
1. Uses \`os.totalmem()\` (HOST memory) and \`v8.getHeapStatistics()\` (HOST heap)
2. Compares the target (50% of host memory) against the HOST's current heap limit
3. If the host already has enough heap, returns \`[]\` (empty - no memory args)

The empty args were passed to \`start_sandbox()\` which sets \`NODE_OPTIONS\` for the container. The container started with Node.js default ~950MB heap, crashing during directory scanning.

Additionally, the sandbox child process skips the relaunch check (\`!process.env.SANDBOX\` at line 362), so the host MUST compute correct args.

## Changes

### \`packages/cli/src/utils/bootstrap.ts\`
- Added \`parseDockerMemoryToMB()\` - parses Docker memory format strings (e.g. "6g" -> 6144, "4096m" -> 4096, "1073741824" bytes -> 1024)
- Added \`computeSandboxMemoryArgs()\` - ALWAYS returns \`--max-old-space-size=N\` where N = 50% of available memory. Unlike \`shouldRelaunchForMemory()\`, never compares against current process heap since the sandbox starts fresh
- \`shouldRelaunchForMemory()\` is UNCHANGED - still used for host process relaunch at line 366

### \`packages/cli/src/gemini.tsx\`
- Replaced \`shouldRelaunchForMemory()\` call in sandbox entry path with \`computeSandboxMemoryArgs()\`
- Reads container memory from \`LLXPRT_SANDBOX_MEMORY\`, \`SANDBOX_MEMORY\` env vars, or parses \`--memory\` from \`SANDBOX_FLAGS\`
- Falls back to host memory (for seatbelt sandboxes without explicit memory limits)

### Tests
- Added 13 tests for \`parseDockerMemoryToMB\` and \`computeSandboxMemoryArgs\` in \`bootstrap.test.ts\`
- Updated mock in \`gemini.provider-init.test.ts\` to include new exports

## Verification
- All tests pass (6584 + 3599 + 49 + 32 = 10264 tests)
- Lint clean
- Type check clean
- Build succeeds
- Smoke test passes

Fixes #1380