### PR TITLE
Fix task subagent sessionId context propagation (Fixes #1447)

### DIFF
--- a/packages/core/src/core/subagent.test.ts
+++ b/packages/core/src/core/subagent.test.ts
@@ -1067,6 +1067,31 @@ describe('subagent.ts', () => {
         expect(scope.output.terminate_reason).toBe(SubagentTerminateMode.ERROR);
       });
 
+      it('should throw an error if sessionId template variable is missing', async () => {
+        const { config } = await createMockConfig();
+        const promptConfig: PromptConfig = {
+          systemPrompt: 'Session ${sessionId}',
+        };
+        const context = new ContextState();
+
+        const { overrides } = createRuntimeOverrides();
+        const scope = await SubAgentScope.create(
+          'test-agent',
+          config,
+          promptConfig,
+          defaultModelConfig,
+          defaultRunConfig,
+          undefined,
+          undefined,
+          overrides,
+        );
+
+        await expect(scope.runNonInteractive(context)).rejects.toThrow(
+          'Missing context values for the following keys: sessionId',
+        );
+        expect(scope.output.terminate_reason).toBe(SubagentTerminateMode.ERROR);
+      });
+
       it('should validate that systemPrompt and initialMessages are mutually exclusive', async () => {
         const { config } = await createMockConfig();
         const promptConfig: PromptConfig = {

--- a/packages/core/src/tools/task.ts
+++ b/packages/core/src/tools/task.ts
@@ -487,6 +487,12 @@ class TaskToolInvocation extends BaseToolInvocation<
     const context = new ContextState();
     context.set('task_goal', this.normalized.goalPrompt);
     context.set('task_name', this.normalized.subagentName);
+
+    const sessionId = this.config.getSessionId();
+    if (sessionId.length > 0) {
+      context.set('sessionId', sessionId);
+    }
+
     for (const [key, value] of Object.entries(this.normalized.context)) {
       context.set(key, value);
     }


### PR DESCRIPTION
## Summary
Fixes #1447

- backfill sessionId into task-created subagent context using config.getSessionId when available
- preserve explicit caller-provided context.sessionId by applying caller context after backfill
- add regression tests covering backfill, explicit override precedence, and empty session id behavior
- add subagent template test asserting missing sessionId still throws when unavailable

## Verification
- npm run test
- npm run lint
- npm run typecheck
- npm run format
- npm run build
- node scripts/start.js --profile-load synthetic --keyfile ~/.llxprt/keys/.synthetic2_key "write me a haiku and nothing else"
