### PR TITLE
fix(ci): resolve ESLint OOM and invalid gh flag in release workflow (Fixes #1825)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -579,6 +579,6 @@ jobs:
           gh issue create \
             --title "Release Failed for ${{ steps.version.outputs.RELEASE_TAG || 'N/A' }} on $(date +'%Y-%m-%d')" \
             --body "The release workflow failed. See the full run for details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            --type "Bug"
+            --label "ci/cd"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/preflight-ci.js
+++ b/scripts/preflight-ci.js
@@ -39,7 +39,14 @@ try {
 
 // Continue with the rest of preflight
 run('npm run format');
+
+// Increase heap size for ESLint - matches CI workflow's NODE_OPTIONS setting
+// Without this, ESLint OOMs on the full codebase (~4GB usage)
+const prevNodeOptions = process.env.NODE_OPTIONS || '';
+process.env.NODE_OPTIONS =
+  `${prevNodeOptions} --max-old-space-size=8192`.trim();
 run('npm run lint:ci');
+process.env.NODE_OPTIONS = prevNodeOptions;
 run('npm run build');
 run('npm run typecheck');
 run('npm run test:ci');


### PR DESCRIPTION
## TLDR

The release workflow fails with two issues: ESLint runs out of memory during preflight checks, and the failure-notification step uses an invalid `gh` CLI flag (`--type`) so no issue gets created when the release fails.

This PR fixes both by increasing the Node.js heap size for ESLint in `preflight-ci.js` and replacing the invalid `--type "Bug"` with `--label "ci/cd"` in the workflow.

## Dive Deeper

**ESLint OOM:** The `npm run lint:ci` step in `scripts/preflight-ci.js` was crashing with `FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory` after consuming ~4GB of RAM. The `ci.yml` workflow already handles this by setting `NODE_OPTIONS: '--max-old-space-size=8192'` on its lint step, but the release workflow runs lint through `preflight-ci.js` which didn't set this. The fix sets `NODE_OPTIONS` in the script before running lint, then restores the previous value afterward.

**Invalid gh flag:** The `Create Issue on Failure` step used `--type "Bug"` which doesn't exist in the `gh issue create` CLI. This was a silent secondary failure — when the release failed, it couldn't even notify the team. Replaced with `--label "ci/cd"` which matches the project's existing label set.

See the failing run: https://github.com/vybestack/llxprt-code/actions/runs/23698228044/job/69037165914

## Reviewer Test Plan

1. Review the diff in `scripts/preflight-ci.js` — the NODE_OPTIONS is set/restored around the lint step only
2. Review the diff in `.github/workflows/release.yml` — `--type "Bug"` replaced with `--label "ci/cd"`
3. Verify CI passes (the lint step in CI already uses the same heap size setting)
4. For full validation, trigger a dry-run release workflow dispatch

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #1825