### PR TITLE
docs: clarify /auth enable vs /auth login behavior (Fixes #1708)

### DIFF
--- a/docs/cli/providers.md
+++ b/docs/cli/providers.md
@@ -58,7 +58,7 @@ From the command line:
 llxprt --provider codex
 ```
 
-Each command opens a browser for authentication with your existing account. See [OAuth Setup](../oauth-setup.md) for details.
+Each `enable` command sets up lazy OAuth — a browser opens automatically when you make your first request to that provider. Use `/auth <provider> login` to open the browser immediately. See [OAuth Setup](../oauth-setup.md) for details.
 
 ### API Keys (Keyring)
 

--- a/docs/gemini-cli-tips.md
+++ b/docs/gemini-cli-tips.md
@@ -42,7 +42,7 @@ For OAuth providers (Gemini, Anthropic, Codex, Qwen), enable them:
 /auth anthropic enable
 ```
 
-Authentication opens a browser automatically when you make your first request.
+With `/auth <provider> enable`, authentication is lazy — a browser opens automatically when you make your first request. Use `/auth <provider> login` to open the browser immediately.
 
 See [Authentication](./cli/authentication.md) for full details.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -74,7 +74,7 @@ llxprt
 /model qwen-3-coder
 ```
 
-Each `/auth` command opens a browser for OAuth with your existing account.
+Each `/auth <provider> enable` command enables lazy OAuth — a browser opens automatically when you make your first request to that provider. Use `/auth <provider> login` to open the browser immediately.
 
 ### Option C: API Keys
 


### PR DESCRIPTION
## Summary

Fixes #1708 — Several documentation pages incorrectly stated that \`/auth enable\` opens a browser for OAuth. In reality, \`/auth <provider> enable\` enables **lazy** OAuth (the browser opens on first request), while \`/auth <provider> login\` opens the browser immediately.

## Changes

- **docs/getting-started.md**: Corrected the description after the OAuth examples to explain lazy vs immediate auth.
- **docs/cli/providers.md**: Same correction in the provider setup section.
- **docs/gemini-cli-tips.md**: Added clarification about enable vs login behavior.

All three files now consistently explain that \`enable\` sets up lazy auth and \`login\` triggers immediate browser-based auth, matching the existing correct documentation in \`docs/oauth-setup.md\`.