### PR TITLE
fix(client): handle 413 errors with retry and tool name guidance (Fixes #1707)

### DIFF
--- a/packages/core/src/core/MessageStreamOrchestrator.ts
+++ b/packages/core/src/core/MessageStreamOrchestrator.ts
@@ -51,6 +51,7 @@ export interface MessageStreamDeps {
     prompt_id: string,
     turns?: number,
     isInvalidStreamRetry?: boolean,
+    is413Retry?: boolean,
   ) => AsyncGenerator<ServerGeminiStreamEvent, Turn>;
 }
 
@@ -61,6 +62,7 @@ interface StreamContext {
   signal: AbortSignal;
   turns: number;
   isInvalidStreamRetry: boolean;
+  is413Retry: boolean;
 }
 
 interface IterationResult {
@@ -90,6 +92,7 @@ export class MessageStreamOrchestrator {
     prompt_id: string,
     turns: number,
     isInvalidStreamRetry: boolean,
+    is413Retry: boolean = false,
   ): AsyncGenerator<ServerGeminiStreamEvent, Turn> {
     this.deps.logger.debug(
       () => 'DEBUG: GeminiClient.sendMessageStream called',
@@ -106,6 +109,7 @@ export class MessageStreamOrchestrator {
       signal,
       turns,
       isInvalidStreamRetry,
+      is413Retry,
     };
 
     const request = yield* this._preflight(initialRequest, ctx);
@@ -331,6 +335,7 @@ export class MessageStreamOrchestrator {
         turn,
         ctx,
         hadToolCallsThisTurn,
+        initialRequest,
       );
       if (iterResult.earlyReturn) return turn;
       hadToolCallsThisTurn = iterResult.hadToolCallsThisTurn;
@@ -358,6 +363,7 @@ export class MessageStreamOrchestrator {
     turn: Turn,
     ctx: StreamContext,
     hadToolCallsPrior: boolean,
+    initialRequest: PartListUnion,
   ): AsyncGenerator<ServerGeminiStreamEvent, IterationResult> {
     const { loopDetector, todoContinuationService, updateTelemetryTokenCount } =
       this.deps;
@@ -418,6 +424,7 @@ export class MessageStreamOrchestrator {
         ctx,
         deferredEvents,
         { hadToolCallsThisTurn, todoPauseSeen, hadThinking, hadContent },
+        initialRequest,
       );
       if (terminalResult) return terminalResult;
     }
@@ -443,11 +450,47 @@ export class MessageStreamOrchestrator {
       hadThinking: boolean;
       hadContent: boolean;
     },
+    initialRequest: PartListUnion,
   ): AsyncGenerator<ServerGeminiStreamEvent, IterationResult | undefined> {
     const { config, sendMessageStream } = this.deps;
     const boundedTurns = Math.min(ctx.turns, MAX_TURNS);
 
     if (event.type === GeminiEventType.Error) {
+      const errorStatus =
+        event.value?.error && typeof event.value.error === 'object'
+          ? (event.value.error as { status?: number }).status
+          : undefined;
+
+      if (errorStatus === 413 && config.getContinueOnFailedApiCall()) {
+        if (ctx.is413Retry) {
+          for (const d of deferredEvents) yield d;
+          await this._fireAfterHook(ctx);
+          return this._earlyIterResult(state.hadToolCallsThisTurn, {
+            ...state,
+            deferredEvents,
+          });
+        }
+        const toolNames = this._extractToolNamesFromRequest(initialRequest);
+        const toolList =
+          toolNames.length > 0
+            ? ` The tools involved were: ${toolNames.join(', ')}.`
+            : '';
+        const message = `System: The previous tool calls produced a response that was too large (HTTP 413).${toolList} Please retry with fewer or more focused queries.`;
+        yield* sendMessageStream(
+          [{ text: message }],
+          signal,
+          ctx.prompt_id,
+          boundedTurns - 1,
+          false,
+          true,
+        );
+        await this._fireAfterHook(ctx);
+        return this._earlyIterResult(state.hadToolCallsThisTurn, {
+          ...state,
+          deferredEvents,
+        });
+      }
+
       for (const d of deferredEvents) yield d;
       await this._fireAfterHook(ctx);
       return this._earlyIterResult(state.hadToolCallsThisTurn, {
@@ -482,6 +525,25 @@ export class MessageStreamOrchestrator {
     }
 
     return undefined;
+  }
+
+  private _extractToolNamesFromRequest(request: PartListUnion): string[] {
+    if (!Array.isArray(request)) return [];
+    const names = new Set<string>();
+    for (const part of request) {
+      if (
+        typeof part === 'object' &&
+        part !== null &&
+        'functionResponse' in part
+      ) {
+        const funcResp = (part as { functionResponse: { name?: string } })
+          .functionResponse;
+        if (funcResp?.name) {
+          names.add(funcResp.name);
+        }
+      }
+    }
+    return [...names];
   }
 
   private _earlyIterResult(

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -1693,6 +1693,173 @@ sub memory
       expect(mockTurnRunFn).toHaveBeenCalledTimes(2);
     });
 
+    it('should retry with tool-name message when 413 error is received', async () => {
+      vi.spyOn(client['config'], 'getContinueOnFailedApiCall').mockReturnValue(
+        true,
+      );
+      // Arrange: first stream yields a 413 error, second yields content
+      const mockStream1 = (async function* () {
+        yield {
+          type: GeminiEventType.Error,
+          value: {
+            error: { message: 'Payload too large', status: 413 },
+          },
+        };
+      })();
+      const mockStream2 = (async function* () {
+        yield { type: GeminiEventType.Content, value: 'Retried content' };
+      })();
+
+      mockTurnRunFn
+        .mockReturnValueOnce(mockStream1)
+        .mockReturnValueOnce(mockStream2);
+
+      const mockChat: Partial<GeminiChat> = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+        getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+      };
+      client['chat'] = mockChat as GeminiChat;
+
+      // Include functionResponse parts to test tool name extraction
+      const initialRequest = [
+        { text: 'Hi' },
+        {
+          functionResponse: {
+            name: 'read_file',
+            response: { content: 'large content...' },
+          },
+        },
+        {
+          functionResponse: {
+            name: 'search_file',
+            response: { content: 'more large content...' },
+          },
+        },
+      ];
+      const promptId = 'prompt-id-413-retry';
+      const signal = new AbortController().signal;
+
+      // Act
+      const stream = client.sendMessageStream(initialRequest, signal, promptId);
+      const events = await fromAsync(stream);
+
+      // Assert: both the error event and the retried content should appear
+      expect(events).toEqual([
+        {
+          type: GeminiEventType.Error,
+          value: {
+            error: { message: 'Payload too large', status: 413 },
+          },
+        },
+        { type: GeminiEventType.Content, value: 'Retried content' },
+      ]);
+
+      // turn.run should be called twice
+      expect(mockTurnRunFn).toHaveBeenCalledTimes(2);
+
+      // Second call should include the 413 system message with tool names
+      expect(mockTurnRunFn).toHaveBeenNthCalledWith(
+        2,
+        [
+          {
+            text: 'System: The previous tool calls produced a response that was too large (HTTP 413). The tools involved were: read_file, search_file. Please retry with fewer or more focused queries.',
+          },
+        ],
+        expect.any(Object),
+      );
+    });
+
+    it('should not retry on 413 when getContinueOnFailedApiCall returns false', async () => {
+      vi.spyOn(client['config'], 'getContinueOnFailedApiCall').mockReturnValue(
+        false,
+      );
+      // Arrange
+      const mockStream1 = (async function* () {
+        yield {
+          type: GeminiEventType.Error,
+          value: {
+            error: { message: 'Payload too large', status: 413 },
+          },
+        };
+      })();
+
+      mockTurnRunFn.mockReturnValueOnce(mockStream1);
+
+      const mockChat: Partial<GeminiChat> = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+        getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+      };
+      client['chat'] = mockChat as GeminiChat;
+
+      const initialRequest = [{ text: 'Hi' }];
+      const promptId = 'prompt-id-413-no-retry';
+      const signal = new AbortController().signal;
+
+      // Act
+      const stream = client.sendMessageStream(initialRequest, signal, promptId);
+      const events = await fromAsync(stream);
+
+      // Assert: only the error event, no retry
+      expect(events).toEqual([
+        {
+          type: GeminiEventType.Error,
+          value: {
+            error: { message: 'Payload too large', status: 413 },
+          },
+        },
+      ]);
+
+      // turn.run should be called only once
+      expect(mockTurnRunFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('should stop recursing after one retry when 413 errors are repeatedly received', async () => {
+      vi.spyOn(client['config'], 'getContinueOnFailedApiCall').mockReturnValue(
+        true,
+      );
+      // Arrange: always return a 413 error
+      mockTurnRunFn.mockImplementation(() =>
+        (async function* () {
+          yield {
+            type: GeminiEventType.Error,
+            value: {
+              error: { message: 'Payload too large', status: 413 },
+            },
+          };
+        })(),
+      );
+
+      const mockChat: Partial<GeminiChat> = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+        getLastPromptTokenCount: vi.fn().mockReturnValue(0),
+      };
+      client['chat'] = mockChat as GeminiChat;
+
+      const initialRequest = [{ text: 'Hi' }];
+      const promptId = 'prompt-id-413-infinite';
+      const signal = new AbortController().signal;
+
+      // Act
+      const stream = client.sendMessageStream(initialRequest, signal, promptId);
+      const events = await fromAsync(stream);
+
+      // Assert: exactly 2 Error events (original + 1 retry), no infinite loop
+      expect(events.length).toBe(2);
+      expect(
+        events.every(
+          (e) =>
+            e.type === GeminiEventType.Error &&
+            (e.value as { error: { status?: number } }).error?.status === 413,
+        ),
+      ).toBe(true);
+
+      // turn.run should be called exactly twice
+      expect(mockTurnRunFn).toHaveBeenCalledTimes(2);
+    });
+
     it('should auto-continue when model generates thinking-only output', async () => {
       const forwardedRequests: Part[][] = [];
       let callCount = 0;

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -214,8 +214,8 @@ export class GeminiClient {
         this.currentSequenceModel = null;
       },
       updateTelemetryTokenCount: () => this.updateTelemetryTokenCount(),
-      sendMessageStream: (req, sig, pid, trns, isRetry) =>
-        this.sendMessageStream(req, sig, pid, trns, isRetry),
+      sendMessageStream: (req, sig, pid, trns, isRetry, is413) =>
+        this.sendMessageStream(req, sig, pid, trns, isRetry, is413),
     };
   }
 
@@ -673,6 +673,7 @@ export class GeminiClient {
     prompt_id: string,
     turns: number = this.MAX_TURNS,
     isInvalidStreamRetry: boolean = false,
+    is413Retry: boolean = false,
   ): AsyncGenerator<ServerGeminiStreamEvent, Turn> {
     return yield* this.messageStreamOrchestrator.execute(
       initialRequest,
@@ -680,6 +681,7 @@ export class GeminiClient {
       prompt_id,
       turns,
       isInvalidStreamRetry,
+      is413Retry,
     );
   }
 


### PR DESCRIPTION
## Summary

When the API returns HTTP 413 (payload too large), the system now detects the error and retries with a descriptive system message telling the model which tool calls produced oversized responses and instructing it to retry with fewer or more focused queries.

Fixes #1707

## Problem

GPT-5.4 (and other models) could throw a 413 error when tool call responses were too large, causing the system to stop entirely. The model had no guidance on how to recover.

## Solution

Follows the existing `InvalidStream` retry pattern in `MessageStreamOrchestrator`:

- **413 detection**: In `_handleTerminalEvent`, checks for `GeminiEventType.Error` with `status === 413`
- **Tool name extraction**: New helper `_extractToolNamesFromRequest()` extracts `functionResponse.name` values from the request parts so the model knows which tools produced oversized responses
- **Descriptive retry message**: Sends a system message like "The previous tool calls produced a response that was too large (HTTP 413). The tools involved were: read_file, search_file. Please retry with fewer or more focused queries."
- **Recursion guard**: `is413Retry` flag on `StreamContext` prevents infinite retry loops (max one retry)
- **Config gating**: Retries only occur when `getContinueOnFailedApiCall()` returns true (same gate as InvalidStream retry)

## Files Changed

- `packages/core/src/core/MessageStreamOrchestrator.ts` - Core 413 retry logic, tool name extraction helper, recursion guard
- `packages/core/src/core/client.ts` - `is413Retry` parameter threading through sendMessageStream
- `packages/core/src/core/client.test.ts` - Three new tests

## Tests Added

1. **Happy path**: 413 error triggers retry with correct system message including extracted tool names
2. **Config flag off**: No retry when `getContinueOnFailedApiCall()` returns false
3. **Infinite recursion prevention**: Consecutive 413 errors result in exactly 2 events (original + 1 retry), then stop

## Verification

- All 70 tests pass (including 3 new)
- Lint: 0 errors
- Typecheck: clean
- Build: clean
- Smoke test: passes