### PR TITLE
fix(anthropic): use getAuthTokenForPrompt in buildProviderClient for OAuth support (Fixes #1813)

### DIFF
--- a/packages/core/src/providers/anthropic/AnthropicProvider.stateless.test.ts
+++ b/packages/core/src/providers/anthropic/AnthropicProvider.stateless.test.ts
@@ -148,6 +148,26 @@ class TestAnthropicProvider extends AnthropicProvider {
   protected override async getAuthToken(): Promise<string> {
     return this.nextAuthToken;
   }
+
+  protected override async getAuthTokenForPrompt(): Promise<string> {
+    return this.nextAuthToken;
+  }
+}
+
+class TestAnthropicProviderOAuth extends AnthropicProvider {
+  constructor() {
+    super(undefined, 'https://api.anthropic.com', {
+      getEphemeralSettings: () => ({ streaming: 'disabled' }),
+    });
+  }
+
+  protected override async getAuthToken(): Promise<string> {
+    return '';
+  }
+
+  protected override async getAuthTokenForPrompt(): Promise<string> {
+    return 'oauth-token-resolved';
+  }
 }
 
 const createSettings = (runtimeId: string): SettingsService => {
@@ -332,5 +352,31 @@ describe('Anthropic provider stateless contract tests', () => {
       temperature: 0.3,
     });
     expect(getEphemerals).not.toHaveBeenCalled();
+  });
+
+  it('uses OAuth token from getAuthTokenForPrompt in fallback path when no resolved token is provided', async () => {
+    const provider = new TestAnthropicProviderOAuth();
+    const baselineInstances = FakeAnthropicClass.created.length;
+    const settings = createSettings('runtime-oauth');
+    const config = createRuntimeConfigStub(settings);
+    const runtime = createProviderRuntimeContext({
+      runtimeId: 'runtime-oauth',
+      settingsService: settings,
+      config,
+    });
+
+    await provider
+      .generateChatCompletion(
+        buildCallOptions(provider, {
+          settings,
+          runtime,
+          config,
+        }),
+      )
+      .next();
+
+    const created = FakeAnthropicClass.created.slice(baselineInstances);
+    expect(created).toHaveLength(1);
+    expect(created[0].options.apiKey).toBe('oauth-token-resolved');
   });
 });

--- a/packages/core/src/providers/anthropic/AnthropicProvider.ts
+++ b/packages/core/src/providers/anthropic/AnthropicProvider.ts
@@ -180,7 +180,7 @@ export class AnthropicProvider extends BaseProvider {
     }
 
     if (!authToken) {
-      authToken = await this.getAuthToken();
+      authToken = await this.getAuthTokenForPrompt();
     }
 
     if (!authToken) {


### PR DESCRIPTION
## TLDR

AnthropicProvider.buildProviderClient() was calling getAuthToken() (includeOAuth: false) instead of getAuthTokenForPrompt() (includeOAuth: true), which prevented OAuth token resolution when using Anthropic with OAuth authentication and no API key configured. This one-line fix aligns AnthropicProvider with the pattern already used by OpenAIResponsesProvider.

## Dive Deeper

The authentication system in BaseProvider uses a two-method pattern:
- **getAuthToken()**: For config-time checks, calls resolveAuthentication({ includeOAuth: false })
- **getAuthTokenForPrompt()**: For actual API calls, calls resolveAuthentication({ includeOAuth: true })

buildProviderClient() is called during prompt sends (from generateChatCompletionWithOptions), so it should use the OAuth-enabled method. The fallback path at line 183 (when no runtime token is provided via options.resolved.authToken) was incorrectly using getAuthToken(), skipping OAuth entirely.

This fix covers all Anthropic prompt-send paths: interactive mode, --provider anthropic CLI flag, and non-interactive mode, since they all flow through buildProviderClient().

getModels() correctly continues using getAuthToken() since it is a config-time operation that should not trigger OAuth flows.

### Changes

1. **AnthropicProvider.ts** (line 183): Changed getAuthToken() to getAuthTokenForPrompt() in the buildProviderClient fallback path
2. **AnthropicProvider.stateless.test.ts**: Added behavioral test with TestAnthropicProviderOAuth subclass that verifies the OAuth token from getAuthTokenForPrompt is used when no resolved auth token is provided

## Reviewer Test Plan

1. Pull the branch and run the Anthropic stateless tests:
   - npx vitest run packages/core/src/providers/anthropic/AnthropicProvider.stateless.test.ts
   - Verify the new test "uses OAuth token from getAuthTokenForPrompt in fallback path" passes
2. Run the full Anthropic test suite:
   - npx vitest run packages/core/src/providers/anthropic/
   - All 219 tests should pass
3. To validate the actual OAuth flow end-to-end (requires OAuth-enabled environment):
   - Ensure no ANTHROPIC_API_KEY env var is set
   - Start llxprt-code
   - Run: /provider anthropic
   - Run: /auth anthropic enable
   - Run: /auth anthropic login (complete OAuth flow)
   - Send a message - should succeed instead of throwing auth error

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #1813