### PR TITLE
fix(oauth): add disk-read on lock timeout to prevent cross-process token replay (Fixes #1781)

### DIFF
--- a/packages/cli/src/auth/__tests__/proactive-renewal-cross-process.spec.ts
+++ b/packages/cli/src/auth/__tests__/proactive-renewal-cross-process.spec.ts
@@ -144,6 +144,117 @@ describe('ProactiveRenewalManager – cross-process refresh safety', () => {
       expect(provider.refreshToken).not.toHaveBeenCalled();
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // CR-03: Lock timeout with disk-read detection
+  // ---------------------------------------------------------------------------
+
+  describe('lock timeout – disk-read detection', () => {
+    it('reads from disk and reschedules when lock times out and token was refreshed externally', async () => {
+      const originalToken = makeToken('access-A', 'refresh-R1', 600);
+      manager.scheduleProactiveRenewal('anthropic', 'default', originalToken);
+
+      // Lock acquisition times out (another process holds it)
+      vi.mocked(tokenStore.acquireRefreshLock).mockResolvedValue(false);
+
+      // Another process already refreshed the token while holding the lock
+      const externallyRefreshedToken = makeToken(
+        'access-B',
+        'refresh-R2',
+        3600,
+      );
+      vi.mocked(tokenStore.getToken).mockResolvedValue(
+        externallyRefreshedToken,
+      );
+
+      await manager.runProactiveRenewal('anthropic', 'default');
+
+      // Should NOT attempt to refresh — another process did it
+      expect(provider.refreshToken).not.toHaveBeenCalled();
+      // Lock should not have been released (we never acquired it)
+      expect(tokenStore.releaseRefreshLock).not.toHaveBeenCalled();
+      // Token should NOT have been saved (we didn't refresh)
+      expect(tokenStore.saveToken).not.toHaveBeenCalled();
+
+      // Verify rescheduling: a retry would fire within the backoff window
+      // (~30-65s). A fresh schedule based on the new 3600s expiry fires much
+      // later. Advance past the retry backoff window and confirm no refresh
+      // attempt was made (timer was rescheduled for the new token's expiry).
+      vi.advanceTimersByTime(65 * 1000);
+      await vi.runAllTimersAsync();
+
+      // No refreshToken call — the timer hasn't fired yet because it was
+      // rescheduled based on the externally-refreshed token's 3600s expiry
+      expect(provider.refreshToken).not.toHaveBeenCalled();
+    });
+
+    it('schedules retry when lock times out and token unchanged on disk', async () => {
+      const originalToken = makeToken('access-A', 'refresh-R1', 600);
+      manager.scheduleProactiveRenewal('anthropic', 'default', originalToken);
+
+      // Lock acquisition times out
+      vi.mocked(tokenStore.acquireRefreshLock).mockResolvedValue(false);
+
+      // Token on disk is unchanged — no other process refreshed it
+      vi.mocked(tokenStore.getToken).mockResolvedValue(
+        makeToken('access-A', 'refresh-R1', 600),
+      );
+
+      await manager.runProactiveRenewal('anthropic', 'default');
+
+      // Should NOT attempt to refresh (we couldn't acquire the lock)
+      expect(provider.refreshToken).not.toHaveBeenCalled();
+
+      // Now allow lock to succeed on retry to verify the retry was scheduled
+      vi.mocked(tokenStore.acquireRefreshLock).mockResolvedValue(true);
+      const refreshedToken = makeToken('access-B', 'refresh-R2', 3600);
+      vi.mocked(provider.refreshToken).mockResolvedValue(refreshedToken);
+      // Disk still has original token at retry time
+      vi.mocked(tokenStore.getToken).mockResolvedValue(
+        makeToken('access-A', 'refresh-R1', 600),
+      );
+
+      // Advance timers to trigger retry (backoff starts at ~30s)
+      vi.advanceTimersByTime(65 * 1000);
+      await vi.runAllTimersAsync();
+
+      // On retry, lock was acquired and refresh was attempted
+      expect(provider.refreshToken).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // CR-04: No refresh_token fallthrough (proactive renewal path)
+  // ---------------------------------------------------------------------------
+
+  describe('no refresh_token fallthrough', () => {
+    it('skips refresh and clears state when token has no refresh_token', async () => {
+      // scheduleProactiveRenewal should return early — no timer set
+      const tokenNoRefresh: OAuthToken = {
+        access_token: 'access-A',
+        refresh_token: '',
+        token_type: 'Bearer',
+        expiry: Math.floor(Date.now() / 1000) + 600,
+      };
+      manager.scheduleProactiveRenewal('anthropic', 'default', tokenNoRefresh);
+
+      // Also test runProactiveRenewal when disk token has no refresh_token:
+      // set up as if a renewal timer fires but disk token lost its refresh_token
+      const tokenWithRefresh = makeToken('access-A', 'refresh-R1', 600);
+      manager.scheduleProactiveRenewal(
+        'anthropic',
+        'default',
+        tokenWithRefresh,
+      );
+
+      const diskTokenNoRefresh = makeExpiredToken('access-A', '');
+      vi.mocked(tokenStore.getToken).mockResolvedValue(diskTokenNoRefresh);
+
+      await manager.runProactiveRenewal('anthropic', 'default');
+
+      expect(provider.refreshToken).not.toHaveBeenCalled();
+    });
+  });
 });
 
 describe('executeTokenRefresh – refresh_token guard', () => {
@@ -211,5 +322,32 @@ describe('executeTokenRefresh – refresh_token guard', () => {
 
     expect(provider.refreshToken).toHaveBeenCalledTimes(1);
     expect(result?.access_token).toBe('access-B');
+  });
+
+  it('returns null when disk token has no refresh_token', async () => {
+    const originalToken = makeExpiredToken('access-A', 'refresh-R1');
+    const diskTokenNoRefresh: OAuthToken = {
+      access_token: 'access-A',
+      refresh_token: undefined,
+      token_type: 'Bearer',
+      expiry: Math.floor(Date.now() / 1000) - 60,
+    };
+
+    vi.mocked(tokenStore.getToken).mockResolvedValue(diskTokenNoRefresh);
+
+    const result = await executeTokenRefresh(
+      'anthropic',
+      'default',
+      originalToken,
+      Math.floor(Date.now() / 1000) + 30,
+      tokenStore,
+      providerRegistry as ProviderRegistry,
+      renewalManager,
+    );
+
+    // Should NOT call refreshToken (disk token has no refresh_token)
+    expect(provider.refreshToken).not.toHaveBeenCalled();
+    // Should return null
+    expect(result).toBeNull();
   });
 });

--- a/packages/cli/src/auth/proactive-renewal-manager.ts
+++ b/packages/cli/src/auth/proactive-renewal-manager.ts
@@ -257,8 +257,25 @@ export class ProactiveRenewalManager {
     );
 
     if (!lockAcquired) {
-      // Lock timeout - retry later
-      this.scheduleProactiveRetry(providerName, normalizedBucket);
+      // Issue #1781: Before retrying, check if another process already
+      // refreshed the token while holding the lock. If the on-disk token
+      // differs from the one we scheduled this renewal for, the other
+      // process handled it — reschedule based on the new token instead of
+      // incrementing the failure counter.
+      const diskToken = await this.tokenStore.getToken(
+        providerName,
+        normalizedBucket,
+      );
+      if (diskToken && this.isTokenRefreshed(key, diskToken)) {
+        this.proactiveRenewals.delete(key);
+        this.scheduleProactiveRenewal(
+          providerName,
+          normalizedBucket,
+          diskToken,
+        );
+      } else {
+        this.scheduleProactiveRetry(providerName, normalizedBucket);
+      }
       return;
     }
 
@@ -352,6 +369,15 @@ export class ProactiveRenewalManager {
     // Direct runProactiveRenewal call (no prior schedule) — use expiry-based check
     const nowInSeconds = Math.floor(Date.now() / 1000);
     return currentToken.expiry > nowInSeconds + 30;
+  }
+
+  /**
+   * Issue #1781: Check whether a disk token differs from the scheduled snapshot
+   * or has a valid expiry, indicating another process already refreshed it.
+   * Used by acquireAndRefresh when the lock times out.
+   */
+  private isTokenRefreshed(key: string, diskToken: OAuthToken): boolean {
+    return this.hasTokenBeenRefreshedExternally(key, diskToken);
   }
 
   async configureProactiveRenewalsForProfile(profile: unknown): Promise<void> {


### PR DESCRIPTION
## Summary

When two llxprt-code instances share the same unbucketed OAuth profile, their proactive renewal timers can fire near-simultaneously. Because Anthropic refresh tokens are single-use, the second process attempts to refresh with an already-consumed refresh token, causing Anthropic to revoke the entire session.

## Root Cause

The `acquireAndRefresh()` method in `ProactiveRenewalManager` handled lock timeout by blindly scheduling a retry (`scheduleProactiveRetry`) without checking whether another process had already refreshed the token. This meant:
1. Process A acquires the lock and refreshes successfully
2. Process B's lock acquisition times out
3. Process B retries later, but its scheduled snapshot still has the old (now-consumed) refresh_token
4. Process B eventually refreshes with the stale refresh_token → Anthropic revokes the session

## Changes

### `packages/cli/src/auth/proactive-renewal-manager.ts`
- Modified `acquireAndRefresh()` to read the token from disk when `acquireRefreshLock` returns `false` (timeout)
- Added `isTokenRefreshed()` helper that delegates to `hasTokenBeenRefreshedExternally()` to compare the disk token against the scheduled snapshot (access_token and refresh_token)
- If externally refreshed: deletes stale timer entry and calls `scheduleProactiveRenewal()` with the new token (resets failure counter, schedules based on new expiry)
- If unchanged: falls through to existing `scheduleProactiveRetry()` (increments failure counter, exponential backoff)

### `packages/cli/src/auth/__tests__/proactive-renewal-cross-process.spec.ts`
Added 4 new test cases:
1. **CR-03 (external refresh)**: Lock timeout + token refreshed by another process → reschedules based on new token, no refresh attempted
2. **CR-03 (unchanged token)**: Lock timeout + token unchanged on disk → schedules retry with backoff, eventually refreshes on retry
3. **CR-04 (proactive renewal)**: Token with no refresh_token → skips refresh, clears state
4. **CR-04 (executeTokenRefresh)**: Disk token with no refresh_token → returns null, no refresh attempted

## Acceptance Criteria

- [x] File-based refresh lock prevents concurrent refresh across processes (pre-existing)
- [x] After acquiring lock, refresh_token compared to scheduled; if different, skip (pre-existing)
- [x] **Non-refreshing process reads updated token from disk and uses it** (new in this PR)
- [x] Proactive renewal jitter sufficient to stagger multi-process timers (pre-existing 0-30s jitter)

Fixes #1781