### PR TITLE
Remove stale UI version bump from release script (Fixes #1834)

### DIFF
--- a/scripts/version.js
+++ b/scripts/version.js
@@ -90,23 +90,7 @@ if (cliPackageJson.config?.sandboxImageUri) {
   writeJson(cliPackageJsonPath, cliPackageJson);
 }
 
-// 6. Bump the version in the UI package (not an npm workspace).
-const uiPackageJsonPath = resolve(process.cwd(), 'packages/ui/package.json');
-try {
-  const uiPackageJson = readJson(uiPackageJsonPath);
-  uiPackageJson.version = newVersion;
-  if (uiPackageJson.peerDependencies?.['@vybestack/llxprt-code-core']) {
-    uiPackageJson.peerDependencies['@vybestack/llxprt-code-core'] =
-      `^${newVersion}`;
-  }
-  console.log(`Updated ui package to version ${newVersion}`);
-  writeJson(uiPackageJsonPath, uiPackageJson);
-} catch (err) {
-  console.error('Error updating ui package version:', err);
-  process.exit(1);
-}
-
-// 7. Run `npm install` to update package-lock.json.
+// 6. Run `npm install` to update package-lock.json.
 run('npm install');
 
 console.log(`Successfully bumped versions to v${newVersion}.`);


### PR DESCRIPTION
## Summary
- remove the obsolete packages/ui version bump block from scripts/version.js
- keep release:version focused on existing workspaces and existing package manifests
- prevent release failure in Update package versions after OpenTUI UI package removal

## Root cause
The release workflow failed at npm run release:version because scripts/version.js still attempted to open packages/ui/package.json and exited on ENOENT.

## Validation
- reproduced the failing command locally: npm run release:version 0.10.0-nightly.260329.b47300aab
- confirmed it now succeeds without packages/ui present
- reverted generated version-bump artifacts after validation so only scripts/version.js changed

## Scope
- no behavior changes outside release versioning script path
- no workflow changes in this PR
