### PR TITLE
Clear conversation history on provider switch (Fixes #1683)

### DIFF
--- a/packages/cli/src/integration-tests/provider-switching.integration.test.ts
+++ b/packages/cli/src/integration-tests/provider-switching.integration.test.ts
@@ -242,6 +242,42 @@ describe('Runtime Provider Switching Integration', () => {
     expect(config.getModel()).toBe('custom-default-model');
     expect(providerB.getModels).not.toHaveBeenCalled();
   });
+  it('clears conversation history when switching providers', async () => {
+    const providerA = createMockProvider('providerA');
+    const providerB = createMockProvider('providerB');
+    providerManager.registerProvider(providerA);
+    providerManager.registerProvider(providerB);
+
+    providerManager.setActiveProvider('providerA');
+
+    // Add some conversation history via the GeminiClient's HistoryService
+    const historyService = config.getGeminiClient()?.getHistoryService?.();
+    if (historyService) {
+      historyService.add({
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Hello from providerA' }],
+      });
+      historyService.add({
+        speaker: 'ai',
+        blocks: [{ type: 'text', text: 'Response from providerA' }],
+      });
+      expect(historyService.getAll().length).toBeGreaterThan(0);
+    }
+
+    const result = await switchActiveProvider('providerB');
+
+    expect(result.changed).toBe(true);
+    // History should be cleared after switch
+    if (historyService) {
+      expect(historyService.getAll()).toHaveLength(0);
+    }
+    // Info message about clearing should be present
+    expect(
+      result.infoMessages.some((msg) =>
+        msg.includes('Conversation history cleared'),
+      ),
+    ).toBe(true);
+  });
 });
 function createMockProvider(name: string): IProvider & {
   apiKey?: string;

--- a/packages/cli/src/runtime/runtimeSettings.ts
+++ b/packages/cli/src/runtime/runtimeSettings.ts
@@ -2063,6 +2063,31 @@ export async function switchActiveProvider(
     }
   }
 
+  // @fix issue1683 - Clear conversation history on provider switch to prevent
+  // cross-provider format mismatches (e.g. tool call ID formats, thinking blocks)
+  // that cause API errors like "Missing required parameter".
+  try {
+    const geminiClient = config.getGeminiClient?.();
+    const historyService = geminiClient?.getHistoryService?.();
+    if (historyService) {
+      historyService.clear();
+      infoMessages.push(
+        'Conversation history cleared for provider compatibility.',
+      );
+      logger.debug(
+        () =>
+          `[cli-runtime] Cleared HistoryService on provider switch from ${currentProvider ?? 'none'} to ${name}`,
+      );
+    }
+  } catch (error) {
+    logger.debug(
+      () =>
+        `[cli-runtime] Failed to clear history on provider switch: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+    );
+  }
+
   return {
     changed: true,
     previousProvider: currentProvider,


### PR DESCRIPTION
## Summary

When switching between providers (e.g. Anthropic to OpenAI Responses API), the accumulated `HistoryService` content carried cross-provider format artifacts (tool call ID formats, thinking blocks, media blocks) that caused API errors like `Missing required parameter: input[60].output[1]`.

## Root Cause

The `switchActiveProvider()` function in `runtimeSettings.ts` swapped the active provider but did not clear the underlying `HistoryService`. The UI display was cleared via `onClear()`, but the conversation history persisted. When the new provider (OpenAI Responses API) tried to replay this history, incompatible formats caused 400 errors.

## Fix

Clear the `HistoryService` after a successful provider switch within `switchActiveProvider()`. This ensures the new provider starts with a clean conversation context. The clearing is wrapped in try/catch so it cannot block the switch itself, and an info message notifies the user that history was cleared.

## Changes

- **`packages/cli/src/runtime/runtimeSettings.ts`**: Added history clearing logic after provider switch succeeds, with info message and debug logging
- **`packages/cli/src/integration-tests/provider-switching.integration.test.ts`**: Added test verifying history is cleared on provider switch

Fixes #1683