### PR TITLE
fix(zed): await message processing and handle errors in ACP receive loop (Fixes #1552)

### DIFF
--- a/packages/cli/src/zed-integration/acp.test.ts
+++ b/packages/cli/src/zed-integration/acp.test.ts
@@ -1,0 +1,260 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { AgentSideConnection, Agent, Client } from './acp.js';
+import * as schema from './schema.js';
+import { ReadableStream, WritableStream } from 'node:stream/web';
+
+function createReadableStream(messages: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const msg of messages) {
+        controller.enqueue(encoder.encode(msg + '\n'));
+      }
+      controller.close();
+    },
+  });
+}
+
+function createCapturingWritableStream(): {
+  stream: WritableStream<Uint8Array>;
+  getOutput: () => string;
+} {
+  const chunks: Uint8Array[] = [];
+  const decoder = new TextDecoder();
+  const stream = new WritableStream<Uint8Array>({
+    write(chunk) {
+      chunks.push(chunk);
+    },
+  });
+  return {
+    stream,
+    getOutput: () => chunks.map((c) => decoder.decode(c)).join(''),
+  };
+}
+
+function createMockAgent(): Agent {
+  return {
+    async initialize(
+      _params: schema.InitializeRequest,
+    ): Promise<schema.InitializeResponse> {
+      return {
+        protocolVersion: schema.PROTOCOL_VERSION,
+        authMethods: [
+          {
+            id: 'test',
+            name: 'Test Method',
+            description: 'Test authentication method',
+          },
+        ],
+        agentCapabilities: {},
+      };
+    },
+    async newSession(
+      _params: schema.NewSessionRequest,
+    ): Promise<schema.NewSessionResponse> {
+      return { sessionId: 'test-session' };
+    },
+    async authenticate(_params: schema.AuthenticateRequest): Promise<void> {},
+    async prompt(
+      _params: schema.PromptRequest,
+    ): Promise<schema.PromptResponse> {
+      return { stopReason: 'end_turn' };
+    },
+    async cancel(_params: schema.CancelNotification): Promise<void> {},
+  };
+}
+
+async function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe('AgentSideConnection', () => {
+  it('should send initialize response back to client', async () => {
+    const initializeRequest = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: schema.PROTOCOL_VERSION,
+        clientCapabilities: {
+          fs: {
+            readTextFile: true,
+            writeTextFile: true,
+          },
+        },
+      },
+    });
+
+    const output = createReadableStream([initializeRequest]);
+    const { stream: input, getOutput } = createCapturingWritableStream();
+
+    new AgentSideConnection(
+      (_client: Client) => createMockAgent(),
+      input,
+      output,
+    );
+
+    await delay(100);
+
+    const responseText = getOutput();
+    expect(responseText).toBeTruthy();
+
+    const lines = responseText.trim().split('\n');
+    expect(lines.length).toBeGreaterThan(0);
+
+    const response = JSON.parse(lines[0]);
+    expect(response).toMatchObject({
+      jsonrpc: '2.0',
+      id: 1,
+      result: {
+        protocolVersion: schema.PROTOCOL_VERSION,
+        authMethods: expect.any(Array),
+        agentCapabilities: expect.any(Object),
+      },
+    });
+  });
+
+  it('should send error response for unknown methods', async () => {
+    const unknownRequest = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'unknown_method',
+      params: {},
+    });
+
+    const output = createReadableStream([unknownRequest]);
+    const { stream: input, getOutput } = createCapturingWritableStream();
+
+    new AgentSideConnection(
+      (_client: Client) => createMockAgent(),
+      input,
+      output,
+    );
+
+    await delay(100);
+
+    const responseText = getOutput();
+    expect(responseText).toBeTruthy();
+
+    const lines = responseText.trim().split('\n');
+    expect(lines.length).toBeGreaterThan(0);
+
+    const response = JSON.parse(lines[0]);
+    expect(response).toMatchObject({
+      jsonrpc: '2.0',
+      id: 2,
+      error: {
+        code: -32601,
+        message: 'Method not found',
+      },
+    });
+  });
+
+  it('should handle invalid JSON without crashing the receive loop', async () => {
+    const invalidJson = 'this is not valid json';
+    const validRequest = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 3,
+      method: 'initialize',
+      params: {
+        protocolVersion: schema.PROTOCOL_VERSION,
+        clientCapabilities: {
+          fs: {
+            readTextFile: true,
+            writeTextFile: true,
+          },
+        },
+      },
+    });
+
+    const output = createReadableStream([invalidJson, validRequest]);
+    const { stream: input, getOutput } = createCapturingWritableStream();
+
+    new AgentSideConnection(
+      (_client: Client) => createMockAgent(),
+      input,
+      output,
+    );
+
+    await delay(100);
+
+    const responseText = getOutput();
+    expect(responseText).toBeTruthy();
+
+    const lines = responseText.trim().split('\n');
+    expect(lines.length).toBeGreaterThan(0);
+
+    const response = JSON.parse(lines[0]);
+    expect(response).toMatchObject({
+      jsonrpc: '2.0',
+      id: 3,
+      result: expect.any(Object),
+    });
+  });
+
+  it('should process multiple messages sequentially', async () => {
+    const request1 = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 4,
+      method: 'initialize',
+      params: {
+        protocolVersion: schema.PROTOCOL_VERSION,
+        clientCapabilities: {
+          fs: {
+            readTextFile: true,
+            writeTextFile: true,
+          },
+        },
+      },
+    });
+
+    const request2 = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 5,
+      method: 'session/new',
+      params: {
+        cwd: '/test',
+        mcpServers: [],
+      },
+    });
+
+    const output = createReadableStream([request1, request2]);
+    const { stream: input, getOutput } = createCapturingWritableStream();
+
+    new AgentSideConnection(
+      (_client: Client) => createMockAgent(),
+      input,
+      output,
+    );
+
+    await delay(100);
+
+    const responseText = getOutput();
+    expect(responseText).toBeTruthy();
+
+    const lines = responseText.trim().split('\n').filter(Boolean);
+    expect(lines.length).toBe(2);
+
+    const response1 = JSON.parse(lines[0]);
+    expect(response1).toMatchObject({
+      jsonrpc: '2.0',
+      id: 4,
+      result: expect.any(Object),
+    });
+
+    const response2 = JSON.parse(lines[1]);
+    expect(response2).toMatchObject({
+      jsonrpc: '2.0',
+      id: 5,
+      result: {
+        sessionId: 'test-session',
+      },
+    });
+  });
+});

--- a/packages/cli/src/zed-integration/acp.ts
+++ b/packages/cli/src/zed-integration/acp.ts
@@ -167,7 +167,12 @@ class Connection {
     this.#handler = handler;
     this.#peerInput = peerInput;
     this.#textEncoder = new TextEncoder();
-    this.#receive(peerOutput);
+    this.#receive(peerOutput).catch((error) => {
+      acpLogger.debug(
+        () =>
+          `Receive loop error: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    });
   }
 
   async #receive(output: ReadableStream<Uint8Array>) {
@@ -184,8 +189,15 @@ class Connection {
         const trimmedLine = line.trim();
 
         if (trimmedLine) {
-          const message = JSON.parse(trimmedLine);
-          this.#processMessage(message);
+          try {
+            const message = JSON.parse(trimmedLine);
+            await this.#processMessage(message);
+          } catch (error) {
+            acpLogger.debug(
+              () =>
+                `Error processing message: ${error instanceof Error ? error.message : String(error)}`,
+            );
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

Fixes #1552 - Zed integration was hanging because the ACP connection receive loop had a floating promise that silently swallowed errors.

## Problem

In \`packages/cli/src/zed-integration/acp.ts\`, the \`Connection\` class's \`#receive\` method calls \`this.#processMessage(message)\` on line 188 WITHOUT \`await\`. This creates a floating promise that:

1. Silently swallows any errors during message processing
2. Allows messages to be processed out of order  
3. Was exposed by upstream async error handling improvements in commit d860795c

The Zed client connects, sends an initialization message (334 bytes received per logs), but never receives a response. The agent hangs.

## Changes

### 1. Created behavioral tests (\`acp.test.ts\`)

Added end-to-end tests for \`AgentSideConnection\` that verify the JSON-RPC protocol works correctly:
- \`should send initialize response back to client\` - verifies responses are written with correct id and result
- \`should send error response for unknown methods\` - verifies JSON-RPC error responses (-32601 code)
- \`should handle invalid JSON without crashing the receive loop\` - verifies malformed input doesn't break processing
- \`should process multiple messages sequentially\` - verifies all requests get responses in order

### 2. Fixed floating promise in \`#receive\` method

**Added \`await\` to processMessage call (line 194):**
\`\`\`typescript
await this.#processMessage(message);
\`\`\`

**Added try-catch for error handling:**
Wrapped JSON.parse and processMessage in try-catch to prevent malformed messages from crashing the receive loop. Errors are logged via \`acpLogger.debug\` instead of crashing.

### 3. Fixed floating promise in constructor

**Added .catch() handler to #receive call (line 170):**
\`\`\`typescript
this.#receive(peerOutput).catch((error) => {
  acpLogger.debug(() => \`Receive loop error: ${...}\`);
});
\`\`\`

## Verification

All verification steps completed successfully:

✅ \`npm run test\` - all new tests pass, existing tests still pass (2 pre-existing failures unrelated)
✅ \`npm run typecheck\` - no type errors  
✅ \`npm run format\` - code properly formatted
✅ \`npm run build\` - successful build
✅ Smoke test - CLI starts and responds correctly

## Testing Notes

The tests use \`ReadableStream\` and \`WritableStream\` from \`node:stream/web\` to create mock JSON-RPC communication channels and verify that:
- Responses match request IDs (required for JSON-RPC)
- Error responses have proper error codes and structure
- The receive loop continues processing after errors
- Multiple messages are handled sequentially

This follows TDD - tests were written first (failing), then the fix was implemented to make them pass.