### PR TITLE
feat(anthropic): add Claude Sonnet 4.6 to OAuth static menu (Fixes #1472)

### DIFF
--- a/packages/core/src/providers/anthropic/AnthropicProvider.ts
+++ b/packages/core/src/providers/anthropic/AnthropicProvider.ts
@@ -435,6 +435,14 @@ export class AnthropicProvider extends BaseProvider {
           maxOutputTokens: 32000,
         },
         {
+          id: 'claude-sonnet-4-6',
+          name: 'Claude Sonnet 4.6',
+          provider: this.name,
+          supportedToolFormats: ['anthropic'],
+          contextWindow: 400000,
+          maxOutputTokens: 64000,
+        },
+        {
           id: 'claude-sonnet-4-5-20250929',
           name: 'Claude Sonnet 4.5',
           provider: this.name,
@@ -576,6 +584,14 @@ export class AnthropicProvider extends BaseProvider {
         supportedToolFormats: ['anthropic'],
         contextWindow: 500000,
         maxOutputTokens: 32000,
+      },
+      {
+        id: 'claude-sonnet-4-6',
+        name: 'Claude Sonnet 4.6',
+        provider: this.name,
+        supportedToolFormats: ['anthropic'],
+        contextWindow: 400000,
+        maxOutputTokens: 64000,
       },
       {
         id: 'claude-sonnet-4-5-20250929',


### PR DESCRIPTION
## Summary

Adds Claude Sonnet 4.6 to the Anthropic OAuth static menu in `AnthropicProvider.ts` as requested in issue #1472.

## Changes

- Added `claude-sonnet-4-6` to the OAuth static model list (returned when `isOAuthToken` is true)
- Added `claude-sonnet-4-6` to the default models list (returned when no authentication is available)

## Configuration

Uses the same settings as Sonnet 4.5 since the max plan exposure differs from full capabilities:
- **Context Window:** 400,000 tokens
- **Max Output Tokens:** 64,000 tokens

This is consistent with the approach mentioned in the issue - the max plan has different capabilities than the full API.

## Testing

- All existing tests pass
- Lint, typecheck, format, and build all pass
- Smoke test successful

Fixes #1472