### PR TITLE
fix(cli): llxprt --version prints nothing (Fixes #1849)

### DIFF
--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -29,6 +29,7 @@ import {
 import { dynamicSettingsRegistry } from './utils/dynamicSettings.js';
 import { shouldRelaunchForMemory, isDebugMode } from './utils/bootstrap.js';
 import { relaunchAppInChildProcess } from './utils/relaunch.js';
+import { getCliVersion } from './utils/version.js';
 
 // Custom error to identify mock process.exit calls
 class MockProcessExitError extends Error {
@@ -267,6 +268,58 @@ describe('gemini.tsx main function', () => {
     }
 
     expect(parseArgumentsMock).toHaveBeenCalledWith({});
+    expect(loadSettingsMock).not.toHaveBeenCalled();
+  });
+
+  it('should print version and exit when --version is passed', async () => {
+    const originalArgv = process.argv;
+    process.argv = ['node', 'llxprt', '--version'];
+
+    const getCliVersionMock = vi.mocked(getCliVersion);
+    getCliVersionMock.mockResolvedValue('1.2.3');
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new MockProcessExitError(code);
+    });
+
+    mockWriteToStdout.mockClear();
+
+    try {
+      await expect(main()).rejects.toThrow(MockProcessExitError);
+      expect(mockWriteToStdout).toHaveBeenCalledWith(`1.2.3
+`);
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    } finally {
+      process.argv = originalArgv;
+      exitSpy.mockRestore();
+    }
+
+    expect(loadSettingsMock).not.toHaveBeenCalled();
+  });
+
+  it('should print version and exit when -v is passed', async () => {
+    const originalArgv = process.argv;
+    process.argv = ['node', 'llxprt', '-v'];
+
+    const getCliVersionMock = vi.mocked(getCliVersion);
+    getCliVersionMock.mockResolvedValue('1.2.3');
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new MockProcessExitError(code);
+    });
+
+    mockWriteToStdout.mockClear();
+
+    try {
+      await expect(main()).rejects.toThrow(MockProcessExitError);
+      expect(mockWriteToStdout).toHaveBeenCalledWith(`1.2.3
+`);
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    } finally {
+      process.argv = originalArgv;
+      exitSpy.mockRestore();
+    }
+
     expect(loadSettingsMock).not.toHaveBeenCalled();
   });
 

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -348,7 +348,8 @@ export async function main() {
   // but no listeners are registered yet, so yargs output would be lost.
   const rawArgs = process.argv.slice(2);
   if (rawArgs.includes('--version') || rawArgs.includes('-v')) {
-    debugLogger.log(await getCliVersion());
+    writeToStdout(`${await getCliVersion()}
+`);
     process.exit(0);
   }
   if (rawArgs.includes('--help') || rawArgs.includes('-h')) {


### PR DESCRIPTION
## Summary

Fixes #1849 - Running `llxprt --version` (or `-v`) exits cleanly but prints nothing to stdout. The version string should be printed.

## Fix

The `--version` handler in `gemini.tsx` was calling `debugLogger.log()` which only outputs when debug mode is enabled. Replaced it with `writeToStdout()` so the version always prints.

## Changes

- **packages/cli/src/gemini.tsx** - Use `writeToStdout()` instead of `debugLogger.log()` in the `--version` handler
- **packages/cli/src/gemini.test.tsx** - Added unit tests for `--version` and `-v` flags

## Verification

- `node scripts/start.js --version` now outputs `0.10.0`
- `node scripts/start.js -v` now outputs `0.10.0`
- All unit tests pass
- Typecheck, lint, build, and smoke test all pass