### PR TITLE
Fix profile clear semantics for key/keyfile/base-url (Fixes #208)

### DIFF
--- a/packages/cli/src/runtime/__tests__/authKeyName.test.ts
+++ b/packages/cli/src/runtime/__tests__/authKeyName.test.ts
@@ -445,4 +445,88 @@ describe('API key precedence and named key resolution @plan:PLAN-20260211-SECURE
     config.setEphemeralSetting('auth-key-name', 'mykey');
     expect(config.getEphemeralSetting('auth-key-name')).toBe('mykey');
   });
+
+  describe('Issue #208 auth-key-name clear behavior', () => {
+    let mockKeyring: KeyringAdapter & { store: Map<string, string> };
+    let tempDir: string;
+    let runtimeMod: typeof import('../runtimeSettings.js');
+    let contextFactoryMod: typeof import('../runtimeContextFactory.js');
+    let cleanupHandle: (() => Promise<void> | void) | null = null;
+
+    beforeEach(async () => {
+      mockKeyring = createMockKeyring();
+      tempDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), 'auth-key-name-clear-'),
+      );
+      mockStorageRef = createTestStorage(mockKeyring, tempDir);
+
+      runtimeMod = await import('../runtimeSettings.js');
+      contextFactoryMod = await import('../runtimeContextFactory.js');
+    });
+
+    afterEach(async () => {
+      if (cleanupHandle) {
+        await Promise.resolve(cleanupHandle()).catch(() => {});
+        cleanupHandle = null;
+      }
+      clearActiveProviderRuntimeContext();
+      await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    });
+
+    async function setupRuntime(): Promise<{
+      config: {
+        getEphemeralSetting: (key: string) => unknown;
+        setEphemeralSetting: (key: string, value: unknown) => void;
+      };
+      settingsService: {
+        getProviderSettings: (providerName: string) => Record<string, unknown>;
+      };
+    }> {
+      const handle = await contextFactoryMod.createIsolatedRuntimeContext({
+        runtimeId: 'auth-key-clear-test',
+        workspaceDir: tempDir,
+        prepare: async ({ providerManager }) => {
+          providerManager.registerProvider(createStubProvider());
+          providerManager.setActiveProvider('test-provider');
+        },
+      });
+      await handle.activate();
+      cleanupHandle = handle.cleanup;
+
+      return {
+        config: handle.config as {
+          getEphemeralSetting: (key: string) => unknown;
+          setEphemeralSetting: (key: string, value: unknown) => void;
+        },
+        settingsService: handle.settingsService as {
+          getProviderSettings: (
+            providerName: string,
+          ) => Record<string, unknown>;
+        },
+      };
+    }
+
+    it('clears auth-key-name and keyfile state when API key is cleared', async () => {
+      const { config, settingsService } = await setupRuntime();
+
+      config.setEphemeralSetting('auth-key-name', 'saved-name');
+      config.setEphemeralSetting('auth-keyfile', '/tmp/test-provider.key');
+
+      const providerSettings =
+        settingsService.getProviderSettings('test-provider');
+      providerSettings.apiKeyfile = '/tmp/test-provider.key';
+      providerSettings['auth-keyfile'] = '/tmp/test-provider.key';
+
+      await runtimeMod.updateActiveProviderApiKey(null);
+
+      expect(config.getEphemeralSetting('auth-key-name')).toBeUndefined();
+      expect(config.getEphemeralSetting('auth-keyfile')).toBeUndefined();
+      expect(
+        settingsService.getProviderSettings('test-provider').apiKeyfile,
+      ).toBeUndefined();
+      expect(
+        settingsService.getProviderSettings('test-provider')['auth-keyfile'],
+      ).toBeUndefined();
+    });
+  });
 });

--- a/packages/cli/src/runtime/runtimeSettings.ts
+++ b/packages/cli/src/runtime/runtimeSettings.ts
@@ -1011,32 +1011,6 @@ export function buildRuntimeProfileSnapshot(): Profile {
     }
   }
 
-  const snapshotHasAuthKeyfile =
-    snapshot['auth-keyfile'] !== undefined && snapshot['auth-keyfile'] !== null;
-  const snapshotHasAuthKeyName =
-    snapshot['auth-key-name'] !== undefined &&
-    snapshot['auth-key-name'] !== null;
-
-  if (
-    !snapshotHasAuthKeyfile &&
-    !snapshotHasAuthKeyName &&
-    snapshot['auth-key'] === undefined
-  ) {
-    const authKey =
-      ephemeralRecord['auth-key'] ??
-      (settingsService.get('auth-key') as string | undefined);
-    if (authKey) {
-      snapshot['auth-key'] = authKey;
-    }
-  }
-
-  if (snapshot['base-url'] === undefined) {
-    const baseUrl = providerSettings.baseUrl as string | undefined;
-    if (baseUrl) {
-      snapshot['base-url'] = baseUrl;
-    }
-  }
-
   if (snapshot['GOOGLE_CLOUD_PROJECT'] === undefined) {
     const project = process.env.GOOGLE_CLOUD_PROJECT;
     if (typeof project === 'string' && project.trim().length > 0) {
@@ -2077,8 +2051,11 @@ export async function updateActiveProviderApiKey(
   if (!trimmed) {
     settingsService.setProviderSetting(providerName, 'apiKey', undefined);
     settingsService.setProviderSetting(providerName, 'auth-key', undefined);
+    settingsService.setProviderSetting(providerName, 'apiKeyfile', undefined);
+    settingsService.setProviderSetting(providerName, 'auth-keyfile', undefined);
     config.setEphemeralSetting('auth-key', undefined);
     config.setEphemeralSetting('auth-keyfile', undefined);
+    config.setEphemeralSetting('auth-key-name', undefined);
 
     const isPaidMode = provider.isPaidMode?.();
     logger.debug(
@@ -2098,8 +2075,11 @@ export async function updateActiveProviderApiKey(
   }
 
   settingsService.setProviderSetting(providerName, 'apiKey', trimmed);
+  settingsService.setProviderSetting(providerName, 'apiKeyfile', undefined);
+  settingsService.setProviderSetting(providerName, 'auth-keyfile', undefined);
   config.setEphemeralSetting('auth-key', trimmed);
   config.setEphemeralSetting('auth-keyfile', undefined);
+  config.setEphemeralSetting('auth-key-name', undefined);
 
   const isPaidMode = provider.isPaidMode?.();
   logger.debug(
@@ -2126,10 +2106,13 @@ export async function updateActiveProviderBaseUrl(
   const providerName = provider.name;
   const trimmed = baseUrl?.trim();
 
-  if (!trimmed || trimmed === '' || trimmed === 'none') {
+  const normalizedBaseUrl =
+    trimmed && trimmed.toLowerCase() === 'none' ? '' : trimmed;
+
+  if (!normalizedBaseUrl) {
     settingsService.setProviderSetting(providerName, 'baseUrl', undefined);
     settingsService.setProviderSetting(providerName, 'baseURL', undefined);
-    config.setEphemeralSetting('base-url', trimmed ?? undefined);
+    config.setEphemeralSetting('base-url', undefined);
     return {
       changed: true,
       providerName,
@@ -2137,14 +2120,22 @@ export async function updateActiveProviderBaseUrl(
     };
   }
 
-  settingsService.setProviderSetting(providerName, 'baseUrl', trimmed);
-  settingsService.setProviderSetting(providerName, 'baseURL', trimmed);
-  config.setEphemeralSetting('base-url', trimmed);
+  settingsService.setProviderSetting(
+    providerName,
+    'baseUrl',
+    normalizedBaseUrl,
+  );
+  settingsService.setProviderSetting(
+    providerName,
+    'baseURL',
+    normalizedBaseUrl,
+  );
+  config.setEphemeralSetting('base-url', normalizedBaseUrl);
   return {
     changed: true,
     providerName,
-    message: `Base URL updated to '${trimmed}' for provider '${providerName}'.`,
-    baseUrl: trimmed,
+    message: `Base URL updated to '${normalizedBaseUrl}' for provider '${providerName}'.`,
+    baseUrl: normalizedBaseUrl,
   };
 }
 
@@ -2376,8 +2367,9 @@ export async function applyCliArgumentOverrides(
     if (profileKeyName) {
       const resolvedKey = await resolveNamedKey(profileKeyName);
       await updateActiveProviderApiKey(resolvedKey);
-      // Clear raw key from ephemeral settings — the profile already has
-      // auth-key-name, so snapshots should preserve that, not the secret.
+      // Preserve the name reference so snapshots persist auth-key-name,
+      // not the resolved secret.
+      config.setEphemeralSetting('auth-key-name', profileKeyName);
       config.setEphemeralSetting('auth-key', undefined);
       config.setEphemeralSetting('auth-keyfile', undefined);
       logger.debug(


### PR DESCRIPTION
## TLDR
This fixes issue #208 by making profile save/load/apply treat cleared auth and base-url as first-class state, so switching profiles (including same-provider transitions) cannot resurrect stale key, keyfile, key-name, or base-url values.

## Dive Deeper
The root bug was ambiguous absence handling in runtime/profile flows: cleared values could be omitted from ephemeral state and later reintroduced from fallback provider/global values.

This change hardens that path in two places:
- Snapshot correctness: buildRuntimeProfileSnapshot() no longer backfills auth-key or base-url from fallback sources when ephemerals are cleared.
- Apply correctness: applyProfileWithGuards() now interprets omitted or explicit-clear auth/base-url directives as clear operations, and executes runtime clear helpers before continuing profile application.

Related runtime hygiene included:
- updateActiveProviderApiKey(null) now clears associated keyfile and key-name state (auth-keyfile, auth-key-name, provider keyfile slots), preventing stale named-key references.
- non-null API key updates clear keyfile/key-name state to avoid mixed stale auth state.
- updateActiveProviderBaseUrl() normalizes case-insensitive none to an actual clear and does not persist literal none.
- named-key profile resolution preserves auth-key-name reference while clearing raw key material so snapshots retain pointer semantics instead of secret material.

## Reviewer Test Plan
1. Reproduce issue behavior manually:
   - Set provider key/base-url.
   - Clear key/keyfile/base-url.
   - Save profile A.
   - Switch to another profile/provider and back.
   - Confirm cleared fields stay cleared and are not resurrected.
2. Run focused regression tests:
   - packages/cli/src/runtime/__tests__/profileApplication.test.ts
   - packages/cli/src/runtime/__tests__/authKeyName.test.ts
   - packages/cli/src/runtime/__tests__/runtimeIsolation.test.ts
3. Confirm full suite and build green (commands listed below).

## Testing Matrix

|          |  |  |  |
| -------- | --- | --- | --- |
| npm run  | [OK] (local) |  |  |
| npx      |  |  |  |
| Docker   |  |  |  |
| Podman   |  | - | - |
| Seatbelt |  | - | - |

Local verification run:
- npm run test
- npm run lint
- npm run typecheck
- npm run format
- npm run build
- node scripts/start.js --profile-load syntheticglm47 'write me a haiku'

## Linked issues / bugs
Fixes #208
