### PR TITLE
fix: restore checkmark symbol in CLI UI indicators (fixes #1773)

### DIFF
--- a/packages/cli/src/commands/mcp/list.ts
+++ b/packages/cli/src/commands/mcp/list.ts
@@ -107,7 +107,7 @@ export async function listMcpServers(): Promise<void> {
     let statusText = '';
     switch (status) {
       case MCPServerStatus.CONNECTED:
-        statusIndicator = COLOR_GREEN + '[OK]' + RESET_COLOR;
+        statusIndicator = COLOR_GREEN + '✓' + RESET_COLOR;
         statusText = 'Connected';
         break;
       case MCPServerStatus.CONNECTING:

--- a/packages/cli/src/config/extensions/consent.ts
+++ b/packages/cli/src/config/extensions/consent.ts
@@ -149,7 +149,7 @@ export async function requestHookConsent(
       const consent = answer.trim().toLowerCase() === 'y';
       if (consent) {
         debugLogger.log(
-          `[OK] Hooks enabled for extension "${sanitizedExtensionName}".`,
+          `✓ Hooks enabled for extension "${sanitizedExtensionName}".`,
         );
       } else {
         debugLogger.log(

--- a/packages/cli/src/runtime/providerMutations.ts
+++ b/packages/cli/src/runtime/providerMutations.ts
@@ -275,7 +275,7 @@ export async function updateActiveProviderApiKey(
       message:
         `API key removed for provider '${providerName}'` +
         (providerName === 'gemini' && isPaidMode === false
-          ? '\n[OK] You are now using OAuth (no paid usage).'
+          ? '\n✓ You are now using OAuth (no paid usage).'
           : ''),
       isPaidMode,
     };

--- a/packages/cli/src/ui/commands/authCommand.test.ts
+++ b/packages/cli/src/ui/commands/authCommand.test.ts
@@ -438,7 +438,7 @@ describe('AuthCommandExecutor OAuth Support', () => {
 
       // Then: Should return formatted status indicators with enablement info
       expect(result).toEqual([
-        '[[OK]] gemini: authenticated (expires in 60m) [OAuth enabled]',
+        '[✓] gemini: authenticated (expires in 60m) [OAuth enabled]',
         '[] qwen: not authenticated [OAuth disabled]',
       ]);
     });

--- a/packages/cli/src/ui/commands/authCommand.ts
+++ b/packages/cli/src/ui/commands/authCommand.ts
@@ -629,7 +629,7 @@ export class AuthCommandExecutor {
     try {
       const statuses = await this.oauthManager.getAuthStatus();
       return statuses.map((status) => {
-        const indicator = status.authenticated ? '[[OK]]' : '[]';
+        const indicator = status.authenticated ? '[✓]' : '[]';
         const authInfo = status.authenticated
           ? `authenticated${status.expiresIn ? ` (expires in ${Math.floor(status.expiresIn / 60)}m)` : ''}`
           : 'not authenticated';

--- a/packages/cli/src/ui/commands/todoCommand.ts
+++ b/packages/cli/src/ui/commands/todoCommand.ts
@@ -217,7 +217,7 @@ export const todoCommand: SlashCommand = {
           const pos = idx + 1;
           const statusIcon =
             todo.status === 'completed'
-              ? '[OK]'
+              ? '✓'
               : todo.status === 'in_progress'
                 ? '▸'
                 : '○';

--- a/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
@@ -259,14 +259,14 @@ describe('<HistoryItemDisplay />', () => {
       ...baseItem,
       type: 'info',
       text: 'Custom icon message',
-      icon: '[OK]',
+      icon: '✓',
     };
     const { lastFrame } = renderWithProviders(
       <HistoryItemDisplay {...baseItem} item={item} />,
     );
     const output = lastFrame();
     expect(output).toContain('Custom icon message');
-    expect(output).toContain('[OK]');
+    expect(output).toContain('✓');
   });
 
   it('renders InfoMessage with custom color', () => {

--- a/packages/cli/src/ui/components/StatsDisplay.tsx
+++ b/packages/cli/src/ui/components/StatsDisplay.tsx
@@ -301,9 +301,7 @@ export const StatsDisplay: React.FC<StatsDisplayProps> = ({
           <StatRow title="Tool Calls:">
             <Text color={theme.text.primary}>
               {tools.totalCalls} ({' '}
-              <Text color={theme.status.success}>
-                [OK] {tools.totalSuccess}
-              </Text>{' '}
+              <Text color={theme.status.success}>✓ {tools.totalSuccess}</Text>{' '}
               <Text color={theme.status.error}>x {tools.totalFail}</Text> )
             </Text>
           </StatRow>

--- a/packages/cli/src/ui/components/WelcomeOnboarding/CompletionStep.tsx
+++ b/packages/cli/src/ui/components/WelcomeOnboarding/CompletionStep.tsx
@@ -97,7 +97,7 @@ export const CompletionStep: React.FC<CompletionStepProps> = ({
         </Text>
         <Text color={Colors.Foreground}> </Text>
         <Text bold color={Colors.AccentGreen}>
-          {'[OK] Authentication complete!'}
+          {'✓ Authentication complete!'}
         </Text>
       </Box>
 

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
@@ -47,7 +47,7 @@ vi.mock('./ToolMessage.js', () => ({
       resultDisplay,
     });
     const statusSymbol = {
-      [ToolCallStatus.Success]: '[OK]',
+      [ToolCallStatus.Success]: '✓',
       [ToolCallStatus.Pending]: 'o',
       [ToolCallStatus.Executing]: '⊷',
       [ToolCallStatus.Confirming]: '?',

--- a/packages/cli/src/ui/constants.ts
+++ b/packages/cli/src/ui/constants.ts
@@ -20,7 +20,7 @@ export const SHELL_NAME = 'Shell';
 
 // Tool status symbols used in ToolMessage component
 export const TOOL_STATUS = {
-  SUCCESS: '[OK]',
+  SUCCESS: '✓',
   PENDING: 'o',
   EXECUTING: '⊷',
   CONFIRMING: '?',

--- a/packages/core/src/tools/check-async-tasks.ts
+++ b/packages/core/src/tools/check-async-tasks.ts
@@ -94,7 +94,7 @@ class CheckAsyncTasksInvocation extends BaseToolInvocation<
         task.status === 'running'
           ? ''
           : task.status === 'completed'
-            ? '[OK]'
+            ? '✓'
             : task.status === 'failed'
               ? '[FAILED]'
               : '';
@@ -111,7 +111,7 @@ class CheckAsyncTasksInvocation extends BaseToolInvocation<
         t.status === 'running'
           ? ''
           : t.status === 'completed'
-            ? '[OK]'
+            ? '✓'
             : t.status === 'failed'
               ? '[FAILED]'
               : '';
@@ -231,7 +231,7 @@ class CheckAsyncTasksInvocation extends BaseToolInvocation<
       task.status === 'running'
         ? ''
         : task.status === 'completed'
-          ? '[OK]'
+          ? '✓'
           : task.status === 'failed'
             ? '[FAILED]'
             : '';


### PR DESCRIPTION
## Summary

Restores the Unicode checkmark symbol `\u2713` (U+2713) in CLI UI display elements that were incorrectly replaced with `[OK]` text by a previous LLM change (commit `864d3827a`).

**Scope:** CLI UI display only. The EmojiFilter (`\u2713` \u2192 `[OK]` for LLM output) is intentionally left unchanged.

## Changes

### Source files (symbol restored)
- `packages/cli/src/ui/constants.ts` - `TOOL_STATUS.SUCCESS` constant
- `packages/cli/src/ui/components/StatsDisplay.tsx` - tool call success counter
- `packages/core/src/tools/check-async-tasks.ts` - completed task icons (3 locations)
- `packages/cli/src/ui/commands/todoCommand.ts` - completed todo status icon
- `packages/cli/src/commands/mcp/list.ts` - connected MCP server indicator
- `packages/cli/src/ui/components/WelcomeOnboarding/CompletionStep.tsx` - auth success message
- `packages/cli/src/runtime/providerMutations.ts` - OAuth usage confirmation
- `packages/cli/src/config/extensions/consent.ts` - hooks enabled message
- `packages/cli/src/ui/commands/authCommand.ts` - authenticated status indicator (`[\u2713]` vs `[]`)

### Test files (assertions updated to match)
- `packages/cli/src/ui/commands/authCommand.test.ts`
- `packages/cli/src/ui/components/HistoryItemDisplay.test.tsx`
- `packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx`

## Verification

- `npm run build` - passes
- `npm run typecheck` - passes (both packages)
- `npm run lint` - passes (warnings are pre-existing)
- `node scripts/start.js --profile-load synthetic "write me a haiku and nothing else"` - passes
- All test failures confirmed pre-existing on main (snapshot/context issues unrelated to this PR)

closes #1773