### PR TITLE
fix(ui): context-limit not applied on first profile load (Fixes #1842)

### DIFF
--- a/packages/cli/src/ui/AppContainerRuntime.tsx
+++ b/packages/cli/src/ui/AppContainerRuntime.tsx
@@ -233,6 +233,7 @@ function buildUIStateParamsCore(r: HookResults) {
       : d.providerOptions,
     selectedProvider: d.selectedProvider,
     currentModel: d.currentModel,
+    contextLimit: d.contextLimit,
     profiles: d.profiles,
     toolsDialogAction: d.toolsDialogAction,
     toolsDialogTools: d.toolsDialogTools,

--- a/packages/cli/src/ui/containers/AppContainer/builders/buildUIState.test.ts
+++ b/packages/cli/src/ui/containers/AppContainer/builders/buildUIState.test.ts
@@ -58,6 +58,7 @@ const makeParams = (): UIStateParams => ({
   providerOptions: [],
   selectedProvider: '',
   currentModel: '',
+  contextLimit: undefined,
   profiles: [],
   toolsDialogAction: 'enable',
   toolsDialogTools: [],

--- a/packages/cli/src/ui/containers/AppContainer/builders/buildUIState.ts
+++ b/packages/cli/src/ui/containers/AppContainer/builders/buildUIState.ts
@@ -86,6 +86,7 @@ export interface UIStateParams {
   providerOptions: string[];
   selectedProvider: string;
   currentModel: string;
+  contextLimit: number | undefined;
   profiles: string[];
   toolsDialogAction: 'enable' | 'disable';
   toolsDialogTools: AnyDeclarativeTool[];
@@ -287,6 +288,7 @@ function buildDialogData(p: UIStateParams) {
     providerOptions: p.providerOptions,
     selectedProvider: p.selectedProvider,
     currentModel: p.currentModel,
+    contextLimit: p.contextLimit,
     profiles: p.profiles,
     toolsDialogAction: p.toolsDialogAction,
     toolsDialogTools: p.toolsDialogTools,

--- a/packages/cli/src/ui/containers/AppContainer/hooks/useAppDialogs.ts
+++ b/packages/cli/src/ui/containers/AppContainer/hooks/useAppDialogs.ts
@@ -134,6 +134,9 @@ function useDialogsCore(
 ) {
   const { config, settings, addItem, consoleMessages } = p;
   const { currentModel, setCurrentModel } = useModelTracking({ config });
+  const [contextLimit, setContextLimit] = useState<number | undefined>(
+    () => config.getEphemeralSetting('context-limit') as number | undefined,
+  );
   const displayPrefs = useDisplayPreferences();
   const orchestration = useDialogOrchestration();
   const workspace = useWorkspaceMigration(settings);
@@ -157,6 +160,8 @@ function useDialogsCore(
   return {
     currentModel,
     setCurrentModel,
+    contextLimit,
+    setContextLimit,
     ...displayPrefs,
     ...orchestration,
     ...workspace,
@@ -187,6 +192,8 @@ function useDialogsAuthProviders(
   st: ReturnType<typeof useDialogsState>,
   currentModel: string,
   setCurrentModel: (model: string) => void,
+  contextLimit: number | undefined,
+  setContextLimit: (limit: number | undefined) => void,
   setShowErrorDetails: (value: boolean) => void,
 ) {
   const {
@@ -215,6 +222,8 @@ function useDialogsAuthProviders(
     currentModel,
     setCurrentModel,
     getActiveModelName: runtime.getActiveModelName,
+    contextLimit,
+    setContextLimit,
   });
   useAppEventHandlers({
     handleNewMessage,
@@ -244,6 +253,8 @@ function useDialogsAuth(
   st: ReturnType<typeof useDialogsState>,
   currentModel: string,
   setCurrentModel: (model: string) => void,
+  contextLimit: number | undefined,
+  setContextLimit: (limit: number | undefined) => void,
   setShowErrorDetails: (value: boolean) => void,
 ) {
   const { config, settings, appState, addItem } = p;
@@ -261,6 +272,8 @@ function useDialogsAuth(
     st,
     currentModel,
     setCurrentModel,
+    contextLimit,
+    setContextLimit,
     setShowErrorDetails,
   );
   return {
@@ -371,6 +384,8 @@ export function useAppDialogs(params: AppDialogsParams) {
     st,
     core.currentModel,
     core.setCurrentModel,
+    core.contextLimit,
+    core.setContextLimit,
     core.setShowErrorDetails,
   );
   const profiles = useDialogsProfiles(params);

--- a/packages/cli/src/ui/containers/AppContainer/hooks/useModelRuntimeSync.test.ts
+++ b/packages/cli/src/ui/containers/AppContainer/hooks/useModelRuntimeSync.test.ts
@@ -20,10 +20,15 @@ describe('useModelRuntimeSync', () => {
 
   it('uses provider model when runtime model is non-empty and updates current model', () => {
     const setCurrentModel = vi.fn();
+    const setContextLimit = vi.fn();
     const getActiveModelName = vi.fn().mockReturnValue('provider-model');
     const config = {
       getModel: vi.fn().mockReturnValue('config-model'),
-    } as unknown as { getModel: () => string };
+      getEphemeralSetting: vi.fn().mockReturnValue(undefined),
+    } as unknown as {
+      getModel: () => string;
+      getEphemeralSetting: (key: string) => number | undefined;
+    };
 
     renderHook(() =>
       useModelRuntimeSync({
@@ -31,6 +36,8 @@ describe('useModelRuntimeSync', () => {
         currentModel: 'stale-model',
         setCurrentModel,
         getActiveModelName,
+        contextLimit: undefined,
+        setContextLimit,
       }),
     );
 
@@ -39,10 +46,15 @@ describe('useModelRuntimeSync', () => {
 
   it('falls back to config model when runtime model is blank', () => {
     const setCurrentModel = vi.fn();
+    const setContextLimit = vi.fn();
     const getActiveModelName = vi.fn().mockReturnValue('   ');
     const config = {
       getModel: vi.fn().mockReturnValue('config-model'),
-    } as unknown as { getModel: () => string };
+      getEphemeralSetting: vi.fn().mockReturnValue(undefined),
+    } as unknown as {
+      getModel: () => string;
+      getEphemeralSetting: (key: string) => number | undefined;
+    };
 
     renderHook(() =>
       useModelRuntimeSync({
@@ -50,6 +62,8 @@ describe('useModelRuntimeSync', () => {
         currentModel: 'old-model',
         setCurrentModel,
         getActiveModelName,
+        contextLimit: undefined,
+        setContextLimit,
       }),
     );
 
@@ -58,10 +72,15 @@ describe('useModelRuntimeSync', () => {
 
   it('does not update state when effective model already matches current model', () => {
     const setCurrentModel = vi.fn();
+    const setContextLimit = vi.fn();
     const getActiveModelName = vi.fn().mockReturnValue('provider-model');
     const config = {
       getModel: vi.fn().mockReturnValue('config-model'),
-    } as unknown as { getModel: () => string };
+      getEphemeralSetting: vi.fn().mockReturnValue(undefined),
+    } as unknown as {
+      getModel: () => string;
+      getEphemeralSetting: (key: string) => number | undefined;
+    };
 
     renderHook(() =>
       useModelRuntimeSync({
@@ -69,6 +88,8 @@ describe('useModelRuntimeSync', () => {
         currentModel: 'provider-model',
         setCurrentModel,
         getActiveModelName,
+        contextLimit: undefined,
+        setContextLimit,
       }),
     );
 
@@ -77,6 +98,7 @@ describe('useModelRuntimeSync', () => {
 
   it('polls every 500ms and clears interval on unmount', () => {
     const setCurrentModel = vi.fn();
+    const setContextLimit = vi.fn();
     const getActiveModelName = vi
       .fn()
       .mockReturnValueOnce('provider-a')
@@ -84,7 +106,11 @@ describe('useModelRuntimeSync', () => {
       .mockReturnValueOnce('provider-c');
     const config = {
       getModel: vi.fn().mockReturnValue('config-model'),
-    } as unknown as { getModel: () => string };
+      getEphemeralSetting: vi.fn().mockReturnValue(undefined),
+    } as unknown as {
+      getModel: () => string;
+      getEphemeralSetting: (key: string) => number | undefined;
+    };
 
     const { unmount } = renderHook(() =>
       useModelRuntimeSync({
@@ -92,6 +118,8 @@ describe('useModelRuntimeSync', () => {
         currentModel: 'none',
         setCurrentModel,
         getActiveModelName,
+        contextLimit: undefined,
+        setContextLimit,
       }),
     );
 
@@ -106,5 +134,109 @@ describe('useModelRuntimeSync', () => {
     vi.advanceTimersByTime(2000);
 
     expect(setCurrentModel).toHaveBeenCalledTimes(callsAfterUnmount);
+  });
+
+  describe('contextLimit tracking', () => {
+    it('detects contextLimit changes and calls setContextLimit', () => {
+      const setCurrentModel = vi.fn();
+      const setContextLimit = vi.fn();
+      const getActiveModelName = vi.fn().mockReturnValue('same-model');
+      const config = {
+        getModel: vi.fn().mockReturnValue('same-model'),
+        getEphemeralSetting: vi
+          .fn()
+          .mockReturnValueOnce(undefined)
+          .mockReturnValueOnce(200000),
+      } as unknown as {
+        getModel: () => string;
+        getEphemeralSetting: (key: string) => number | undefined;
+      };
+
+      renderHook(() =>
+        useModelRuntimeSync({
+          config: config as never,
+          currentModel: 'same-model',
+          setCurrentModel,
+          getActiveModelName,
+          contextLimit: undefined,
+          setContextLimit,
+        }),
+      );
+
+      expect(setContextLimit).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(500);
+
+      expect(setContextLimit).toHaveBeenCalledWith(200000);
+    });
+
+    it('does not call setContextLimit when contextLimit has not changed', () => {
+      const setCurrentModel = vi.fn();
+      const setContextLimit = vi.fn();
+      const getActiveModelName = vi.fn().mockReturnValue('same-model');
+      const config = {
+        getModel: vi.fn().mockReturnValue('same-model'),
+        getEphemeralSetting: vi.fn().mockReturnValue(200000),
+      } as unknown as {
+        getModel: () => string;
+        getEphemeralSetting: (key: string) => number | undefined;
+      };
+
+      renderHook(() =>
+        useModelRuntimeSync({
+          config: config as never,
+          currentModel: 'same-model',
+          setCurrentModel,
+          getActiveModelName,
+          contextLimit: 200000,
+          setContextLimit,
+        }),
+      );
+
+      expect(setContextLimit).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(500);
+      vi.advanceTimersByTime(500);
+
+      expect(setContextLimit).not.toHaveBeenCalled();
+    });
+
+    it('detects both model and contextLimit changes simultaneously', () => {
+      const setCurrentModel = vi.fn();
+      const setContextLimit = vi.fn();
+      const getActiveModelName = vi
+        .fn()
+        .mockReturnValueOnce('old-model')
+        .mockReturnValueOnce('new-model');
+      const config = {
+        getModel: vi.fn().mockReturnValue('old-model'),
+        getEphemeralSetting: vi
+          .fn()
+          .mockReturnValueOnce(undefined)
+          .mockReturnValueOnce(200000),
+      } as unknown as {
+        getModel: () => string;
+        getEphemeralSetting: (key: string) => number | undefined;
+      };
+
+      renderHook(() =>
+        useModelRuntimeSync({
+          config: config as never,
+          currentModel: 'old-model',
+          setCurrentModel,
+          getActiveModelName,
+          contextLimit: undefined,
+          setContextLimit,
+        }),
+      );
+
+      expect(setCurrentModel).not.toHaveBeenCalled();
+      expect(setContextLimit).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(500);
+
+      expect(setCurrentModel).toHaveBeenCalledWith('new-model');
+      expect(setContextLimit).toHaveBeenCalledWith(200000);
+    });
   });
 });

--- a/packages/cli/src/ui/containers/AppContainer/hooks/useModelRuntimeSync.ts
+++ b/packages/cli/src/ui/containers/AppContainer/hooks/useModelRuntimeSync.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { debugLogger, type Config } from '@vybestack/llxprt-code-core';
 
 interface UseModelRuntimeSyncParams {
@@ -12,22 +12,21 @@ interface UseModelRuntimeSyncParams {
   currentModel: string;
   setCurrentModel: (model: string) => void;
   getActiveModelName: () => string | undefined;
+  contextLimit?: number;
+  setContextLimit: (limit: number | undefined) => void;
 }
 
-/**
- * @hook useModelRuntimeSync
- * @description Syncs UI model label with provider/runtime effective model
- * @inputs config, currentModel, setCurrentModel, getActiveModelName
- * @outputs void
- * @sideEffects 500ms polling interval while mounted
- * @cleanup Clears interval on unmount
- */
 export function useModelRuntimeSync({
   config,
   currentModel,
   setCurrentModel,
   getActiveModelName,
+  contextLimit,
+  setContextLimit,
 }: UseModelRuntimeSyncParams): void {
+  const contextLimitRef = useRef(contextLimit);
+  contextLimitRef.current = contextLimit;
+
   useEffect(() => {
     const checkModelChange = () => {
       const configModel = config.getModel();
@@ -41,11 +40,24 @@ export function useModelRuntimeSync({
         );
         setCurrentModel(effectiveModel);
       }
+
+      const currentContextLimit = config.getEphemeralSetting(
+        'context-limit',
+      ) as number | undefined;
+      if (currentContextLimit !== contextLimitRef.current) {
+        setContextLimit(currentContextLimit);
+      }
     };
 
     checkModelChange();
     const interval = setInterval(checkModelChange, 500);
 
     return () => clearInterval(interval);
-  }, [config, currentModel, getActiveModelName, setCurrentModel]);
+  }, [
+    config,
+    currentModel,
+    getActiveModelName,
+    setCurrentModel,
+    setContextLimit,
+  ]);
 }

--- a/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -86,6 +86,7 @@ export interface UIState {
   providerOptions: string[];
   selectedProvider: string;
   currentModel: string;
+  contextLimit: number | undefined;
   profiles: string[];
   toolsDialogAction: 'enable' | 'disable';
   toolsDialogTools: AnyDeclarativeTool[];

--- a/packages/cli/src/ui/layouts/DefaultAppLayout.tsx
+++ b/packages/cli/src/ui/layouts/DefaultAppLayout.tsx
@@ -156,6 +156,7 @@ export const DefaultAppLayout = ({
     vimMode,
     tokenMetrics,
     currentModel,
+    contextLimit,
     availableTerminalHeight: uiAvailableTerminalHeight,
     activeShellPtyId,
     embeddedShellFocused,
@@ -539,11 +540,7 @@ export const DefaultAppLayout = ({
                 historyTokenCount={historyTokenCount}
                 nightly={nightly}
                 vimMode={vimModeEnabled ? vimMode : undefined}
-                contextLimit={
-                  config.getEphemeralSetting('context-limit') as
-                    | number
-                    | undefined
-                }
+                contextLimit={contextLimit}
                 isTrustedFolder={config.isTrustedFolder()}
                 tokensPerMinute={tokenMetrics.tokensPerMinute}
                 throttleWaitTimeMs={tokenMetrics.throttleWaitTimeMs}
@@ -711,11 +708,7 @@ export const DefaultAppLayout = ({
               historyTokenCount={historyTokenCount}
               nightly={nightly}
               vimMode={vimModeEnabled ? vimMode : undefined}
-              contextLimit={
-                config.getEphemeralSetting('context-limit') as
-                  | number
-                  | undefined
-              }
+              contextLimit={contextLimit}
               isTrustedFolder={config.isTrustedFolder()}
               tokensPerMinute={tokenMetrics.tokensPerMinute}
               throttleWaitTimeMs={tokenMetrics.throttleWaitTimeMs}


### PR DESCRIPTION
## Summary

Fixes #1842 - Running \`/profile load\` requires executing twice for the context-limit to be correctly displayed in the footer.

## Root Cause

\`DefaultAppLayout.tsx\` was reading \`context-limit\` inline during render via \`config.getEphemeralSetting('context-limit')\`. The only mechanism triggering re-renders was \`useModelRuntimeSync\`, which polls every 500ms for model changes.

During profile load, this sequence causes a race condition:

1. All ephemerals are cleared (context-limit becomes \`undefined\`)
2. Provider is switched (model changes)
3. The 500ms poll fires, sees the model changed, triggers a re-render with stale \`undefined\` context-limit
4. \`applyNonAuthEphemerals\` later sets context-limit to the correct value (e.g. 200k)
5. But nothing triggers another re-render, so the stale value persists in the footer

On the second \`/profile load\`, the model is already correct so no premature mid-load re-render occurs, and the final render captures the correct context-limit.

## Fix

Extended \`useModelRuntimeSync\` to also track \`context-limit\` changes in its 500ms polling loop. The context-limit is now managed as reactive state (\`useState\`) rather than being read inline from config during render. This ensures any mid-load re-render will eventually pick up the correct value on the next poll cycle.

### Files Changed

- **useModelRuntimeSync.ts** - Added \`contextLimit\`/\`setContextLimit\` params; polls for context-limit changes using a ref to avoid effect re-subscription
- **useAppDialogs.ts** - Creates \`contextLimit\` state and threads it through to \`useModelRuntimeSync\`
- **DefaultAppLayout.tsx** - Reads \`contextLimit\` from UI state instead of inline config reads (2 locations)
- **UIStateContext.tsx** / **buildUIState.ts** / **AppContainerRuntime.tsx** - Added \`contextLimit\` to UI state plumbing
- **useModelRuntimeSync.test.ts** - 3 new tests for context-limit tracking behavior

## Testing

- All 7 \`useModelRuntimeSync\` tests pass (4 existing + 3 new)
- Typecheck passes
- Build passes
- Smoke test with \`--profile-load synthetic\` passes