### PR TITLE
fix(ci): update GitHub Actions to valid commit SHAs in evals-nightly.yml (Fixes #1857)

### DIFF
--- a/.github/workflows/evals-nightly.yml
+++ b/.github/workflows/evals-nightly.yml
@@ -19,10 +19,10 @@ jobs:
         run_attempt: [1, 2, 3]
     steps:
       - name: Checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # ratchet:actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # ratchet:actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # ratchet:actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
@@ -42,7 +42,7 @@ jobs:
 
       - name: Upload eval logs
         if: always()
-        uses: actions/upload-artifact@ea0f049d75fb3ce01f6f6e8e8b4d7c0b81059256 # ratchet:actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4
         with:
           name: eval-logs-${{ matrix.run_attempt }}
           path: evals/logs
@@ -55,15 +55,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # ratchet:actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # ratchet:actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # ratchet:actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
         with:
           node-version: '20'
 
       - name: Download all artifacts
-        uses: actions/download-artifact@b4c6125a4be4c0faaf4b94f8a41eae1b37f68453 # ratchet:actions/download-artifact@v4
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # ratchet:actions/download-artifact@v5
         with:
           path: artifacts
 


### PR DESCRIPTION
## Problem

The Evals Nightly workflow (https://github.com/vybestack/llxprt-code/actions/runs/23780422068) was failing with errors resolving GitHub Actions:

- `actions/upload-artifact@ea0f049d75fb3ce01f6f6e8e8b4d7c0b81059256` - Unable to resolve action
- `actions/download-artifact@b4c6125a4be4c0faaf4b94f8a41eae1b37f68453` - Unable to resolve action

These specific commit SHAs appear to be unavailable or may have been removed/altered from the actions repositories.

## Solution

Updated to valid commit SHAs that are consistent with other workflows in the repository (ci.yml, nightly.yml, luther.yml):

| Action | Old (Invalid) | New (Valid) |
|--------|--------------|-------------|
| actions/upload-artifact | ea0f049d75fb3ce01f6f6e8e8b4d7c0b81059256 | ea165f8d65b6e75b540449e92b4886f43607fa02 (v4) |
| actions/download-artifact | b4c6125a4be4c0faaf4b94f8a41eae1b37f68453 | 634f93cb2916e3fdff6788551b99b062d0335ce0 (v5) |
| actions/checkout | 08eba0b27e820071cde6df949e0beb9ba4906955 | 08c6903cd8c0fde910a37f88322edcfb5dd907a8 (v5) |
| actions/setup-node | 0a44ba7841725637a19e28fa30b79a866c81b0a6 | 49933ea5288caeca8642d1e84afbd3f7d6820020 (v4) |

## Verification

- Build passes: `npm run build` completes successfully
- Typecheck passes: `npm run typecheck` completes successfully

## Module

0.10.0

Fixes #1857