### PR TITLE
fix(subagent): filter disabled tools instead of throwing runtime error (Fixes #1747)

### DIFF
--- a/packages/core/src/core/subagent.ts
+++ b/packages/core/src/core/subagent.ts
@@ -189,7 +189,6 @@ export class SubAgentScope {
     if (toolConfig) {
       const filteredToolConfig = await filterToolsAgainstRuntime({
         toolConfig,
-        toolRegistry,
         toolsView,
       });
       // Use undefined if all tools were filtered out

--- a/packages/core/src/core/subagentRuntimeSetup.test.ts
+++ b/packages/core/src/core/subagentRuntimeSetup.test.ts
@@ -97,10 +97,6 @@ describe('subagentRuntimeSetup', () => {
 
   describe('filterToolsAgainstRuntime', () => {
     it('should return filtered ToolConfig with only allowed tools', async () => {
-      const toolRegistry = {
-        getTool: (name: string) =>
-          name === 'allowed_tool' ? { name } : undefined,
-      };
       const toolsView = {
         listToolNames: () => ['allowed_tool'],
         getToolMetadata: () => ({ name: 'allowed_tool', description: '' }),
@@ -108,14 +104,12 @@ describe('subagentRuntimeSetup', () => {
       const toolConfig = { tools: ['allowed_tool'] };
       const result = await filterToolsAgainstRuntime({
         toolConfig,
-        toolRegistry,
         toolsView,
       });
       expect(result.tools).toEqual(['allowed_tool']);
     });
 
     it('should filter out disabled tools not in runtime', async () => {
-      const toolRegistry = { getTool: () => undefined };
       const toolsView = {
         listToolNames: () => ['other_tool'],
         getToolMetadata: () => undefined,
@@ -123,14 +117,12 @@ describe('subagentRuntimeSetup', () => {
       const toolConfig = { tools: ['google_web_fetch'] };
       const result = await filterToolsAgainstRuntime({
         toolConfig,
-        toolRegistry,
         toolsView,
       });
       expect(result.tools).toEqual([]);
     });
 
     it('should preserve tools that are present in toolsView', async () => {
-      const toolRegistry = { getTool: () => undefined };
       const toolsView = {
         listToolNames: () => ['google_web_fetch', 'read_file'],
         getToolMetadata: (name: string) => ({ name, description: '' }),
@@ -138,14 +130,12 @@ describe('subagentRuntimeSetup', () => {
       const toolConfig = { tools: ['google_web_fetch', 'read_file'] };
       const result = await filterToolsAgainstRuntime({
         toolConfig,
-        toolRegistry,
         toolsView,
       });
       expect(result.tools).toEqual(['google_web_fetch', 'read_file']);
     });
 
     it('should handle mixed allowed and disallowed tools', async () => {
-      const toolRegistry = { getTool: () => undefined };
       const toolsView = {
         listToolNames: () => ['read_file', 'write_file'],
         getToolMetadata: (name: string) => ({ name, description: '' }),
@@ -155,7 +145,6 @@ describe('subagentRuntimeSetup', () => {
       };
       const result = await filterToolsAgainstRuntime({
         toolConfig,
-        toolRegistry,
         toolsView,
       });
       // google_web_fetch should be filtered out
@@ -163,7 +152,6 @@ describe('subagentRuntimeSetup', () => {
     });
 
     it('should return empty tools array when all tools are filtered out', async () => {
-      const toolRegistry = { getTool: () => undefined };
       const toolsView = {
         listToolNames: () => ['other_tool'],
         getToolMetadata: () => undefined,
@@ -171,14 +159,12 @@ describe('subagentRuntimeSetup', () => {
       const toolConfig = { tools: ['missing_tool'] };
       const result = await filterToolsAgainstRuntime({
         toolConfig,
-        toolRegistry,
         toolsView,
       });
       expect(result.tools).toEqual([]);
     });
 
     it('should pass with empty whitelist (allow all)', async () => {
-      const toolRegistry = { getTool: () => undefined };
       const toolsView = {
         listToolNames: () => [],
         getToolMetadata: () => undefined,
@@ -186,7 +172,6 @@ describe('subagentRuntimeSetup', () => {
       const toolConfig = { tools: [] };
       const result = await filterToolsAgainstRuntime({
         toolConfig,
-        toolRegistry,
         toolsView,
       });
       expect(result.tools).toEqual([]);

--- a/packages/core/src/core/subagentRuntimeSetup.ts
+++ b/packages/core/src/core/subagentRuntimeSetup.ts
@@ -97,12 +97,11 @@ export function convertMetadataToFunctionDeclaration(
  * Returns a new ToolConfig with only the tools that are permitted.
  * Tools not in the allowed set are logged as warnings and removed.
  *
- * @param params - Object containing toolConfig, toolRegistry, and toolsView
+ * @param params - Object containing toolConfig and toolsView
  * @returns A Promise that resolves to a filtered ToolConfig
  */
 export async function filterToolsAgainstRuntime(params: {
   toolConfig: ToolConfig;
-  toolRegistry: ToolRegistry;
   toolsView: ToolRegistryView;
 }): Promise<ToolConfig> {
   const { toolConfig, toolsView } = params;


### PR DESCRIPTION
## Summary

Fixes #1747 - Subagent sees disabled google_web_fetch and fails at runtime (possible regression of #1654)

## Problem

Subagent launches can fail because the model attempts to call google_web_fetch even when that tool is disabled for the runtime bundle. The runtime rejects it with:

    Tool "google_web_fetch" is not permitted for this runtime bundle.

The root cause was that validateToolsAgainstRuntime was throwing an error when a tool in toolConfig.tools was not in the allowed set from toolsView.listToolNames(). However, buildRuntimeFunctionDeclarations in the same file already filters out unavailable tools with a warning - creating an inconsistency.

## Solution

Convert validateToolsAgainstRuntime from a throwing validator to a filtering function that returns a cleaned ToolConfig. This aligns with the existing pattern in buildRuntimeFunctionDeclarations which silently skips unavailable tools.

### Changes

1. Renamed validateToolsAgainstRuntime to filterToolsAgainstRuntime
2. Changed return type from Promise<void> to Promise<ToolConfig>
3. Filter out unavailable tools with a debug warning instead of throwing
4. Use the filtered ToolConfig in SubAgentScope.create
5. Handle edge case where all tools are filtered out (toolConfig becomes undefined)
6. Updated tests to expect filtering behavior instead of throwing

## Verification

- All 32 tests in subagentRuntimeSetup.test.ts pass
- Core package typecheck passes
- Build succeeds for all packages
- Smoke test passed - successfully generated haiku with synthetic profile
- No stale references to validateToolsAgainstRuntime remain

## Related Issues

- #1654 - Original issue about default disabled tools not being properly propagated
- #1747 - This issue (regression of #1654)

---

Fixes #1747