### PR TITLE
fix: remediate post-merge gaps for gmerge/0.26.0 high-risk batches

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -38,6 +38,7 @@ import { resolveProviderAndModel } from './providerModelResolver.js';
 import { buildConfig } from './configBuilder.js';
 import { finalizeConfig } from './postConfigRuntime.js';
 import { resolveIntermediateConfig } from './intermediateConfig.js';
+import { getCliVersion } from '../utils/version.js';
 
 import type { ContextResolutionResult } from './interactiveContext.js';
 
@@ -170,6 +171,7 @@ export async function loadCliConfig(
 
   const config = buildConfig({
     sessionId,
+    cliVersion: await getCliVersion(),
     cwd,
     argv,
     profileSettingsWithTools: intermediate.profileSettingsWithTools,

--- a/packages/cli/src/config/configBuilder.ts
+++ b/packages/cli/src/config/configBuilder.ts
@@ -27,6 +27,7 @@ import type { ProviderModelResult } from './providerModelResolver.js';
 
 export interface ConfigBuildInput {
   readonly sessionId: string;
+  readonly cliVersion?: string;
   readonly cwd: string;
   readonly argv: CliArgs;
   readonly profileSettingsWithTools: Settings;

--- a/packages/cli/src/ui/layouts/DefaultAppLayout.test.tsx
+++ b/packages/cli/src/ui/layouts/DefaultAppLayout.test.tsx
@@ -115,7 +115,7 @@ const mockUseUIActions = vi.mocked(useUIActions);
 function createConfigStub() {
   return {
     getScreenReader: () => false,
-    getAccessibility: () => ({ disableLoadingPhrases: false }),
+    getAccessibility: () => ({ enableLoadingPhrases: true }),
     getMcpServers: () => [],
     getBlockedMcpServers: () => [],
     getTargetDir: () => '/tmp',

--- a/packages/cli/src/ui/layouts/DefaultAppLayout.tsx
+++ b/packages/cli/src/ui/layouts/DefaultAppLayout.tsx
@@ -435,13 +435,13 @@ export const DefaultAppLayout = ({
                 <LoadingIndicator
                   thought={
                     streamingState === StreamingState.WaitingForConfirmation ||
-                    config.getAccessibility()?.disableLoadingPhrases ||
+                    !config.getAccessibility()?.enableLoadingPhrases ||
                     config.getScreenReader()
                       ? undefined
                       : thought
                   }
                   currentLoadingPhrase={
-                    config.getAccessibility()?.disableLoadingPhrases ||
+                    !config.getAccessibility()?.enableLoadingPhrases ||
                     config.getScreenReader()
                       ? undefined
                       : currentLoadingPhrase
@@ -603,13 +603,13 @@ export const DefaultAppLayout = ({
               <LoadingIndicator
                 thought={
                   streamingState === StreamingState.WaitingForConfirmation ||
-                  config.getAccessibility()?.disableLoadingPhrases ||
+                  !config.getAccessibility()?.enableLoadingPhrases ||
                   config.getScreenReader()
                     ? undefined
                     : thought
                 }
                 currentLoadingPhrase={
-                  config.getAccessibility()?.disableLoadingPhrases ||
+                  !config.getAccessibility()?.enableLoadingPhrases ||
                   config.getScreenReader()
                     ? undefined
                     : currentLoadingPhrase

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -123,7 +123,7 @@ export class Config extends ConfigBase {
     this.resourceRegistry = new ResourceRegistry();
     this.toolRegistry = await this.createToolRegistry(initializationMessageBus);
     this.mcpClientManager = new McpClientManager(
-      await getCoreVersion(),
+      this.cliVersion ?? (await getCoreVersion()),
       this.toolRegistry,
       this,
       this.eventEmitter,

--- a/packages/core/src/config/configBaseCore.ts
+++ b/packages/core/src/config/configBaseCore.ts
@@ -76,6 +76,7 @@ export abstract class ConfigBaseCore {
   protected fileSystemService!: FileSystemService;
   protected contentGeneratorConfig!: ContentGeneratorConfig;
   protected readonly embeddingModel: string | undefined;
+  protected readonly cliVersion: string | undefined;
   protected readonly sandbox: SandboxConfig | undefined;
   protected readonly targetDir!: string;
   protected workspaceContext!: WorkspaceContext;

--- a/packages/core/src/config/configConstructor.ts
+++ b/packages/core/src/config/configConstructor.ts
@@ -79,6 +79,7 @@ export interface ConfigConstructorTarget {
 
   // Core identity and workspace
   sessionId: string;
+  cliVersion: string | undefined;
   embeddingModel: string | undefined;
   fileSystemService: FileSystemService;
   sandbox: SandboxConfig | undefined;
@@ -224,6 +225,7 @@ function applyCoreIdentity(
   params: ConfigParameters,
 ): void {
   config.sessionId = params.sessionId;
+  config.cliVersion = params.cliVersion;
   config.embeddingModel = params.embeddingModel;
   config.fileSystemService = new StandardFileSystemService();
   config.sandbox = params.sandbox;

--- a/packages/core/src/config/configTypes.ts
+++ b/packages/core/src/config/configTypes.ts
@@ -51,7 +51,7 @@ export enum ApprovalMode {
 }
 
 export interface AccessibilitySettings {
-  disableLoadingPhrases?: boolean;
+  enableLoadingPhrases?: boolean;
   screenReader?: boolean;
 }
 
@@ -310,6 +310,11 @@ export interface BucketFailoverHandler {
 
 export interface ConfigParameters {
   sessionId: string;
+  /**
+   * Optional CLI version string. When provided, this will be passed to
+   * McpClientManager for client identification with MCP servers.
+   */
+  cliVersion?: string;
   embeddingModel?: string;
   sandbox?: SandboxConfig;
   targetDir: string;


### PR DESCRIPTION
## Summary

This PR addresses the post-merge remediation items identified in the gmerge/0.26.0 merge (commit 96ca183f6).

## Remediation Items Addressed

### Implemented Fixes

**R21: Migrate disableLoadingPhrases to enableLoadingPhrases**
- Renamed AccessibilitySettings interface property from disableLoadingPhrases to enableLoadingPhrases
- Updated all 4 references in DefaultAppLayout.tsx with inverted logic
- Updated mock in DefaultAppLayout.test.tsx

**R32: Plumb real CLI version into McpClientManager**
- Added cliVersion field to ConfigBuildInput and ConfigParameters
- CLI config now passes getCliVersion() to core Config
- McpClientManager uses cliVersion ?? getCoreVersion() for client identification

### Verified Items (No Changes Needed)

- **P3**: DiffModified already removed from theme docs
- **R1**: Extension config setting gates already correct (experimental.extensionConfig check present)
- **R9**: MOVE_UP/MOVE_DOWN already use proper keyMatchers wiring
- **R14**: Optional chaining on settings?.merged is appropriate (initialization safety)
- **R17**: MCP discovery state behavior already correct with proper gating
- **R33**: Hooks schema split already complete with proper merge strategy
- **R39**: MCP status/message queue hooks already wired into app flow
- **R40**: clearContext propagation for AfterAgent hooks already implemented

## Verification

- [x] npm run lint passes
- [x] npm run typecheck passes
- [x] npm run build passes
- [x] Smoke test (node scripts/start.js --profile-load synthetic) passes