### PR TITLE
fix(set-command): remove model_param alias, keep only modelparam (Fixes #1821)

### DIFF
--- a/packages/cli/src/ui/commands/setCommand.test.ts
+++ b/packages/cli/src/ui/commands/setCommand.test.ts
@@ -352,43 +352,6 @@ describe('setCommand runtime integration', () => {
     });
   });
 
-  it('handles model_param (with underscore) in unset path', async () => {
-    const result = await setCommand.action!(
-      context,
-      'unset model_param max_tokens',
-    );
-
-    expect(mockRuntime.clearActiveModelParam).toHaveBeenCalledWith(
-      'max_tokens',
-    );
-    expect(mockRuntime.setEphemeralSetting).toHaveBeenCalledWith(
-      'max_tokens',
-      undefined,
-    );
-    expect(result).toEqual({
-      type: 'message',
-      messageType: 'info',
-      content: "Model parameter 'max_tokens' cleared",
-    });
-  });
-
-  it('handles model_param (with underscore) in set path', async () => {
-    const result = await setCommand.action!(
-      context,
-      'model_param temperature 0.7',
-    );
-
-    expect(mockRuntime.setActiveModelParam).toHaveBeenCalledWith(
-      'temperature',
-      0.7,
-    );
-    expect(result).toEqual({
-      type: 'message',
-      messageType: 'info',
-      content: "Model parameter 'temperature' set to 0.7",
-    });
-  });
-
   it('surfaces error from clearActiveModelParam even when ephemeral also cleared', async () => {
     mockRuntime.clearActiveModelParam.mockImplementationOnce(() => {
       throw new Error('cannot clear');

--- a/packages/cli/src/ui/commands/setCommand.ts
+++ b/packages/cli/src/ui/commands/setCommand.ts
@@ -65,9 +65,6 @@ const toTitleCase = (input: string): string =>
     .trim()
     .replace(/\b\w/g, (char) => char.toUpperCase());
 
-const normalizeModelParamKey = (key: string): string =>
-  key === 'model_param' ? 'modelparam' : key;
-
 type SettingCompleter = NonNullable<ValueArgument['completer']>;
 type SettingLiteralSpec = {
   value: string;
@@ -185,7 +182,6 @@ const setSchema: CommandArgumentSchema = [
 
           const specialKeys = [
             'modelparam',
-            'model_param',
             'custom-headers',
             ...Array.from(directSettingKeys),
           ];
@@ -207,7 +203,7 @@ const setSchema: CommandArgumentSchema = [
             description: 'nested key for specific settings',
             hint: async (_ctx, tokens: TokenInfo) => {
               const key = tokens.tokens[1];
-              if (normalizeModelParamKey(key) === 'modelparam') {
+              if (key === 'modelparam') {
                 return 'model parameter name (e.g., temperature, max_tokens)';
               }
               if (key === 'custom-headers') {
@@ -219,7 +215,7 @@ const setSchema: CommandArgumentSchema = [
               const key = tokens.tokens[1];
               const enableFuzzy = getFuzzyEnabled(ctx);
 
-              if (normalizeModelParamKey(key) === 'modelparam') {
+              if (key === 'modelparam') {
                 const params = getRuntimeApi().getActiveModelParams();
                 const paramNames = Object.keys(params);
                 const filtered = filterStrings(paramNames, partial, {
@@ -258,13 +254,6 @@ const setSchema: CommandArgumentSchema = [
     kind: 'literal',
     value: 'modelparam',
     description: 'Model parameter option',
-    stopPropagation: true,
-    next: modelParamSchemaNext,
-  },
-  {
-    kind: 'literal',
-    value: 'model_param',
-    description: 'Model parameter option (alias)',
     stopPropagation: true,
     next: modelParamSchemaNext,
   },
@@ -389,7 +378,7 @@ export const setCommand: SlashCommand = {
     const parts = trimmedArgs.split(/\s+/);
     const key = parts[0];
 
-    if (normalizeModelParamKey(key) === 'modelparam') {
+    if (key === 'modelparam') {
       if (parts.length < 3) {
         return {
           type: 'message',
@@ -442,7 +431,7 @@ export const setCommand: SlashCommand = {
       const targetKey = parts[1];
       const subKey = parts[2];
 
-      if (normalizeModelParamKey(targetKey) === 'modelparam') {
+      if (targetKey === 'modelparam') {
         if (!subKey) {
           return {
             type: 'message',


### PR DESCRIPTION
Removes the model_param alias from the /set command, leaving only modelparam as the valid spelling.

## Changes
- Removed normalizeModelParamKey helper function
- Removed model_param from specialKeys array in unset completer
- Removed model_param literal from setSchema
- Updated all call sites to use direct key === 'modelparam' checks
- Removed test cases for model_param alias behavior

This is a breaking change with no backward compatibility shim as requested.

Closes #1821