### PR TITLE
fix(security): prevent duplicate/unmasked key commands in history (Fixes #1476)

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1252,10 +1252,12 @@ export const useGeminiStream = (
 
       // Display user message IMMEDIATELY for string queries (not continuations)
       // This ensures the user sees their input right away, before any async processing
+      // Skip slash commands - slashCommandProcessor handles adding those (with sanitization for secure commands)
       if (
         typeof query === 'string' &&
         query.trim().length > 0 &&
-        !options?.isContinuation
+        !options?.isContinuation &&
+        !isSlashCommand(query.trim())
       ) {
         const trimmedQuery = query.trim();
         addItem(


### PR DESCRIPTION
## Summary

Fixes #1476

Previously, when running `/key save <name> <api-key>` or `/key <raw-key>`, the system would:
1. Add an **unmasked copy** to history (via `useGeminiStream.ts`)
2. Add a **masked copy** to history (via `slashCommandProcessor.ts`)

This resulted in **TWO entries** in history, one of which leaked the secret key in plaintext.

## The Fix

Skip adding the user message in `useGeminiStream.ts` for slash commands. The `slashCommandProcessor.ts` already handles adding these with proper sanitization for secure commands like `/key` and `/toolkey`.

Now, secure commands are added to history **exactly once, masked**.

## Testing

- All existing tests pass
- Smoke test passes
- Verified lint, typecheck, format, and build all pass

## Security Impact

This prevents API keys from being leaked in plaintext in the command history when users run `/key save` or `/key <raw-key>` commands.