### PR TITLE
fix(ci): use --type instead of --label for bug issue creation (Fixes #1429)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -598,6 +598,6 @@ jobs:
           gh issue create \
             --title "Release Failed for ${{ steps.version.outputs.RELEASE_TAG || 'N/A' }} on $(date +'%Y-%m-%d')" \
             --body "The release workflow failed. See the full run for details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            --label "bug"
+            --type "Bug"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes #1429

The release workflow was using --label "bug" when creating issues on failure, but the bug label was removed as it is redundant with the GitHub issue type "Bug".

## Changes

- Changed .github/workflows/release.yml to use --type "Bug" instead of --label "bug" when creating issues on workflow failure

## Why

GitHub now supports issue types (Bug, Feature, Task) that are separate from labels. The project removed the redundant "bug" label in favor of using the Bug type, but the release workflow was not updated, causing failures when trying to create issues for failed releases.

## Testing

- Verified the change is syntactically correct YAML
- Tested CLI with synthetic profile: node bundle/llxprt.js --profile-load syntheticglm47 (works correctly)
- npm run test passes
- npm run lint passes
- npm run format passes

Note: Pre-existing typecheck and build failures on main branch are unrelated to this workflow-only change.