### PR TITLE
Enable bucket failover during compression 401 errors (fixes #1859)

### DIFF
--- a/packages/core/src/core/compression/CompressionHandler.ts
+++ b/packages/core/src/core/compression/CompressionHandler.ts
@@ -766,6 +766,9 @@ export class CompressionHandler {
       }
     }
 
+    // Get config from runtimeContext for bucket failover handling
+    const config = this.runtimeContext.providerRuntime?.config;
+
     return {
       history: this.historyService.getCurated(),
       runtimeContext: this.runtimeContext,
@@ -786,6 +789,7 @@ export class CompressionHandler {
       ...(activeTodos ? { activeTodos } : {}),
       compressionVerification:
         this.runtimeContext.ephemerals.compressionVerification?.() ?? false,
+      ...(config ? { config } : {}),
     };
   }
 

--- a/packages/core/src/core/compression/MiddleOutStrategy.ts
+++ b/packages/core/src/core/compression/MiddleOutStrategy.ts
@@ -130,6 +130,7 @@ export class MiddleOutStrategy implements CompressionStrategy {
     const { text: summary, usage: capturedUsage } = await this.callProvider(
       provider,
       compressionRequest,
+      context.config,
     );
 
     if (!summary.trim()) {
@@ -139,7 +140,11 @@ export class MiddleOutStrategy implements CompressionStrategy {
     // Optional verification pass — gated by compressionVerification flag (default off)
     let finalSummary = summary;
     if (context.compressionVerification) {
-      finalSummary = await runVerificationPass(provider, summary);
+      finalSummary = await runVerificationPass(
+        provider,
+        summary,
+        context.config,
+      );
     }
 
     // Assemble result
@@ -231,11 +236,13 @@ export class MiddleOutStrategy implements CompressionStrategy {
   private async callProvider(
     provider: IProvider,
     request: IContent[],
+    config?: import('./types.js').CompressionContext['config'],
   ): Promise<{ text: string; usage?: UsageStats }> {
     try {
       const stream = provider.generateChatCompletion({
         contents: request,
         tools: undefined,
+        config,
       });
 
       let summary = '';

--- a/packages/core/src/core/compression/OneShotStrategy.ts
+++ b/packages/core/src/core/compression/OneShotStrategy.ts
@@ -105,6 +105,7 @@ export class OneShotStrategy implements CompressionStrategy {
     const { text: summary, usage: capturedUsage } = await this.callProvider(
       provider,
       compressionRequest,
+      context.config,
     );
 
     if (!summary.trim()) {
@@ -114,7 +115,11 @@ export class OneShotStrategy implements CompressionStrategy {
     // Optional verification pass — gated by compressionVerification flag (default off)
     let finalSummary = summary;
     if (context.compressionVerification) {
-      finalSummary = await runVerificationPass(provider, summary);
+      finalSummary = await runVerificationPass(
+        provider,
+        summary,
+        context.config,
+      );
     }
 
     // Assemble result: summary + continuation directive + preserved tail
@@ -207,11 +212,13 @@ export class OneShotStrategy implements CompressionStrategy {
   private async callProvider(
     provider: IProvider,
     request: IContent[],
+    config?: import('./types.js').CompressionContext['config'],
   ): Promise<{ text: string; usage?: UsageStats }> {
     try {
       const stream = provider.generateChatCompletion({
         contents: request,
         tools: undefined,
+        config,
       });
 
       let summary = '';

--- a/packages/core/src/core/compression/types.ts
+++ b/packages/core/src/core/compression/types.ts
@@ -24,6 +24,7 @@ import type { DebugLogger } from '../../debug/DebugLogger.js';
 import type { IProvider } from '../../providers/IProvider.js';
 import type { PromptResolver } from '../../prompt-config/prompt-resolver.js';
 import type { PromptContext } from '../../prompt-config/types.js';
+import type { Config } from '../../config/config.js';
 
 // ---------------------------------------------------------------------------
 // Strategy trigger
@@ -130,6 +131,11 @@ export interface CompressionContext {
    * existing users.
    */
   readonly compressionVerification?: boolean;
+  /**
+   * Config object for bucket failover handling during compression LLM calls.
+   * Enables RetryOrchestrator to access getBucketFailoverHandler().
+   */
+  readonly config?: Config;
 }
 
 /**

--- a/packages/core/src/core/compression/utils.ts
+++ b/packages/core/src/core/compression/utils.ts
@@ -265,10 +265,12 @@ export function buildTriggerInstruction(toCompress: IContent[]): string {
  *
  * @param provider - the provider to use for the verification call
  * @param initialSummary - the summary produced by the initial compression call
+ * @param config - optional config for bucket failover handling during verification
  */
 export async function runVerificationPass(
   provider: IProvider,
   initialSummary: string,
+  config?: import('./types.js').CompressionContext['config'],
 ): Promise<string> {
   const verificationRequest: IContent[] = [
     COMPRESSION_SECURITY_PREAMBLE,
@@ -300,6 +302,7 @@ export async function runVerificationPass(
     const stream = provider.generateChatCompletion({
       contents: verificationRequest,
       tools: undefined,
+      config,
     });
 
     let verifiedText = '';


### PR DESCRIPTION
## Summary

This PR threads the Config object through the compression call chain so that RetryOrchestrator can access getBucketFailoverHandler() during compression LLM calls, enabling proper bucket failover handling for 401 errors during compression operations.

## Background

The compression system (MiddleOutStrategy, OneShotStrategy) calls LLM providers for summarization. These providers are wrapped by RetryOrchestrator which handles retry/failover logic. However, RetryOrchestrator reads the bucket failover handler from options.runtime?.config?.getBucketFailoverHandler?.() or options.config?.getBucketFailoverHandler?.() in the generateChatCompletion call options.

Previously, MiddleOutStrategy and OneShotStrategy only passed { contents, tools: undefined } to the provider, with no config reference. This meant bucket failover could not be triggered even though the provider was correctly wrapped in RetryOrchestrator.

## Changes

1. **Added optional config property to CompressionContext interface** (packages/core/src/core/compression/types.ts)
   - Added readonly config?: Config property to enable strategies to access bucket failover handler

2. **Pass config from CompressionHandler.buildCompressionContext()** (packages/core/src/core/compression/CompressionHandler.ts)
   - Retrieves config from runtimeContext.providerRuntime?.config
   - Includes config in the returned CompressionContext object

3. **Pass config in MiddleOutStrategy.callProvider()** (packages/core/src/core/compression/MiddleOutStrategy.ts)
   - Updated generateChatCompletion() call to include config from compression context

4. **Pass config in OneShotStrategy.callProvider()** (packages/core/src/core/compression/OneShotStrategy.ts)
   - Updated generateChatCompletion() call to include config from compression context

5. **Pass config in runVerificationPass()** (packages/core/src/core/compression/utils.ts)
   - Updated generateChatCompletion() call in verification pass to include config

## How it works

With the config now passed through:
- RetryOrchestrator will have access to getBucketFailoverHandler()
- On first 401: free refresh retry is granted
- On second 401: bucket failover is attempted
- If all buckets exhausted: AllBucketsExhaustedError is thrown
- This error will then be caught by the strategy and wrapped appropriately

No changes were needed to compression error classification (isTransientCompressionError) as the failover happens at the provider/orchestrator layer before errors reach compression handling.

## Testing

- Build passes successfully
- Core package tests pass
- Smoke test with synthetic profile successful

Closes #1859