### PR TITLE
fix: silence pgrep noise (#1132) and fix ENOENT rejection storm (#1647)

### DIFF
--- a/packages/core/src/recording/SessionRecordingService.ts
+++ b/packages/core/src/recording/SessionRecordingService.ts
@@ -26,7 +26,7 @@
 
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import { mkdirSync } from 'node:fs';
+import { mkdirSync, existsSync, watch, type FSWatcher } from 'node:fs';
 import { type IContent } from '../services/history/IContent.js';
 import {
   type SessionRecordingServiceConfig,
@@ -53,6 +53,7 @@ export class SessionRecordingService {
   private readonly sessionId: string;
   private readonly chatsDir: string;
   private preContentBuffer: SessionRecordLine[] = [];
+  private chatsDirWatcher: FSWatcher | null = null;
 
   /**
    * @plan PLAN-20260211-SESSIONRECORDING.P05
@@ -144,6 +145,7 @@ export class SessionRecordingService {
     const fileName = `session-${timestamp}-${prefix}.jsonl`;
     this.filePath = path.join(this.chatsDir, fileName);
     mkdirSync(this.chatsDir, { recursive: true });
+    this.startChatsDirWatcher();
   }
 
   /**
@@ -156,7 +158,37 @@ export class SessionRecordingService {
   private scheduleDrain(): void {
     if (this.draining) return;
     this.draining = true;
-    this.drainPromise = this.drain();
+    this.drainPromise = this.drain().catch((error: unknown) => {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT') {
+        const diag = this.diagnoseMissingPath();
+        console.error(
+          `[SessionRecording] ENOENT writing session file — recording stopped.
+` +
+            `  filePath: ${this.filePath}
+` +
+            `  chatsDir exists: ${diag.chatsDirExists}
+` +
+            `  parentDir exists: ${diag.parentDirExists} (${diag.parentDir})
+` +
+            `  grandparentDir exists: ${diag.grandparentDirExists} (${diag.grandparentDir})
+` +
+            `  This directory was removed mid-session by an external process or AI shell command.`,
+        );
+      } else {
+        console.error(
+          `[SessionRecording] Unexpected error writing session file — recording stopped.
+` +
+            `  filePath: ${this.filePath}
+` +
+            `  error: ${error}`,
+        );
+      }
+      this.queue = [];
+      this.chatsDirWatcher?.close();
+      this.chatsDirWatcher = null;
+      this.active = false;
+    });
   }
 
   /**
@@ -180,6 +212,9 @@ export class SessionRecordingService {
         } catch (error: unknown) {
           const code = (error as NodeJS.ErrnoException).code;
           if (code === 'ENOSPC' || code === 'EACCES') {
+            this.queue = [];
+            this.chatsDirWatcher?.close();
+            this.chatsDirWatcher = null;
             this.active = false;
             return;
           }
@@ -259,6 +294,7 @@ export class SessionRecordingService {
     this.seq = lastSeq;
     this.materialized = true;
     this.preContentBuffer = [];
+    this.startChatsDirWatcher();
   }
 
   /**
@@ -275,6 +311,70 @@ export class SessionRecordingService {
     this.active = false;
     this.queue = [];
     this.preContentBuffer = [];
+    if (this.chatsDirWatcher) {
+      this.chatsDirWatcher.close();
+      this.chatsDirWatcher = null;
+    }
+  }
+
+  /**
+   * Diagnose which directory level is missing when ENOENT occurs.
+   */
+  private diagnoseMissingPath(): {
+    chatsDirExists: boolean;
+    parentDir: string;
+    parentDirExists: boolean;
+    grandparentDir: string;
+    grandparentDirExists: boolean;
+  } {
+    const parentDir = path.dirname(this.chatsDir);
+    const grandparentDir = path.dirname(parentDir);
+    return {
+      chatsDirExists: existsSync(this.chatsDir),
+      parentDir,
+      parentDirExists: existsSync(parentDir),
+      grandparentDir,
+      grandparentDirExists: existsSync(grandparentDir),
+    };
+  }
+
+  /**
+   * Watch the chatsDir for rename/deletion events.
+   * When the directory is removed mid-session, this fires and logs the
+   * exact timestamp so it can be correlated with the shell command log.
+   */
+  private startChatsDirWatcher(): void {
+    if (this.chatsDirWatcher) return;
+    try {
+      this.chatsDirWatcher = watch(
+        this.chatsDir,
+        { persistent: false },
+        (eventType) => {
+          if (eventType === 'rename' && !existsSync(this.chatsDir)) {
+            console.error(
+              `[SessionRecording] chatsDir was removed at ${new Date().toISOString()}!
+` +
+                `  path: ${this.chatsDir}
+` +
+                `  sessionId: ${this.sessionId}
+` +
+                `  filePath: ${this.filePath}
+` +
+                `  Check the preceding shell command for the culprit.`,
+            );
+            this.chatsDirWatcher?.close();
+            this.chatsDirWatcher = null;
+          }
+        },
+      );
+      this.chatsDirWatcher.on('error', () => {
+        // Watcher error is expected if the directory was removed
+        this.chatsDirWatcher?.close();
+        this.chatsDirWatcher = null;
+      });
+    } catch {
+      // If watch fails (e.g. directory already gone), silently skip
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -401,7 +401,8 @@ export class ShellToolInvocation extends BaseToolInvocation<
             .filter(Boolean);
           for (const line of pgrepLines) {
             if (!/^\d+$/.test(line)) {
-              console.error(`pgrep: ${line}`);
+              this.logger.debug(() => `pgrep: ${line}`);
+              continue;
             }
             const pid = Number(line);
             if (result.pid && pid !== result.pid) {
@@ -410,7 +411,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
           }
         } else {
           if (!signal.aborted) {
-            console.error('missing pgrep output');
+            this.logger.debug(() => 'missing pgrep output');
           }
         }
 
@@ -427,7 +428,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
           }
         } catch (error) {
           // If we can't get the PGID, that's okay
-          console.error('Failed to get PGID:', error);
+          this.logger.debug(() => `Failed to get PGID: ${error}`);
         }
       }
 


### PR DESCRIPTION
## Summary

Fixes #1132 and #1647.

### Problem 1: pgrep ERROR noise (#1132)
`shell.ts` used `console.error()` for pgrep diagnostic messages ("missing pgrep output", non-numeric pgrep lines, PGID failures). `ConsolePatcher` intercepts all `console.error` calls and routes them to the ctrl-O debug console as ERROR messages. This flooded the debug console with noise like `ERROR: missing pgrep output (x127)`.

**Fix:** Changed 3 `console.error` calls to `this.logger.debug()` — the DebugLogger was already instantiated on the class (`llxprt:shell` namespace) but wasn't used for these messages. Pgrep diagnostics are now only visible when debug logging is enabled.

### Problem 2: ENOENT unhandled rejection storm (#1647)
`SessionRecordingService.scheduleDrain()` stored the promise from `drain()` without a `.catch()`. When the session recording directory was removed mid-session (likely by an AI shell command), `fs.appendFile` threw ENOENT. The catch block in `drain()` only handled ENOSPC/EACCES, so ENOENT was rethrown — becoming an unhandled promise rejection. Since `this.active` was never set to `false`, every subsequent `enqueue()` call re-triggered a failed `drain()`, creating a storm of identical unhandled rejections.

**Fix:**
- `scheduleDrain()` now catches `drain()` errors and emits a **single** clear diagnostic error with directory-level existence checks (chatsDir, parent, grandparent) to identify which directory level was removed
- Recording is then deactivated to prevent the rejection storm
- Added `fs.watch` on `chatsDir` after materialization — when the directory is removed, it logs the exact timestamp and session context so the culprit shell command can be identified

### Root cause of directory deletion
Exhaustive code analysis found **no production code path** that deletes the `chatsDir` (`~/.llxprt/tmp/<hash>/chats/`) or its parent. The most likely cause is an AI-initiated shell command removing the directory. The `fs.watch` diagnostic will confirm this on next occurrence.

## Testing
- All 32 SessionRecordingService tests pass ✅
- All 56 shell.ts tests pass ✅
- All 347 recording module tests pass ✅ (4 pre-existing property-based test timeouts in sessionManagement/SessionDiscovery confirmed on main)

## Files Changed
- `packages/core/src/tools/shell.ts` — 3 lines: `console.error` → `this.logger.debug`
- `packages/core/src/recording/SessionRecordingService.ts` — imports, watcher field, `scheduleDrain()` error handling, `diagnoseMissingPath()`, `startChatsDirWatcher()`, watcher cleanup in `dispose()` and `initializeForResume()`