### PR TITLE
Coalesce same-process bucket reauth flows (Fixes #1680)

### DIFF
--- a/packages/cli/src/auth/BucketFailoverHandlerImpl.spec.ts
+++ b/packages/cli/src/auth/BucketFailoverHandlerImpl.spec.ts
@@ -1437,9 +1437,8 @@ describe('ensureBucketsAuthenticated', () => {
     });
 
     const oauthManager = {
-      getOAuthToken: vi.fn(
-        async (_provider: string, bucket?: string) =>
-          tokenStore.getToken('anthropic', bucket),
+      getOAuthToken: vi.fn(async (_provider: string, bucket?: string) =>
+        tokenStore.getToken('anthropic', bucket),
       ),
       getTokenStore: vi.fn(() => tokenStore),
       setSessionBucket: vi.fn(),
@@ -1449,7 +1448,11 @@ describe('ensureBucketsAuthenticated', () => {
       }),
       authenticateMultipleBuckets: vi.fn(async () => {
         await eagerAuthPromise;
-        await tokenStore.saveToken('anthropic', makeToken('eager-token'), 'bucket-b');
+        await tokenStore.saveToken(
+          'anthropic',
+          makeToken('eager-token'),
+          'bucket-b',
+        );
       }),
     };
 
@@ -1488,9 +1491,8 @@ describe('ensureBucketsAuthenticated', () => {
     });
 
     const oauthManager = {
-      getOAuthToken: vi.fn(
-        async (_provider: string, bucket?: string) =>
-          tokenStore.getToken('anthropic', bucket),
+      getOAuthToken: vi.fn(async (_provider: string, bucket?: string) =>
+        tokenStore.getToken('anthropic', bucket),
       ),
       getTokenStore: vi.fn(() => tokenStore),
       setSessionBucket: vi.fn(),
@@ -1523,7 +1525,10 @@ describe('ensureBucketsAuthenticated', () => {
     await expect(first).resolves.toBe(true);
     await expect(second).resolves.toBe(true);
     expect(oauthManager.authenticate).toHaveBeenCalledTimes(1);
-    expect(oauthManager.authenticate).toHaveBeenCalledWith('anthropic', 'bucket-a');
+    expect(oauthManager.authenticate).toHaveBeenCalledWith(
+      'anthropic',
+      'bucket-a',
+    );
   });
 
   it('re-checks late-started eager auth before pass-3 foreground reauth', async () => {
@@ -1562,7 +1567,11 @@ describe('ensureBucketsAuthenticated', () => {
       }),
       authenticateMultipleBuckets: vi.fn(async () => {
         await eagerAuthGate;
-        await tokenStore.saveToken('anthropic', makeToken('late-eager-token'), 'bucket-a');
+        await tokenStore.saveToken(
+          'anthropic',
+          makeToken('late-eager-token'),
+          'bucket-a',
+        );
       }),
     };
 
@@ -1590,8 +1599,4 @@ describe('ensureBucketsAuthenticated', () => {
     expect(oauthManager.authenticate).not.toHaveBeenCalled();
     expect(handler.getCurrentBucket()).toBe('bucket-a');
   });
-
-
-
-
 });

--- a/packages/cli/src/auth/BucketFailoverHandlerImpl.ts
+++ b/packages/cli/src/auth/BucketFailoverHandlerImpl.ts
@@ -36,7 +36,10 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
   private readonly oauthManager: OAuthManager;
   private triedBucketsThisSession: Set<string>;
   private ensureBucketsAuthInFlight: Promise<void> | null = null;
-  private foregroundReauthInFlightByBucket = new Map<string, Promise<boolean>>();
+  private foregroundReauthInFlightByBucket = new Map<
+    string,
+    Promise<boolean>
+  >();
 
   /**
    * @plan PLAN-20260223-ISSUE1598.P05
@@ -354,9 +357,8 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
     }
 
     if (candidateBucket !== undefined) {
-      const existingForegroundReauth = this.foregroundReauthInFlightByBucket.get(
-        candidateBucket,
-      );
+      const existingForegroundReauth =
+        this.foregroundReauthInFlightByBucket.get(candidateBucket);
       if (existingForegroundReauth) {
         return existingForegroundReauth;
       }
@@ -519,7 +521,8 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
       try {
         return await pass3Promise;
       } finally {
-        const current = this.foregroundReauthInFlightByBucket.get(candidateBucket);
+        const current =
+          this.foregroundReauthInFlightByBucket.get(candidateBucket);
         if (current === pass3Promise) {
           this.foregroundReauthInFlightByBucket.delete(candidateBucket);
         }


### PR DESCRIPTION
## Summary
- coalesce concurrent turn-boundary ensureBucketsAuthenticated calls into a single in-flight auth run
- coalesce concurrent pass-3 foreground reauth attempts per bucket in BucketFailoverHandlerImpl
- have pass-3 wait for in-flight eager auth and re-check token state before opening foreground auth
- add focused concurrency tests covering ensure coalescing, ensure/pass-3 overlap, and concurrent pass-3 deduping

## Root cause addressed
Issue #1680 reported duplicate OAuth browser prompts from a single process. We had per-bucket locking in OAuthManager, but no orchestration-level single-flight in BucketFailoverHandlerImpl for:
- repeated ensureBucketsAuthenticated calls within one process
- concurrent pass-3 foreground auth attempts for the same bucket

This change adds those single-flight guards at the handler layer.

## Verification
- npm run typecheck
- npm run lint -- packages/cli/src/auth/BucketFailoverHandlerImpl.ts packages/cli/src/auth/BucketFailoverHandlerImpl.spec.ts
- npm exec vitest run packages/cli/src/auth/BucketFailoverHandlerImpl.spec.ts
- npm run build
- npm run test --workspace @vybestack/llxprt-code-core -- src/utils/retry.test.ts  (known unrelated flaky failure in current branch)
- npm run test --workspaces --if-present  (same known core retry test failure)

## Notes
A pre-existing flaky test currently fails in core:
- packages/core/src/utils/retry.test.ts -> retryWithBackoff -> should respect maxDelayMs
It reproduces independently of this PR and does not touch files in this change set.