### PR TITLE
fix(subagent): forward user-agent ephemeral setting to subagents (Fixes #1435)

### DIFF
--- a/packages/core/src/core/subagentOrchestrator.ts
+++ b/packages/core/src/core/subagentOrchestrator.ts
@@ -469,6 +469,13 @@ export class SubagentOrchestrator {
     if (disabled) {
       service.set('tools.disabled', disabled);
     }
+
+    const userAgent = this.getStringSetting(profile.ephemeralSettings, [
+      'user-agent',
+    ]);
+    if (userAgent) {
+      service.set('user-agent', userAgent);
+    }
   }
 
   private getNumberSetting(


### PR DESCRIPTION
## Summary

This PR fixes an issue where the Kimi provider was triggering 403 errors when used as a subagent.

## Problem

The Kimi provider alias requires a custom `User-Agent: RooCode/1.0` header to be sent, which is configured via the `user-agent` ephemeral setting. While this worked correctly in the foreground agent, subagents did not receive this header because the `populateSettingsService` method in `subagentOrchestrator.ts` was not forwarding the `user-agent` setting.

This caused Kimi to return a 403 error:
> Kimi For Coding is currently only available for Coding Agents such as Kimi CLI, Claude Code, Roo Code, Kilo Code, etc.

## Solution

Added `user-agent` to the list of ephemeral settings forwarded from the profile to the subagent's SettingsService in `populateSettingsService`, following the same pattern used for other ephemeral settings like `base-url`, `auth-key`, and `tool-format`.

## Changes

- **packages/core/src/core/subagentOrchestrator.ts**: Added 7 lines to extract and forward the `user-agent` ephemeral setting
- **packages/core/src/core/subagentOrchestrator.test.ts**: Added test case that verifies user-agent is correctly forwarded to the subagent SettingsService

## Testing

- [x] Added unit test verifying user-agent forwarding
- [x] All core tests pass (13/13 in subagentOrchestrator.test.ts)
- [x] Lint passes
- [x] Format passes
- [x] Smoke test with haiku generation passes

## Pre-existing issues (not introduced by this PR)

The following failures also exist on main branch:
- LSP integration tests (8 failures) - missing `vscode-jsonrpc/node.js` module
- TypeScript errors in `lsp-service-client.ts` and `useGeminiStream.ts`
- Build failures due to the above TypeScript issues

Fixes #1435