### PR TITLE
Add LSP package to release pipeline (Fixes #1637)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -339,6 +339,12 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Publish @vybestack/llxprt-code-lsp
+        if: ${{ steps.vars.outputs.should_run_standard_release == 'true' }}
+        run: npm publish --workspace=@vybestack/llxprt-code-lsp --access public --tag=${{ steps.version.outputs.NPM_TAG }} ${{ steps.vars.outputs.is_dry_run == 'true' && '--dry-run' || '' }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Install latest core package
         if: ${{ steps.vars.outputs.should_run_standard_release == 'true' && steps.vars.outputs.is_dry_run == 'false' }}
         run: npm install @vybestack/llxprt-code-core@${{ steps.version.outputs.RELEASE_VERSION }} --workspace=@vybestack/llxprt-code --save-exact

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "packages/cli",
         "packages/a2a-server",
         "packages/test-utils",
-        "packages/vscode-ide-companion"
+        "packages/vscode-ide-companion",
+        "packages/lsp"
       ],
       "dependencies": {
         "@ai-sdk/openai": "^2.0.74",
@@ -6498,6 +6499,10 @@
     },
     "node_modules/@vybestack/llxprt-code-core": {
       "resolved": "packages/core",
+      "link": true
+    },
+    "node_modules/@vybestack/llxprt-code-lsp": {
+      "resolved": "packages/lsp",
       "link": true
     },
     "node_modules/@vybestack/llxprt-code-test-utils": {
@@ -20558,6 +20563,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "packages/lsp": {
+      "name": "@vybestack/llxprt-code-lsp",
+      "version": "0.9.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2",
+        "vscode-jsonrpc": "^8.2.1",
+        "zod": "^3.25.76"
+      },
+      "devDependencies": {
+        "@types/node": "^24.2.1",
+        "typescript": "^5.3.3"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "packages/test-utils": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "packages/cli",
     "packages/a2a-server",
     "packages/test-utils",
-    "packages/vscode-ide-companion"
+    "packages/vscode-ide-companion",
+    "packages/lsp"
   ],
   "private": "true",
   "repository": {

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -45,6 +45,7 @@ const actualWorkspaces = [
   '@vybestack/llxprt-code-core',
   '@vybestack/llxprt-code-test-utils',
   'llxprt-code-vscode-ide-companion',
+  '@vybestack/llxprt-code-lsp',
 ];
 
 // Filter for workspaces that actually exist (in case some are optional)


### PR DESCRIPTION
## Summary

Adds the LSP package (`@vybestack/llxprt-code-lsp`) to the release pipeline so it gets published to npm during releases. Without this, users who install llxprt-code and enable LSP get a launch failure because the package is never available on npm.

Fixes #1637

## Changes

### 1. `package.json` - Add LSP to workspaces
Added `packages/lsp` to the root workspaces array. This ensures:
- `npm install` resolves its dependencies
- `npm run build --workspaces` builds it
- `npm run test --workspaces` runs its tests
- `npm run typecheck --workspaces` typechecks it

### 2. `scripts/version.js` - Add LSP to version bumping
Added `@vybestack/llxprt-code-lsp` to the `actualWorkspaces` array so that the release version script bumps its version alongside the other packages.

### 3. `.github/workflows/release.yml` - Add publish step
Added an `npm publish` step for `@vybestack/llxprt-code-lsp` with `--access public`, placed after the UI publish and before the CLI publish. Uses the same pattern as the existing publish steps.

## Verification

- All 196 tests pass
- Lint clean
- Typecheck clean (LSP workspace now included)
- Build succeeds
- Format clean
- Smoke test passes