### PR TITLE
fix: bucket failover handles 403 errors and wraps around all buckets (Fixes #1191)

### DIFF
--- a/packages/cli/src/auth/BucketFailoverHandlerImpl.ts
+++ b/packages/cli/src/auth/BucketFailoverHandlerImpl.ts
@@ -84,13 +84,9 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
    */
   async tryFailover(): Promise<boolean> {
     const currentBucket = this.getCurrentBucket();
-    const startIndex = this.currentBucketIndex + 1;
 
-    for (
-      let nextIndex = startIndex;
-      nextIndex < this.buckets.length;
-      nextIndex++
-    ) {
+    for (let i = 1; i < this.buckets.length; i++) {
+      const nextIndex = (this.currentBucketIndex + i) % this.buckets.length;
       const nextBucket = this.buckets[nextIndex];
       logger.debug('Attempting bucket failover', {
         provider: this.provider,
@@ -115,6 +111,9 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
         this.currentBucketIndex = nextIndex;
         this.oauthManager.setSessionBucket(this.provider, nextBucket);
 
+        console.warn(
+          `Bucket failover: switching from ${currentBucket} to ${nextBucket}`,
+        );
         logger.debug('Bucket failover successful', {
           provider: this.provider,
           newBucket: nextBucket,
@@ -132,6 +131,9 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
       }
     }
 
+    console.error(
+      `Bucket failover: all buckets exhausted for provider ${this.provider}`,
+    );
     logger.debug('No more buckets available for failover', {
       provider: this.provider,
       currentBucket,

--- a/packages/core/src/providers/RetryOrchestrator.ts
+++ b/packages/core/src/providers/RetryOrchestrator.ts
@@ -557,7 +557,10 @@ export class RetryOrchestrator implements IProvider {
   private getBucketFailoverHandler(
     options: GenerateChatOptions,
   ): BucketFailoverHandler | undefined {
-    return options.runtime?.config?.getBucketFailoverHandler?.();
+    return (
+      options.runtime?.config?.getBucketFailoverHandler?.() ??
+      options.config?.getBucketFailoverHandler?.()
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #1191 - Bucket failover now properly handles 403 permission errors and tries all available buckets before giving up.

## Problem

When a bucketed Anthropic profile had one cancelled account (account1) and one valid account (account2):
1. A 403 \`permission_error\` was shown to the user instead of triggering failover to account2
2. Logging out of account1 and re-prompting forced re-authentication of BOTH buckets, even account2 which was still valid
3. Bucket failover could only iterate forward through the bucket list, never wrapping around to earlier buckets

## Changes

### Bug 1: Wrap-around bucket failover (\`BucketFailoverHandlerImpl.ts\`)
- Changed \`tryFailover()\` loop from forward-only iteration to modular arithmetic wrap-around
- Now tries ALL other buckets: if on bucket index 2 of [0,1,2,3], tries [3,0,1] in order
- Prevents the case where being on the last bucket means failover always fails

### Bug 2: Failover before full re-auth (\`oauth-manager.ts\`)
- \`getToken()\` now attempts bucket failover before falling through to the browser-based OAuth flow
- Gets the failover handler from config, calls \`tryFailover()\`, then re-fetches the token
- Only triggers full OAuth re-authentication if failover fails or no handler is available

### Bug 3: User-visible notifications (\`BucketFailoverHandlerImpl.ts\`)
- Added \`console.warn\` on successful failover: shows which bucket switched to
- Added \`console.error\` when all buckets exhausted: alerts user that no buckets remain

### Bug 4: Config fallback for failover handler (\`RetryOrchestrator.ts\`)
- \`getBucketFailoverHandler()\` now checks \`options.config\` as fallback when \`options.runtime?.config\` is unavailable
- Matches the multi-source lookup pattern already used in AnthropicProvider

## Testing

- 5 new tests across 3 test files covering wrap-around, failover-before-OAuth, and config fallback
- All 10,821 existing tests continue to pass
- Lint, typecheck, format, build all clean
- Smoke test passes

## Files Changed (6 files, +197/-7)
- \`packages/cli/src/auth/BucketFailoverHandlerImpl.ts\` - wrap-around + notifications
- \`packages/cli/src/auth/BucketFailoverHandlerImpl.spec.ts\` - 2 new tests
- \`packages/cli/src/auth/oauth-manager.ts\` - failover before re-auth
- \`packages/cli/src/auth/oauth-manager.bucketFailover.spec.ts\` - 2 new tests  
- \`packages/core/src/providers/RetryOrchestrator.ts\` - config fallback
- \`packages/core/src/providers/__tests__/RetryOrchestrator.test.ts\` - 1 new test