### PR TITLE
fix(sandbox): remove credential proxy provider allowlist scoping (Fixes #1554)

### DIFF
--- a/packages/cli/src/auth/proxy/__tests__/oauth-initiate.spec.ts
+++ b/packages/cli/src/auth/proxy/__tests__/oauth-initiate.spec.ts
@@ -497,33 +497,18 @@ describe('oauth_initiate handler', () => {
 
     /**
      * @requirement R-OAUTH-15
-     * @scenario Provider not in allowedProviders returns UNAUTHORIZED
-     * @given A server with allowedProviders: ['anthropic']
-     * @when oauth_initiate is called for qwen
-     * @then Response is ok:false with code UNAUTHORIZED
+     * @scenario Provider without configured flow factory returns PROVIDER_NOT_CONFIGURED
+     * @given A server without a flow factory for the requested provider
+     * @when oauth_initiate is called for an unconfigured provider
+     * @then Response is ok:false with code PROVIDER_NOT_CONFIGURED
      */
-    it('unauthorized provider returns UNAUTHORIZED', async () => {
-      // Close existing client and server for this test
-      client.close();
-      await server.stop();
-
-      // Create server with restricted providers
-      server = new CredentialProxyServer({
-        tokenStore: backingStore,
-        providerKeyStorage:
-          keyStorage as unknown as CredentialProxyServerOptions['providerKeyStorage'],
-        allowedProviders: ['anthropic'], // Only anthropic allowed
-      });
-      const socketPath = await server.start();
-      client = new ProxySocketClient(socketPath);
-      await client.ensureConnected();
-
+    it('unconfigured provider returns PROVIDER_NOT_CONFIGURED', async () => {
       const response = await client.request('oauth_initiate', {
-        provider: 'qwen',
+        provider: 'totally_unconfigured_provider',
       });
 
       expect(response.ok).toBe(false);
-      expect(response.code).toBe('UNAUTHORIZED');
+      expect(response.code).toBe('PROVIDER_NOT_CONFIGURED');
     });
   });
 

--- a/packages/cli/src/auth/proxy/__tests__/refresh-flow.spec.ts
+++ b/packages/cli/src/auth/proxy/__tests__/refresh-flow.spec.ts
@@ -720,27 +720,13 @@ describe('refresh_token handler', () => {
       expect(response.code).toBe('INVALID_REQUEST');
     });
 
-    it('unauthorized provider returns UNAUTHORIZED', async () => {
-      // Recreate server with restricted providers
-      client.close();
-      await server.stop();
-
-      server = new CredentialProxyServer({
-        tokenStore: backingStore,
-        providerKeyStorage: keyStorage as unknown as ProviderKeyStorage,
-        flowFactories: new Map([['anthropic', () => testProvider]]),
-        allowedProviders: ['other_provider'], // anthropic not allowed
-      });
-      const socketPath = await server.start();
-      client = new ProxySocketClient(socketPath);
-      await client.ensureConnected();
-
+    it('unconfigured provider returns PROVIDER_NOT_FOUND', async () => {
       const response = await client.request('refresh_token', {
-        provider: 'anthropic',
+        provider: 'unconfigured_provider',
       });
 
       expect(response.ok).toBe(false);
-      expect(response.code).toBe('UNAUTHORIZED');
+      expect(response.code).toBe('PROVIDER_NOT_FOUND');
     });
   });
 

--- a/packages/cli/src/auth/proxy/sandbox-proxy-lifecycle.ts
+++ b/packages/cli/src/auth/proxy/sandbox-proxy-lifecycle.ts
@@ -37,8 +37,6 @@ import { RefreshCoordinator } from './refresh-coordinator.js';
 export interface SandboxProxyConfig {
   socketPath: string;
   idleTimeoutMs?: number;
-  allowedProviders?: string[];
-  allowedBuckets?: string[];
 }
 
 export interface SandboxProxyHandle {
@@ -204,8 +202,6 @@ export async function createAndStartProxy(
     tokenStore,
     providerKeyStorage,
     socketDir: requestedSocketDir,
-    allowedProviders: config.allowedProviders,
-    allowedBuckets: config.allowedBuckets,
     flowFactories,
     refreshCoordinator,
   });

--- a/packages/cli/src/utils/sandbox.test.ts
+++ b/packages/cli/src/utils/sandbox.test.ts
@@ -10,9 +10,7 @@ import {
   getPassthroughEnvVars,
   mountGitConfigFiles,
   setupSshAgentLinux,
-  getProfileScopedCredentialAllowlist,
 } from './sandbox.js';
-import { Config } from '@vybestack/llxprt-code-core';
 
 import fs from 'node:fs';
 import path from 'node:path';
@@ -414,46 +412,6 @@ describe('mountGitConfigFiles', () => {
     expect(vol).toMatch(/:ro$/);
   });
 });
-
-describe('getProfileScopedCredentialAllowlist', () => {
-  it('returns scoped provider when config has active provider', () => {
-    const config = {
-      getProvider: () => 'anthropic',
-      getBucketFailoverHandler: () => undefined,
-    } as unknown as Config;
-
-    expect(getProfileScopedCredentialAllowlist(config)).toEqual({
-      allowedProviders: ['anthropic'],
-      allowedBuckets: undefined,
-    });
-  });
-
-  it('returns provider and deduplicated buckets when failover handler is enabled', () => {
-    const config = {
-      getProvider: () => 'anthropic',
-      getBucketFailoverHandler: () => ({
-        isEnabled: () => true,
-        getBuckets: () => ['default', 'work', 'default', '  work  '],
-      }),
-    } as unknown as Config;
-
-    expect(getProfileScopedCredentialAllowlist(config)).toEqual({
-      allowedProviders: ['anthropic'],
-      allowedBuckets: ['default', 'work'],
-    });
-  });
-
-  it('returns empty allowlist when provider is unavailable', () => {
-    const config = {
-      getProvider: () => undefined,
-      getBucketFailoverHandler: () => undefined,
-    } as unknown as Config;
-
-    expect(getProfileScopedCredentialAllowlist(config)).toEqual({});
-  });
-});
-
-// --- Fix 4: SSH Agent Forwarding (R4-R7) ---
 
 describe('setupSshAgentLinux', () => {
   it('mounts host socket for docker (R5.1)', () => {


### PR DESCRIPTION
## Summary

Removes the credential proxy provider/bucket allowlist that restricted sandbox credential access to only the provider configured at startup. This allowlist prevented mid-session provider switching (e.g., via \`/profile load\`) and provided marginal security value.

Closes #1554

## Problem

The allowlist had several issues:
1. **Marginal security value** - refresh tokens are already stripped at the proxy boundary; exfiltrated tokens are short-lived access tokens only
2. **Broken implementation** - conflated provider names, alias names, and key names into a single check
3. **No multi-provider support** - always a single-element array with no wildcard or override
4. **Blocked legitimate workflows** - users switching providers mid-session were completely blocked

## Changes

### Production code
- **sandbox.ts**: Removed \`getProfileScopedCredentialAllowlist()\` and its call site that passed allowlist to the proxy
- **credential-proxy-server.ts**: Removed \`allowedProviders\`/\`allowedBuckets\` from options interface, removed \`isProviderAllowed()\`/\`isBucketAllowed()\` methods and all guard call sites across 10+ handlers
- **sandbox-proxy-lifecycle.ts**: Removed allowlist fields from \`SandboxProxyConfig\` interface and constructor passthrough

### Test code
- Updated allowlist enforcement tests to verify open-access behavior (all providers/buckets accessible)
- Replaced UNAUTHORIZED expectation tests with multi-provider accessibility tests
- Updated oauth-initiate and refresh-flow tests to use unconfigured provider names instead of allowlist-blocked providers

## Security boundaries retained
- Refresh tokens never cross the socket boundary (stripped by \`sanitizeTokenForProxy\`)
- Socket has 0600 permissions with 128-bit cryptographic nonce
- Peer credential verification
- Rate limiting (RefreshCoordinator with 30s cooldown)
- Message size bounds (FrameDecoder)
- The sandbox container itself

## Verification
- npm run test (all pass; 2 pre-existing failures on main: codesearch.test.ts, providerAliases.test.ts)
- npm run lint (pass)
- npm run typecheck (pass)
- npm run format (pass)
- npm run build (pass)
- Smoke test with \`node scripts/start.js --profile-load syntheticglm47 "write me a haiku"\` (pass)