### PR TITLE
Remove /v1beta from gemini base-url to fix double path (Fixes #1691)

### DIFF
--- a/packages/cli/src/providers/aliases/gemini.config
+++ b/packages/cli/src/providers/aliases/gemini.config
@@ -3,7 +3,7 @@
   "modelsDevProviderId": "google",
   "description": "Google Gemini API",
   "baseProvider": "gemini",
-  "base-url": "https://generativelanguage.googleapis.com/v1beta",
+  "base-url": "https://generativelanguage.googleapis.com",
   "defaultModel": "gemini-2.5-pro",
   "apiKeyEnv": "GEMINI_API_KEY"
 }


### PR DESCRIPTION
## Problem

Google API keys stopped working because the gemini.config base-url included `/v1beta`, but both the `GoogleGenAI` SDK and the `getModels()` fetch call append `/v1beta` internally. This caused doubled paths like `/v1beta/v1beta/models`, resulting in 404 errors.

## Fix

Remove `/v1beta` from the `base-url` in `gemini.config` so the URL is just `https://generativelanguage.googleapis.com`. The SDK and `getModels()` will append `/v1beta` as needed.

## Testing

- All 196 existing tests pass
- Build succeeds