### PR TITLE
feat(codex): add gpt-5.3-codex-spark to Codex provider models (Fixes #1433)

### DIFF
--- a/packages/cli/src/providers/aliases/codex.config
+++ b/packages/cli/src/providers/aliases/codex.config
@@ -13,6 +13,7 @@
   },
   "staticModels": [
     { "id": "gpt-5.3-codex", "name": "gpt-5.3-codex" },
+    { "id": "gpt-5.3-codex-spark", "name": "gpt-5.3-codex-spark" },
     { "id": "gpt-5.2-codex", "name": "gpt-5.2-codex" },
     { "id": "gpt-5.1-codex-max", "name": "gpt-5.1-codex-max" },
     { "id": "gpt-5.1-codex", "name": "gpt-5.1-codex" },

--- a/packages/core/src/providers/openai-responses/CODEX_MODELS.ts
+++ b/packages/core/src/providers/openai-responses/CODEX_MODELS.ts
@@ -31,6 +31,13 @@ export const CODEX_MODELS: IModel[] = [
     supportedToolFormats: ['openai'],
   },
   {
+    id: 'gpt-5.3-codex-spark',
+    name: 'gpt-5.3-codex-spark',
+    provider: 'codex',
+    supportedToolFormats: ['openai'],
+    contextWindow: 131072, // 128K context (smaller than gpt-5.3-codex's 256K)
+  },
+  {
     id: 'gpt-5.2-codex',
     name: 'gpt-5.2-codex',
     provider: 'codex',

--- a/packages/core/src/providers/openai-responses/__tests__/OpenAIResponsesProvider.models.test.ts
+++ b/packages/core/src/providers/openai-responses/__tests__/OpenAIResponsesProvider.models.test.ts
@@ -57,9 +57,10 @@ describe('OpenAIResponsesProvider - Codex Model Listing', () => {
       );
       const models = await provider.getModels();
 
-      // Verify all expected Codex models are present (based on codex-rs list_models.rs + #1308 update)
+      // Verify all expected Codex models are present (based on codex-rs list_models.rs + #1308 update + #1433 gpt-5.3-codex-spark)
       const modelIds = models.map((m) => m.id);
       expect(modelIds).toContain('gpt-5.3-codex');
+      expect(modelIds).toContain('gpt-5.3-codex-spark');
       expect(modelIds).toContain('gpt-5.2-codex');
       expect(modelIds).toContain('gpt-5.1-codex-max');
       expect(modelIds).toContain('gpt-5.1-codex');
@@ -102,9 +103,10 @@ describe('OpenAIResponsesProvider - Codex Model Listing', () => {
       );
       const models = await provider.getModels();
 
-      // Expected models in priority order (with #1308 gpt-5.3-codex addition)
+      // Expected models in priority order (with #1308 gpt-5.3-codex addition + #1433 gpt-5.3-codex-spark)
       const expectedModelIds = [
         'gpt-5.3-codex',
+        'gpt-5.3-codex-spark',
         'gpt-5.2-codex',
         'gpt-5.1-codex-max',
         'gpt-5.1-codex',
@@ -139,6 +141,19 @@ describe('OpenAIResponsesProvider - Codex Model Listing', () => {
       const gpt51 = models.find((m) => m.id === 'gpt-5.1');
       expect(gpt51).toBeDefined();
       expect(gpt51?.name).toBe('gpt-5.1');
+    });
+
+    it('should set contextWindow for gpt-5.3-codex-spark (128K)', async () => {
+      const provider = new OpenAIResponsesProvider(
+        'test-api-key',
+        'https://chatgpt.com/backend-api/codex',
+      );
+      const models = await provider.getModels();
+
+      // gpt-5.3-codex-spark has explicit 128K context window (smaller than default 256K)
+      const spark = models.find((m) => m.id === 'gpt-5.3-codex-spark');
+      expect(spark).toBeDefined();
+      expect(spark?.contextWindow).toBe(131072);
     });
   });
 


### PR DESCRIPTION
## Summary

Add support for the new GPT-5.3-Codex-Spark model to the Codex provider list.

## Background

GPT-5.3-Codex-Spark is a new OpenAI model with:
- 128K context window (text-only)
- 1000+ tokens/second generation speed (15x faster than GPT-5.3-Codex)
- Smaller model optimized for real-time coding and speed
- NOT suitable for xhigh reasoning effort (speed-optimized smaller model)

## Changes

### packages/core/src/providers/openai-responses/CODEX_MODELS.ts
- Added `gpt-5.3-codex-spark` model entry to CODEX_MODELS array
- Positioned right after `gpt-5.3-codex` to maintain logical ordering

### packages/cli/src/providers/aliases/codex.config
- Added `gpt-5.3-codex-spark` to staticModels array
- Positioned right after `gpt-5.3-codex`

### packages/core/src/providers/openai-responses/__tests__/OpenAIResponsesProvider.models.test.ts
- Updated test expectations to include `gpt-5.3-codex-spark`
- Updated comments to reference issue #1433

## Testing

- All modified tests pass
- Linting passes
- Format passes
- Pre-existing issues on main (LSP integration tests, typecheck errors, build errors) are unrelated to this PR

Fixes #1433