### PR TITLE
fix(shell): treat pipelines as atomic commands for instrumentation (Fixes #1481)

### DIFF
--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -295,8 +295,9 @@ class ShellToolInvocation extends BaseToolInvocation<
             // Instrument chained commands with a lightweight marker to indicate which subcommand is starting.
             // This helps the UI display the currently running segment without guessing.
             // Uses the parser-backed splitCommands utility for robust handling of quotes,
-            // escaped delimiters, and other shell operators (||, ;, |).
-            const parts = splitCommands(command);
+            // escaped delimiters, and other shell operators (||, ;).
+            // Pipelines (|) are NOT split - they are single logical commands with one marker.
+            const parts = splitCommands(command, { splitOnPipes: false });
             if (parts.length > 1) {
               command = parts
                 .map((seg) => {


### PR DESCRIPTION
## Summary

Fixes #1481

Shell command instrumentation was incorrectly splitting on pipe operators (`|`), causing confusing `__LLXPRT_CMD__:` markers to appear between piped commands. For example, `cat file | grep foo` would get split and each segment instrumented separately, breaking the visual understanding of pipeline data flow.

## Root Cause

The `splitCommands()` function in shell-utils.ts was treating pipes the same as other command separators (`&&`, `||`, `;`), splitting pipelines into individual commands. This was correct for security/allowlist validation but incorrect for instrumentation purposes.

## Solution

Added a `splitOnPipes` option to `splitCommands()`, `splitCommandsRegex()`, and `splitCommandsWithTree()`:

- **Default (`splitOnPipes: true`)**: Maintains existing behavior for security checks - each command in a pipeline is validated individually
- **`splitOnPipes: false`**: Treats pipelines as atomic units, appropriate for command instrumentation

The shell tool now passes `{ splitOnPipes: false }` when instrumenting commands, so pipelines appear as single logical commands in the output.

## Changes

- `packages/core/src/utils/shell-utils.ts`: Added `SplitCommandsOptions` interface with `splitOnPipes` option, updated `splitCommands()` and `splitCommandsRegex()` to respect the option
- `packages/core/src/utils/shell-parser.ts`: Added `SplitCommandsTreeOptions` interface, updated `splitCommandsWithTree()` to conditionally recurse into pipelines
- `packages/core/src/tools/shell.ts`: Pass `{ splitOnPipes: false }` for instrumentation
- `packages/core/src/utils/shell-utils.test.ts`: Added comprehensive tests for both `splitOnPipes` behaviors
- `packages/core/src/tools/shell.test.ts`: Updated pipe handling test to expect pipeline as single unit

## Testing

- All existing tests pass
- Added new tests covering both tree-sitter and regex fallback paths
- Verified with smoke test