### PR TITLE
Fix function_call_output sending array instead of string (Fixes #1683)

### DIFF
--- a/packages/core/src/providers/openai-responses/OpenAIResponsesProvider.ts
+++ b/packages/core/src/providers/openai-responses/OpenAIResponsesProvider.ts
@@ -361,7 +361,7 @@ export class OpenAIResponsesProvider extends BaseProvider {
       | {
           type: 'function_call_output';
           call_id: string;
-          output: string | ResponsesContentPart[];
+          output: string;
         }
       | {
           type: 'reasoning';
@@ -562,7 +562,7 @@ export class OpenAIResponsesProvider extends BaseProvider {
       | {
           type: 'function_call_output';
           call_id: string;
-          output: string | ResponsesContentPart[];
+          output: string;
         }
       | {
           type: 'reasoning';
@@ -732,28 +732,33 @@ export class OpenAIResponsesProvider extends BaseProvider {
             continue;
           }
 
-          let outputContent: string | ResponsesContentPart[];
+          input.push({
+            type: 'function_call_output',
+            call_id: outputCallId,
+            output: candidate,
+          });
 
+          // OpenAI Responses API function_call_output.output only accepts a
+          // string.  When the tool response carried media blocks (e.g.
+          // screenshots, images from read_file), emit them as a synthetic
+          // user message so the model can still see the actual image data.
           if (mediaBlocks.length > 0) {
-            const parts: ResponsesContentPart[] = [];
-            if (candidate) {
-              parts.push({ type: 'input_text', text: candidate });
-            }
+            const mediaParts: ResponsesContentPart[] = [];
             for (const media of mediaBlocks) {
               const category = classifyMediaBlock(media);
               if (category === 'image') {
-                parts.push({
+                mediaParts.push({
                   type: 'input_image',
                   image_url: normalizeMediaToDataUri(media),
                 });
               } else if (category === 'pdf') {
-                parts.push({
+                mediaParts.push({
                   type: 'input_file',
                   file_data: normalizeMediaToDataUri(media),
                   ...(media.filename ? { filename: media.filename } : {}),
                 });
               } else {
-                parts.push({
+                mediaParts.push({
                   type: 'input_text',
                   text: buildUnsupportedMediaPlaceholder(
                     media,
@@ -762,16 +767,13 @@ export class OpenAIResponsesProvider extends BaseProvider {
                 });
               }
             }
-            outputContent = parts.length > 0 ? parts : candidate;
-          } else {
-            outputContent = candidate;
+            if (mediaParts.length > 0) {
+              input.push({
+                role: 'user',
+                content: mediaParts,
+              });
+            }
           }
-
-          input.push({
-            type: 'function_call_output',
-            call_id: outputCallId,
-            output: outputContent,
-          });
         }
       }
     }

--- a/packages/core/src/providers/openai-responses/buildResponsesInputFromContent.mediaBlock.test.ts
+++ b/packages/core/src/providers/openai-responses/buildResponsesInputFromContent.mediaBlock.test.ts
@@ -98,7 +98,7 @@ describe('buildResponsesInputFromContent - MediaBlock support', () => {
     });
   });
 
-  it('converts MediaBlock in tool responses to multipart output array', () => {
+  it('converts MediaBlock in tool responses to function_call_output + synthetic user message with image', () => {
     const contents: IContent[] = [
       {
         speaker: 'human',
@@ -136,15 +136,15 @@ describe('buildResponsesInputFromContent - MediaBlock support', () => {
 
     const result = buildResponsesInputFromContent(contents);
 
-    expect(result).toHaveLength(3);
+    expect(result).toHaveLength(4);
     expect(result[2]).toEqual({
       type: 'function_call_output',
       call_id: 'call_123',
-      output: [
-        {
-          type: 'input_text',
-          text: 'Screenshot taken',
-        },
+      output: 'Screenshot taken',
+    });
+    expect(result[3]).toEqual({
+      role: 'user',
+      content: [
         {
           type: 'input_image',
           image_url: 'data:image/png;base64,screenshotdata',
@@ -216,11 +216,15 @@ describe('buildResponsesInputFromContent - MediaBlock support', () => {
 
     const result = buildResponsesInputFromContent(contents);
 
-    expect(result).toHaveLength(2);
+    expect(result).toHaveLength(3);
     expect(result[1]).toEqual({
       type: 'function_call_output',
       call_id: 'call_456',
-      output: [
+      output: '',
+    });
+    expect(result[2]).toEqual({
+      role: 'user',
+      content: [
         {
           type: 'input_image',
           image_url: 'data:image/png;base64,imagedata',
@@ -345,7 +349,7 @@ describe('buildResponsesInputFromContent - MediaBlock support', () => {
     });
   });
 
-  it('converts PDF MediaBlock in tool response to input_file', () => {
+  it('converts PDF MediaBlock in tool response to function_call_output + synthetic user message with file', () => {
     const contents: IContent[] = [
       {
         speaker: 'ai',
@@ -380,16 +384,21 @@ describe('buildResponsesInputFromContent - MediaBlock support', () => {
 
     const result = buildResponsesInputFromContent(contents);
 
-    const toolOutput = result[1] as {
-      type: string;
-      output: unknown[];
-    };
-    expect(toolOutput.type).toBe('function_call_output');
-    expect(toolOutput.output).toHaveLength(2);
-    expect(toolOutput.output[1]).toEqual({
-      type: 'input_file',
-      file_data: 'data:application/pdf;base64,JVBERi0xLjQ=',
-      filename: 'doc.pdf',
+    expect(result).toHaveLength(3);
+    expect(result[1]).toEqual({
+      type: 'function_call_output',
+      call_id: 'call_pdf1',
+      output: 'PDF content',
+    });
+    expect(result[2]).toEqual({
+      role: 'user',
+      content: [
+        {
+          type: 'input_file',
+          file_data: 'data:application/pdf;base64,JVBERi0xLjQ=',
+          filename: 'doc.pdf',
+        },
+      ],
     });
   });
 

--- a/packages/core/src/providers/openai-responses/buildResponsesInputFromContent.ts
+++ b/packages/core/src/providers/openai-responses/buildResponsesInputFromContent.ts
@@ -47,7 +47,7 @@ export type ResponsesInputItem =
   | {
       type: 'function_call_output';
       call_id: string;
-      output: string | ResponsesContentPart[];
+      output: string;
     };
 
 export function buildResponsesInputFromContent(
@@ -157,30 +157,33 @@ export function buildResponsesInputFromContent(
 
         const textResult = limited.content || limited.message || '';
 
-        let outputContent: string | ResponsesContentPart[];
+        input.push({
+          type: 'function_call_output',
+          call_id: normalizeToOpenAIToolId(toolResponseBlock.callId),
+          output: textResult,
+        });
 
+        // OpenAI Responses API function_call_output.output only accepts a
+        // string.  When the tool response carried media blocks (e.g.
+        // screenshots, images from read_file), emit them as a synthetic
+        // user message so the model can still see the actual image data.
         if (mediaBlocks.length > 0) {
-          const parts: ResponsesContentPart[] = [];
-
-          if (textResult) {
-            parts.push({ type: 'input_text', text: textResult });
-          }
-
+          const mediaParts: ResponsesContentPart[] = [];
           for (const media of mediaBlocks) {
             const category = classifyMediaBlock(media);
             if (category === 'image') {
-              parts.push({
+              mediaParts.push({
                 type: 'input_image',
                 image_url: normalizeMediaToDataUri(media),
               });
             } else if (category === 'pdf') {
-              parts.push({
+              mediaParts.push({
                 type: 'input_file',
                 file_data: normalizeMediaToDataUri(media),
                 ...(media.filename ? { filename: media.filename } : {}),
               });
             } else {
-              parts.push({
+              mediaParts.push({
                 type: 'input_text',
                 text: buildUnsupportedMediaPlaceholder(
                   media,
@@ -189,17 +192,13 @@ export function buildResponsesInputFromContent(
               });
             }
           }
-
-          outputContent = parts;
-        } else {
-          outputContent = textResult;
+          if (mediaParts.length > 0) {
+            input.push({
+              role: 'user',
+              content: mediaParts,
+            });
+          }
         }
-
-        input.push({
-          type: 'function_call_output',
-          call_id: normalizeToOpenAIToolId(toolResponseBlock.callId),
-          output: outputContent,
-        });
       }
     }
   }


### PR DESCRIPTION
## Summary

Fixes #1683 — error when switching from Anthropic to OpenAI Responses provider.

## Root Cause

The OpenAI Responses API requires \`function_call_output.output\` to be a **string**, but the converter was sending \`ResponsesContentPart[]\` arrays when tool responses contained media blocks (e.g. screenshots from \`take_screenshot\`, images from \`read_file\`). This caused a 400 error: \`Missing required parameter: input[60].output[1]\`.

## Fix

1. **Type fix**: Changed \`function_call_output.output\` from \`string | ResponsesContentPart[]\` to \`string\` in both \`buildResponsesInputFromContent.ts\` and \`OpenAIResponsesProvider.ts\`.

2. **Synthetic user message**: Instead of dropping media or replacing with text placeholders, the converter now emits the \`function_call_output\` with the text-only string, then injects a synthetic \`user\` message carrying the actual image/PDF data via \`input_image\` or \`input_file\` content parts. This preserves model visibility of media across turns while conforming to the API contract.

## Changes

- \`packages/core/src/providers/openai-responses/buildResponsesInputFromContent.ts\` — Emit string output + synthetic user message with media
- \`packages/core/src/providers/openai-responses/OpenAIResponsesProvider.ts\` — Same fix in inline history builder
- \`packages/core/src/providers/openai-responses/buildResponsesInputFromContent.mediaBlock.test.ts\` — Updated tests to verify synthetic user message approach

## Testing

- All 58 OpenAI Responses provider tests pass
- TypeScript compilation clean
- ESLint clean