### PR TITLE
fix(integration-tests): add stdin prompt to prevent CI failures (Fixes #1848)

### DIFF
--- a/integration-tests/run_shell_command.test.ts
+++ b/integration-tests/run_shell_command.test.ts
@@ -104,8 +104,10 @@ describe('run_shell_command', () => {
     rig.createFile('test.txt', 'Lorem\nIpsum\nDolor\n');
 
     // Use 'wc' directly — the fake response fixture always emits 'wc -l'
+    // Provide a prompt via stdin to avoid "No input provided via stdin" error in CI
     const result = await rig.run({
       args: ['--allowed-tools=run_shell_command(wc)'],
+      stdin: 'Count lines in test.txt',
       yolo: false,
     });
 
@@ -142,8 +144,10 @@ describe('run_shell_command', () => {
 
     rig.createFile('test.txt', 'Lorem\nIpsum\nDolor\n');
 
+    // Provide a prompt via stdin to avoid "No input provided via stdin" error in CI
     const result = await rig.run({
-      args: '--allowed-tools=run_shell_command',
+      args: ['--allowed-tools=run_shell_command'],
+      stdin: 'Count lines in test.txt',
       yolo: false,
     });
 
@@ -215,8 +219,10 @@ describe('run_shell_command', () => {
     rig.createFile('test.txt', 'Lorem\nIpsum\nDolor\n');
 
     // Use 'wc' directly — the fake response fixture always emits 'wc -l'
+    // Provide a prompt via stdin to avoid "No input provided via stdin" error in CI
     const result = await rig.run({
-      args: '--allowed-tools=ShellTool(wc)',
+      args: ['--allowed-tools=ShellTool(wc)'],
+      stdin: 'Count lines in test.txt',
       yolo: false,
     });
 
@@ -252,11 +258,13 @@ describe('run_shell_command', () => {
     });
 
     // Use 'wc' directly — the fake response fixture always emits 'wc -l'
+    // Provide a prompt via stdin to avoid "No input provided via stdin" error in CI
     const result = await rig.run({
       args: [
         '--allowed-tools=run_shell_command(wc)',
         '--allowed-tools=run_shell_command(ls)',
       ],
+      stdin: 'List files and count lines',
       yolo: false,
     });
 


### PR DESCRIPTION
This PR fixes the release workflow failure caused by integration tests failing with "No input provided via stdin" error.

## Problem

Four integration tests in "run_shell_command.test.ts" were failing in CI with the error:
- "No input provided via stdin. Input can be provided by piping data into llxprt or using the --prompt option."

In non-interactive mode, when the CLI detects piped input (`process.stdin.isTTY` is falsy in CI environments) but no actual input is provided, it exits with code 1.

The failing tests:
1. should run allowed sub-command in non-interactive mode
2. should succeed with no parens in non-interactive mode
3. should work with ShellTool alias
4. should combine multiple --allowed-tools flags

## Solution

Added `stdin` prompt to each test's `rig.run()` call to provide the required input, allowing the fake provider to drive the test behavior.

## Testing

- Verified all four previously failing tests now pass locally
- Build succeeds
- Smoke test passes

Fixes #1848