### PR TITLE
fix: preserve last user prompt during middle-out compression (Fixes #1650)

### DIFF
--- a/packages/core/src/core/__tests__/compression-dispatcher.test.ts
+++ b/packages/core/src/core/__tests__/compression-dispatcher.test.ts
@@ -195,7 +195,8 @@ describe('Compression Dispatcher Integration (P13)', () => {
         msg.blocks.some(
           (b) =>
             b.type === 'text' &&
-            b.text === 'Understood. Continuing with the current task.',
+            b.text.includes('Understood.') &&
+            b.text.includes('Continuing with the current task.'),
         ),
       );
       expect(hasAck).toBe(false);
@@ -235,7 +236,8 @@ describe('Compression Dispatcher Integration (P13)', () => {
         msg.blocks.some(
           (b) =>
             b.type === 'text' &&
-            b.text === 'Understood. Continuing with the current task.',
+            b.text.includes('Understood.') &&
+            b.text.includes('Continuing with the current task.'),
         ),
       );
       expect(hasAck).toBe(true);

--- a/packages/core/src/core/__tests__/sandwich-compression.test.ts
+++ b/packages/core/src/core/__tests__/sandwich-compression.test.ts
@@ -370,10 +370,13 @@ describe('Sandwich Compression (Issue #1011)', () => {
       );
       const ackMessage = finalHistory[summaryIndex + 1];
       expect(ackMessage.speaker).toBe('ai');
-      expect(ackMessage.blocks[0]).toMatchObject({
-        type: 'text',
-        text: 'Understood. Continuing with the current task.',
-      });
+      expect(ackMessage.blocks[0].type).toBe('text');
+      expect((ackMessage.blocks[0] as { text: string }).text).toContain(
+        'Understood.',
+      );
+      expect((ackMessage.blocks[0] as { text: string }).text).toContain(
+        'Continuing with the current task.',
+      );
     });
   });
 });

--- a/packages/core/src/core/compression/MiddleOutStrategy.test.ts
+++ b/packages/core/src/core/compression/MiddleOutStrategy.test.ts
@@ -512,9 +512,9 @@ describe('MiddleOutStrategy', () => {
       expect(ackMsg.speaker).toBe('ai');
       const textBlock = ackMsg.blocks[0];
       expect(textBlock.type).toBe('text');
-      expect((textBlock as { text: string }).text).toBe(
-        'Understood. Continuing with the current task.',
-      );
+      const ackText = (textBlock as { type: 'text'; text: string }).text;
+      expect(ackText).toContain('Understood.');
+      expect(ackText).toContain('Continuing with the current task.');
     });
   });
 
@@ -711,6 +711,125 @@ describe('MiddleOutStrategy', () => {
       // Both chunks should appear in the aggregated summary
       expect(summaryText).toContain('First part.');
       expect(summaryText).toContain('Second part.');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Last user prompt preservation
+  // -----------------------------------------------------------------------
+
+  describe('last user prompt preservation', () => {
+    it('preserves short last user prompt literally when it falls in toCompress', async () => {
+      // Build 20 messages where the last human message is at index 10
+      // (inside toCompress range 4..15 with default thresholds).
+      // All messages after index 10 are AI-only so the last human is at 10.
+      const history: IContent[] = [];
+      for (let i = 0; i < 20; i++) {
+        if (i === 10) {
+          history.push(humanMsg('fix the failing auth test'));
+        } else if (i <= 10 && i % 2 === 0) {
+          history.push(humanMsg(`user message ${i}`));
+        } else {
+          history.push(aiTextMsg(`ai response ${i}`));
+        }
+      }
+
+      const ctx = buildContext({ history });
+      const strategy = new MiddleOutStrategy();
+      const result = await strategy.compress(ctx);
+
+      const bottomStart =
+        result.newHistory.length - result.metadata.bottomPreserved!;
+      const bottomMessages = result.newHistory.slice(bottomStart);
+      const bottomTexts = bottomMessages
+        .filter((m) => m.speaker === 'human')
+        .flatMap((m) =>
+          m.blocks
+            .filter(
+              (b): b is { type: 'text'; text: string } => b.type === 'text',
+            )
+            .map((b) => b.text),
+        );
+      expect(bottomTexts).toContain('fix the failing auth test');
+    });
+
+    it('does not modify split when last human message is already in toKeepBottom', async () => {
+      const history = generateHistory(20);
+      const ctx = buildContext({ history });
+      const strategy = new MiddleOutStrategy();
+
+      const result = await strategy.compress(ctx);
+
+      const lastHumanIndex = [...history]
+        .reverse()
+        .findIndex((m) => m.speaker === 'human');
+      const lastHumanOriginalIndex = history.length - 1 - lastHumanIndex;
+
+      const bottomSplitIndex = Math.floor(history.length * (1 - 0.2));
+      expect(lastHumanOriginalIndex).toBeGreaterThanOrEqual(bottomSplitIndex);
+      expect(result.metadata.llmCallMade).toBe(true);
+    });
+
+    it('handles history with no human messages', async () => {
+      const history: IContent[] = [];
+      for (let i = 0; i < 20; i++) {
+        history.push(aiTextMsg(`ai message ${i}`));
+      }
+
+      const ctx = buildContext({ history });
+      const strategy = new MiddleOutStrategy();
+      const result = await strategy.compress(ctx);
+
+      expect(result.metadata.strategyUsed).toBe('middle-out');
+    });
+
+    it('continuation directive includes last user prompt context when prompt is preserved', async () => {
+      const history: IContent[] = [];
+      for (let i = 0; i < 20; i++) {
+        if (i === 8) {
+          history.push(humanMsg('please fix the database connection issue'));
+        } else if (i % 2 === 0) {
+          history.push(humanMsg(`user message ${i}`));
+        } else {
+          history.push(aiTextMsg(`ai response ${i}`));
+        }
+      }
+
+      const ctx = buildContext({ history });
+      const strategy = new MiddleOutStrategy();
+      const result = await strategy.compress(ctx);
+
+      const topCount = result.metadata.topPreserved!;
+      const ackMsg = result.newHistory[topCount + 1];
+      expect(ackMsg.speaker).toBe('ai');
+      const ackText = (ackMsg.blocks[0] as { type: 'text'; text: string }).text;
+      expect(ackText).toContain('most recent request');
+    });
+
+    it('handles large last user prompt via context injection', async () => {
+      const longText = 'x'.repeat(5000);
+      const history: IContent[] = [];
+      for (let i = 0; i < 20; i++) {
+        if (i === 8) {
+          history.push(humanMsg(longText));
+        } else if (i % 2 === 0) {
+          history.push(humanMsg(`user message ${i}`));
+        } else {
+          history.push(aiTextMsg(`ai response ${i}`));
+        }
+      }
+
+      const ctx = buildContext({ history });
+      const strategy = new MiddleOutStrategy();
+      const result = await strategy.compress(ctx);
+
+      expect(result.metadata.llmCallMade).toBe(true);
+      expect(result.metadata.strategyUsed).toBe('middle-out');
+
+      const topCount = result.metadata.topPreserved!;
+      const ackMsg = result.newHistory[topCount + 1];
+      const ackText = (ackMsg.blocks[0] as { type: 'text'; text: string }).text;
+      expect(ackText).toContain('most recent request');
     });
   });
 

--- a/packages/core/src/core/compression/MiddleOutStrategy.ts
+++ b/packages/core/src/core/compression/MiddleOutStrategy.ts
@@ -21,7 +21,11 @@
  */
 
 import { readFileSync } from 'node:fs';
-import type { IContent, UsageStats } from '../../services/history/IContent.js';
+import type {
+  IContent,
+  TextBlock,
+  UsageStats,
+} from '../../services/history/IContent.js';
 import type { IProvider } from '../../providers/IProvider.js';
 import type {
   CompressionContext,
@@ -42,8 +46,11 @@ import {
   sanitizeHistoryForCompression,
 } from './utils.js';
 import { getCompressionPrompt } from '../prompts.js';
+import { estimateTokens } from '../../utils/toolOutputLimiter.js';
 
 const MINIMUM_MIDDLE_MESSAGES = 4;
+const LAST_PROMPT_TOKEN_THRESHOLD = 500;
+const LAST_PROMPT_CONTEXT_MAX_LENGTH = 200;
 
 const TRIGGER_INSTRUCTION =
   'First, reason in your scratchpad. Then, generate the <state_snapshot>.';
@@ -69,7 +76,21 @@ export class MiddleOutStrategy implements CompressionStrategy {
     }
 
     // Compute sandwich split
-    const { toKeepTop, toCompress, toKeepBottom } = this.computeSplit(context);
+    let { toKeepTop, toCompress, toKeepBottom } = this.computeSplit(context);
+
+    if (toCompress.length < MINIMUM_MIDDLE_MESSAGES) {
+      return this.noCompressionResult(history);
+    }
+
+    // Preserve the last user prompt if it ended up in the middle section
+    const {
+      toCompress: adjustedCompress,
+      toKeepBottom: adjustedBottom,
+      lastUserPromptContext,
+      largeLastPromptInjection,
+    } = this.preserveLastUserPrompt(toKeepTop, toCompress, toKeepBottom);
+    toCompress = adjustedCompress;
+    toKeepBottom = adjustedBottom;
 
     if (toCompress.length < MINIMUM_MIDDLE_MESSAGES) {
       return this.noCompressionResult(history);
@@ -95,6 +116,7 @@ export class MiddleOutStrategy implements CompressionStrategy {
       },
       ...sanitizeHistoryForCompression(toCompress),
       ...this.buildContextInjections(context),
+      ...largeLastPromptInjection,
       {
         speaker: 'human',
         blocks: [{ type: 'text', text: TRIGGER_INSTRUCTION }],
@@ -122,6 +144,7 @@ export class MiddleOutStrategy implements CompressionStrategy {
       toKeepBottom,
       context.activeTodos,
       capturedUsage,
+      lastUserPromptContext,
     );
 
     const metadata: CompressionResultMetadata = {
@@ -239,12 +262,114 @@ export class MiddleOutStrategy implements CompressionStrategy {
     }
   }
 
+  private preserveLastUserPrompt(
+    toKeepTop: readonly IContent[],
+    toCompress: readonly IContent[],
+    toKeepBottom: readonly IContent[],
+  ): {
+    toCompress: IContent[];
+    toKeepBottom: IContent[];
+    lastUserPromptContext: string | undefined;
+    largeLastPromptInjection: IContent[];
+  } {
+    const fullHistory = [...toKeepTop, ...toCompress, ...toKeepBottom];
+    const lastHumanIndex = this.findLastHumanMessageIndex(fullHistory);
+
+    if (lastHumanIndex === -1) {
+      return {
+        toCompress: [...toCompress],
+        toKeepBottom: [...toKeepBottom],
+        lastUserPromptContext: undefined,
+        largeLastPromptInjection: [],
+      };
+    }
+
+    const compressStart = toKeepTop.length;
+    const compressEnd = compressStart + toCompress.length;
+    const isInCompressRange =
+      lastHumanIndex >= compressStart && lastHumanIndex < compressEnd;
+
+    if (!isInCompressRange) {
+      const lastHumanMsg = fullHistory[lastHumanIndex];
+      const text = this.extractTextFromMessage(lastHumanMsg);
+      const context =
+        text.length > LAST_PROMPT_CONTEXT_MAX_LENGTH
+          ? text.slice(0, LAST_PROMPT_CONTEXT_MAX_LENGTH) + '...'
+          : text;
+      return {
+        toCompress: [...toCompress],
+        toKeepBottom: [...toKeepBottom],
+        lastUserPromptContext: context || undefined,
+        largeLastPromptInjection: [],
+      };
+    }
+
+    const lastHumanMsg = fullHistory[lastHumanIndex];
+    const messageText = this.extractTextFromMessage(lastHumanMsg);
+    const tokenCount = estimateTokens(messageText);
+    const indexInCompress = lastHumanIndex - compressStart;
+
+    if (tokenCount < LAST_PROMPT_TOKEN_THRESHOLD) {
+      const movedMessages = toCompress.slice(indexInCompress);
+      const remainingCompress = toCompress.slice(0, indexInCompress);
+      const context =
+        messageText.length > LAST_PROMPT_CONTEXT_MAX_LENGTH
+          ? messageText.slice(0, LAST_PROMPT_CONTEXT_MAX_LENGTH) + '...'
+          : messageText;
+      return {
+        toCompress: [...remainingCompress],
+        toKeepBottom: [...movedMessages, ...toKeepBottom],
+        lastUserPromptContext: context || undefined,
+        largeLastPromptInjection: [],
+      };
+    }
+
+    const context =
+      messageText.length > LAST_PROMPT_CONTEXT_MAX_LENGTH
+        ? messageText.slice(0, LAST_PROMPT_CONTEXT_MAX_LENGTH) + '...'
+        : messageText;
+    const injection: IContent = {
+      speaker: 'human',
+      blocks: [
+        {
+          type: 'text',
+          text: `IMPORTANT — The user's most recent message (summarized because it was too long to preserve literally). Summarize this user request faithfully and completely, preserving their exact intent, problems described, and any specific instructions:
+
+${messageText}`,
+        },
+      ],
+    };
+    return {
+      toCompress: [...toCompress],
+      toKeepBottom: [...toKeepBottom],
+      lastUserPromptContext: context || undefined,
+      largeLastPromptInjection: [injection],
+    };
+  }
+
+  private findLastHumanMessageIndex(history: readonly IContent[]): number {
+    for (let i = history.length - 1; i >= 0; i--) {
+      if (history[i].speaker === 'human') {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  private extractTextFromMessage(message: IContent): string {
+    return message.blocks
+      .filter((b): b is TextBlock => b.type === 'text')
+      .map((b) => b.text)
+      .join(' ');
+  }
+
   private assembleHistory(
     toKeepTop: IContent[],
     summary: string,
     toKeepBottom: IContent[],
     activeTodos?: string,
     usage?: UsageStats,
+    lastUserPromptContext?: string,
   ): IContent[] {
     const summaryEntry: IContent = {
       speaker: 'human' as const,
@@ -260,7 +385,10 @@ export class MiddleOutStrategy implements CompressionStrategy {
         blocks: [
           {
             type: 'text' as const,
-            text: buildContinuationDirective(activeTodos),
+            text: buildContinuationDirective(
+              activeTodos,
+              lastUserPromptContext,
+            ),
           },
         ],
       },

--- a/packages/core/src/core/compression/__tests__/continuation-directive.test.ts
+++ b/packages/core/src/core/compression/__tests__/continuation-directive.test.ts
@@ -56,4 +56,33 @@ describe('buildContinuationDirective', () => {
     expect(result).not.toContain('Add caching');
     expect(result).not.toContain('Update docs');
   });
+
+  it('includes last user prompt context when provided without todos', () => {
+    const result = buildContinuationDirective(
+      undefined,
+      'Fix the failing test in auth module',
+    );
+    expect(result).toContain('Fix the failing test in auth module');
+    expect(result).toContain('most recent request');
+  });
+
+  it('combines todos and last user prompt context', () => {
+    const todos = '- [in_progress] Fix auth bug';
+    const result = buildContinuationDirective(
+      todos,
+      'The test is still failing after the last change',
+    );
+    expect(result).toContain('Fix auth bug');
+    expect(result).toContain('The test is still failing after the last change');
+  });
+
+  it('ignores empty last user prompt context', () => {
+    const result = buildContinuationDirective(undefined, '');
+    expect(result).toBe('Understood. Continuing with the current task.');
+  });
+
+  it('ignores whitespace-only last user prompt context', () => {
+    const result = buildContinuationDirective(undefined, '   \n  ');
+    expect(result).toBe('Understood. Continuing with the current task.');
+  });
 });

--- a/packages/core/src/core/compression/utils.ts
+++ b/packages/core/src/core/compression/utils.ts
@@ -167,13 +167,28 @@ export function findBackwardValidSplitPoint(
  * references the first task and points the model at todo_read for
  * full recovery; otherwise it emits a simple "continue" statement.
  */
-export function buildContinuationDirective(activeTodos?: string): string {
+export function buildContinuationDirective(
+  activeTodos?: string,
+  lastUserPromptContext?: string,
+): string {
+  const hasPromptContext =
+    lastUserPromptContext !== undefined &&
+    lastUserPromptContext.trim().length > 0;
+  const promptPart = hasPromptContext
+    ? ` The user's most recent request: "${lastUserPromptContext.trim()}".`
+    : '';
+
   if (activeTodos && activeTodos.trim().length > 0) {
     const firstTask = extractFirstTaskContent(activeTodos);
     if (firstTask) {
-      return `Understood. Continue with current task: "${firstTask}". Use todo_read for full context.`;
+      return `Understood.${promptPart} Continue with current task: "${firstTask}". Use todo_read for full context.`;
     }
   }
+
+  if (hasPromptContext) {
+    return `Understood.${promptPart} Continuing with the current task.`;
+  }
+
   return 'Understood. Continuing with the current task.';
 }
 


### PR DESCRIPTION
## Summary

Fixes #1650

After middle-out compression, the LLM would sometimes lose context of the user's most recent request when it fell into the compressed middle section. This caused a "groundhog day" effect where the model would respond to earlier context instead of the user's latest input.

## Problem

The middle-out strategy divides conversation history into three zones by position:
- **Top** (~20%): preserved literally
- **Middle**: compressed via LLM summarization
- **Bottom** (~20%): preserved literally

When the user's last message happened to fall in the middle zone (common in long conversations with many tool calls), it got summarized along with everything else. The LLM then had no clear signal of what the user most recently asked, leading it to address earlier problems or repeat itself.

## Solution

The fix adds a \`preserveLastUserPrompt\` method to \`MiddleOutStrategy\` that detects the last human message and handles it based on its size:

### Short prompts (< 500 tokens)
- Moved literally from the compress zone into the preserved bottom section
- All messages between the last human message and the original bottom boundary are moved together to maintain context coherence
- The LLM sees the user's exact words after compression

### Long prompts (>= 500 tokens)
- A context injection is added to the compression request telling the LLM to pay special attention to this being the user's most recent request
- A truncated excerpt (up to 200 chars) of the message is included in the continuation directive
- This ensures the summary captures the user's intent without bloating the preserved section

### Continuation directive enhancement
- \`buildContinuationDirective()\` now accepts an optional \`lastUserPromptContext\` parameter
- When provided, the directive includes: "The user's most recent request: [context]"
- This gives the model a clear signal of what to continue working on

## Files Changed

| File | Change |
|------|--------|
| \`MiddleOutStrategy.ts\` | Added \`preserveLastUserPrompt()\`, \`findLastHumanMessageIndex()\`, \`extractTextFromMessage()\` methods; updated \`compress()\` and \`assembleHistory()\` to use them |
| \`utils.ts\` | Extended \`buildContinuationDirective()\` with optional \`lastUserPromptContext\` parameter |
| \`MiddleOutStrategy.test.ts\` | 5 new behavioral tests for last-prompt preservation scenarios |
| \`continuation-directive.test.ts\` | 4 new tests for the \`lastUserPromptContext\` parameter |
| \`compression-dispatcher.test.ts\` | Updated ack text assertion to use \`includes()\` instead of exact match |
| \`sandwich-compression.test.ts\` | Updated ack text assertion to use \`toContain()\` instead of exact match |

## Testing

- All 9102 tests pass (527 test files in core package)
- All CLI, a2a-server, vscode-ide-companion, and LSP tests pass
- Typecheck, lint, format, and build all pass
- Smoke test with synthetic profile passes