### PR TITLE
fix(lsp): use fileURLToPath for Windows path compatibility in test fixtures (Fixes #1865)

### DIFF
--- a/packages/lsp/test/lsp-client-integration.test.ts
+++ b/packages/lsp/test/lsp-client-integration.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
 
 import { createLspClient } from '../src/service/lsp-client';
 import type { LspServerConfig } from '../src/types';
 
 const WORKSPACE_ROOT = '/workspace';
-const FIXTURE_PATH = new URL('./fixtures/fake-lsp-server.ts', import.meta.url)
-  .pathname;
+const FIXTURE_PATH = fileURLToPath(
+  new URL('./fixtures/fake-lsp-server.ts', import.meta.url),
+);
 
 function createConfig(args: string[] = []): { config: LspServerConfig } {
   return {

--- a/packages/lsp/test/lsp-client.test.ts
+++ b/packages/lsp/test/lsp-client.test.ts
@@ -1,12 +1,14 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import * as fc from 'fast-check';
+import { fileURLToPath } from 'node:url';
 
 import { createLspClient } from '../src/service/lsp-client';
 import type { LspServerConfig } from '../src/types';
 
 const WORKSPACE_ROOT = '/workspace';
-const FIXTURE_PATH = new URL('./fixtures/fake-lsp-server.ts', import.meta.url)
-  .pathname;
+const FIXTURE_PATH = fileURLToPath(
+  new URL('./fixtures/fake-lsp-server.ts', import.meta.url),
+);
 
 function createConfig(args: string[] = []): { config: LspServerConfig } {
   return {
@@ -393,10 +395,9 @@ describe('LspClient unit TDD edge cases and internal behaviors', () => {
   });
 });
 
-const CONTENT_LENGTH_FIXTURE_PATH = new URL(
-  './fixtures/fake-lsp-server-content-length.ts',
-  import.meta.url,
-).pathname;
+const CONTENT_LENGTH_FIXTURE_PATH = fileURLToPath(
+  new URL('./fixtures/fake-lsp-server-content-length.ts', import.meta.url),
+);
 
 function createContentLengthConfig(): { config: LspServerConfig } {
   return {


### PR DESCRIPTION
## Problem
The Nightly Tests workflow was failing on Windows with multiple LSP client integration test failures:
- Error: LSP server 'fake-ts' exited with code 1
- All LSP client integration tests failing on windows-latest CI runner

## Root Cause
The test fixtures used URL.pathname to extract file paths from import.meta.url. On Windows, this produces paths like `/C:/path/to/file` which are invalid for the Windows file system and cause Node.js to fail when spawning the child process.

## Solution
Replaced URL.pathname with fileURLToPath() from node:url, which properly handles cross-platform path conversion:
- Windows: Converts file:///C:/path to C:\path\to\file
- Unix-like: Works as expected with /path/to/file

## Changes
- packages/lsp/test/lsp-client-integration.test.ts: Added fileURLToPath import and updated FIXTURE_PATH construction
- packages/lsp/test/lsp-client.test.ts: Added fileURLToPath import and updated both FIXTURE_PATH and CONTENT_LENGTH_FIXTURE_PATH construction

## Verification
- All 199 LSP package tests pass
- npm run lint: No new errors (0 errors, 30284 warnings - pre-existing)
- npm run typecheck: Passed
- npm run format: Applied
- Smoke test passed: Application runs correctly

Closes #1865