### PR TITLE
fix(openai): prevent duplicate thinking display with GPT 5.4 (Fixes #1703)

### DIFF
--- a/packages/core/src/providers/openai/parseResponsesStream.reasoning.test.ts
+++ b/packages/core/src/providers/openai/parseResponsesStream.reasoning.test.ts
@@ -422,4 +422,32 @@ describe('parseResponsesStream - Reasoning/Thinking Support', () => {
     expect(secondThinkingBlock?.thought).toBe('Thinking about this');
     expect(secondThinkingBlock?.encryptedContent).toBe('encrypted_data_here');
   });
+
+  it('should suppress reasoning_text.done when output_item.done already emitted visible block', async () => {
+    const outputItemData =
+      '{"type":"response.output_item.done","item":{"type":"reasoning","id":"reasoning_1","summary":[{"type":"summary_text","text":"Visible from output_item"}]}}';
+    const chunks = [
+      `data: ${outputItemData}\n\n`,
+      'data: {"type":"response.reasoning_text.delta","sequence_number":2,"delta":"Different reasoning text"}\n\n',
+      'data: {"type":"response.reasoning_text.done","sequence_number":3}\n\n',
+    ];
+
+    const stream = createSSEStream(chunks);
+    let messages: IContent[] = [];
+
+    for await (const message of parseResponsesStream(stream)) {
+      messages = [...messages, message];
+    }
+
+    const thinkingMessages = messages.filter((m) =>
+      m.blocks.some((block) => block.type === 'thinking'),
+    );
+    expect(thinkingMessages).toHaveLength(1);
+
+    const thinkingBlock = thinkingMessages[0].blocks.find(
+      (block) => block.type === 'thinking',
+    );
+    expect(thinkingBlock?.thought).toBe('Visible from output_item');
+    expect(thinkingBlock?.isHidden).toBe(false);
+  });
 });

--- a/packages/core/src/providers/openai/parseResponsesStream.ts
+++ b/packages/core/src/providers/openai/parseResponsesStream.ts
@@ -333,6 +333,10 @@ export async function* parseResponsesStream(
                     const shouldHide =
                       !includeThinkingInResponse || Boolean(prior);
 
+                    if (!shouldHide) {
+                      hasEmittedVisibleThinking = true;
+                    }
+
                     const baseReasoningBlock: ContentBlock = {
                       type: 'thinking',
                       thought: finalThought,


### PR DESCRIPTION
## Summary

GPT 5.4 sends both \`reasoning_text\` and \`reasoning_summary_text\` SSE events for the same logical thought, but with different text content. The existing content-based deduplication (keyed by exact text in the \`emittedThoughts\` Map) only catches identical strings, so both blocks were emitted as visible ThinkingBlocks, causing the user to see thinking displayed twice.

GPT 5.3-codex only sent \`reasoning_text\` events, so this issue was never triggered before.

## Root Cause

In \`parseResponsesStream.ts\`, the \`reasoning_text.done\` handler emits a ThinkingBlock and records the text in \`emittedThoughts\`. The \`reasoning_summary_text.done\` handler does the same, but since its text is textually different from the full reasoning, the Map lookup misses it and a second visible block is emitted.

## Fix

Added a response-level \`hasEmittedVisibleThinking\` boolean flag. Once any visible ThinkingBlock is emitted via either \`reasoning_text.done\` or \`reasoning_summary_text.done\`, subsequent emissions from the other handler are suppressed (first-wins approach). In practice, \`reasoning_text\` fires first, so users see the full thought chain rather than the condensed summary.

The existing \`emittedThoughts\` Map is preserved untouched for its separate concern: same-text deduplication and \`encrypted_content\` re-emission from \`output_item.done\`.

The fallback path in \`response.completed\`/\`response.done\` also respects the new flag.

## Test Coverage

- Updated existing test to expect 1 ThinkingBlock (was 2) when both event types arrive
- Added test: summary-only scenario still works when no reasoning_text arrives
- Added test: reasoning_text first suppresses subsequent summary
- Added test: summary first suppresses subsequent reasoning_text (order-independent)
- Added regression test: \`output_item.done\` with \`encrypted_content\` still re-emits hidden block after visible emission

## Verification

All pass: test (196/196), lint, typecheck, format, build, smoke test.

Fixes #1703