### PR TITLE
fix(auth): enable auth cache invalidation for unbucketed profiles (Fixes #1739)

### DIFF
--- a/packages/cli/src/auth/BucketFailoverHandlerImpl.ts
+++ b/packages/cli/src/auth/BucketFailoverHandlerImpl.ts
@@ -13,6 +13,7 @@
 import {
   BucketFailoverHandler,
   DebugLogger,
+  flushRuntimeAuthScope,
   type FailoverContext,
   type BucketFailureReason,
   type OAuthToken,
@@ -658,5 +659,13 @@ export class BucketFailoverHandlerImpl implements BucketFailoverHandler {
    */
   getLastFailoverReasons(): Record<string, BucketFailureReason> {
     return { ...this.lastFailoverReasons };
+  }
+  /**
+   * Invalidate the auth cache for a runtime, forcing fresh keychain reads.
+   * Called at turn boundaries and after auth errors.
+   */
+  invalidateAuthCache(runtimeId: string): void {
+    flushRuntimeAuthScope(runtimeId);
+    logger.debug('Auth cache invalidated for runtime', { runtimeId });
   }
 }

--- a/packages/cli/src/auth/__tests__/BucketFailoverHandlerImpl.invalidateAuthCache.test.ts
+++ b/packages/cli/src/auth/__tests__/BucketFailoverHandlerImpl.invalidateAuthCache.test.ts
@@ -30,6 +30,7 @@ describe('BucketFailoverHandlerImpl.invalidateAuthCache', () => {
       getOAuthToken: vi.fn(),
       authenticate: vi.fn(),
       authenticateMultipleBuckets: vi.fn(),
+      forceRefreshToken: vi.fn(),
     };
 
     const metadata: OAuthTokenRequestMetadata = {

--- a/packages/cli/src/auth/__tests__/BucketFailoverHandlerImpl.invalidateAuthCache.test.ts
+++ b/packages/cli/src/auth/__tests__/BucketFailoverHandlerImpl.invalidateAuthCache.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@vybestack/llxprt-code-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@vybestack/llxprt-code-core')>();
+  return {
+    ...actual,
+    flushRuntimeAuthScope: vi.fn(),
+  };
+});
+
+import {
+  flushRuntimeAuthScope,
+  type OAuthTokenRequestMetadata,
+} from '@vybestack/llxprt-code-core';
+import { BucketFailoverHandlerImpl } from '../BucketFailoverHandlerImpl.js';
+import type { BucketFailoverOAuthManagerLike } from '../types.js';
+
+describe('BucketFailoverHandlerImpl.invalidateAuthCache', () => {
+  it('flushes the runtime auth scope for unbucketed profiles', () => {
+    const oauthManager: BucketFailoverOAuthManagerLike = {
+      getSessionBucket: vi.fn().mockReturnValue(undefined),
+      setSessionBucket: vi.fn(),
+      getTokenStore: vi.fn(),
+      getOAuthToken: vi.fn(),
+      authenticate: vi.fn(),
+      authenticateMultipleBuckets: vi.fn(),
+    };
+
+    const metadata: OAuthTokenRequestMetadata = {
+      profileId: 'opusthinking',
+      providerId: 'anthropic',
+      runtimeMetadata: { source: 'test' },
+    };
+
+    const handler = new BucketFailoverHandlerImpl(
+      ['default'],
+      'anthropic',
+      oauthManager,
+      metadata,
+    );
+
+    handler.invalidateAuthCache('runtime-1739');
+
+    expect(flushRuntimeAuthScope).toHaveBeenCalledWith('runtime-1739');
+  });
+});

--- a/packages/cli/src/auth/__tests__/BucketFailoverHandlerImpl.invalidateAuthCache.test.ts
+++ b/packages/cli/src/auth/__tests__/BucketFailoverHandlerImpl.invalidateAuthCache.test.ts
@@ -7,7 +7,8 @@
 import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('@vybestack/llxprt-code-core', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@vybestack/llxprt-code-core')>();
+  const actual =
+    await importOriginal<typeof import('@vybestack/llxprt-code-core')>();
   return {
     ...actual,
     flushRuntimeAuthScope: vi.fn(),

--- a/packages/cli/src/ui/hooks/geminiStream/__tests__/useGeminiStream.turnPreparation.test.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/__tests__/useGeminiStream.turnPreparation.test.ts
@@ -5,8 +5,14 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
-import type { Config } from '@vybestack/llxprt-code-core';
+import type { Config, ThinkingBlock } from '@vybestack/llxprt-code-core';
 import { prepareTurnForQuery } from '../useGeminiStream.js';
+
+const existingThinkingBlock: ThinkingBlock = {
+  type: 'thinking',
+  thought: 'existing',
+  sourceField: 'thought',
+};
 
 describe('prepareTurnForQuery', () => {
   it('runs new-turn handler steps in reset -> invalidate -> ensure order', async () => {
@@ -35,7 +41,9 @@ describe('prepareTurnForQuery', () => {
     const setThought = vi.fn(() => {
       callOrder.push('setThought');
     });
-    const thinkingBlocksRef = { current: ['existing'] };
+    const thinkingBlocksRef = { current: [existingThinkingBlock] } as {
+      current: ThinkingBlock[];
+    };
 
     await prepareTurnForQuery(
       false,
@@ -56,7 +64,7 @@ describe('prepareTurnForQuery', () => {
     expect(handler.resetSession).not.toHaveBeenCalled();
   });
 
-  it('uses default runtime id and continuation path resetSession branch', async () => {
+  it('uses continuation path resetSession branch without resetting new-turn state', async () => {
     const callOrder: string[] = [];
     const handler = {
       reset: vi.fn(() => {
@@ -81,7 +89,9 @@ describe('prepareTurnForQuery', () => {
     const setThought = vi.fn(() => {
       callOrder.push('setThought');
     });
-    const thinkingBlocksRef = { current: ['existing'] };
+    const thinkingBlocksRef = { current: [existingThinkingBlock] } as {
+      current: ThinkingBlock[];
+    };
 
     await prepareTurnForQuery(
       true,
@@ -96,6 +106,36 @@ describe('prepareTurnForQuery', () => {
     expect(handler.invalidateAuthCache).not.toHaveBeenCalled();
     expect(startNewPrompt).not.toHaveBeenCalled();
     expect(setThought).not.toHaveBeenCalled();
-    expect(thinkingBlocksRef.current).toEqual(['existing']);
+    expect(thinkingBlocksRef.current).toEqual([existingThinkingBlock]);
+  });
+
+  it('falls back to the default runtime id when session id is unavailable', async () => {
+    const callOrder: string[] = [];
+    const handler = {
+      reset: vi.fn(() => {
+        callOrder.push('reset');
+      }),
+      invalidateAuthCache: vi.fn((runtimeId: string) => {
+        callOrder.push(`invalidate:${runtimeId}`);
+      }),
+      ensureBucketsAuthenticated: vi.fn(async () => {
+        callOrder.push('ensure');
+      }),
+      resetSession: vi.fn(),
+    };
+    const config = {
+      getBucketFailoverHandler: () => handler,
+      getSessionId: () => undefined,
+    } as unknown as Config;
+
+    await prepareTurnForQuery(
+      false,
+      config,
+      vi.fn(),
+      vi.fn(),
+      { current: [] } as { current: ThinkingBlock[] },
+    );
+
+    expect(callOrder).toContain('invalidate:default');
   });
 });

--- a/packages/cli/src/ui/hooks/geminiStream/__tests__/useGeminiStream.turnPreparation.test.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/__tests__/useGeminiStream.turnPreparation.test.ts
@@ -128,13 +128,9 @@ describe('prepareTurnForQuery', () => {
       getSessionId: () => undefined,
     } as unknown as Config;
 
-    await prepareTurnForQuery(
-      false,
-      config,
-      vi.fn(),
-      vi.fn(),
-      { current: [] } as { current: ThinkingBlock[] },
-    );
+    await prepareTurnForQuery(false, config, vi.fn(), vi.fn(), {
+      current: [],
+    } as { current: ThinkingBlock[] });
 
     expect(callOrder).toContain('invalidate:default');
   });

--- a/packages/cli/src/ui/hooks/geminiStream/__tests__/useGeminiStream.turnPreparation.test.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/__tests__/useGeminiStream.turnPreparation.test.ts
@@ -1,0 +1,101 @@
+/**
+ * @license
+ * Copyright 2025 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { Config } from '@vybestack/llxprt-code-core';
+import { prepareTurnForQuery } from '../useGeminiStream.js';
+
+describe('prepareTurnForQuery', () => {
+  it('runs new-turn handler steps in reset -> invalidate -> ensure order', async () => {
+    const callOrder: string[] = [];
+    const handler = {
+      reset: vi.fn(() => {
+        callOrder.push('reset');
+      }),
+      invalidateAuthCache: vi.fn((runtimeId: string) => {
+        callOrder.push(`invalidate:${runtimeId}`);
+      }),
+      ensureBucketsAuthenticated: vi.fn(async () => {
+        callOrder.push('ensure');
+      }),
+      resetSession: vi.fn(() => {
+        callOrder.push('resetSession');
+      }),
+    };
+    const config = {
+      getBucketFailoverHandler: () => handler,
+      getSessionId: () => 'runtime-1739',
+    } as unknown as Config;
+    const startNewPrompt = vi.fn(() => {
+      callOrder.push('startNewPrompt');
+    });
+    const setThought = vi.fn(() => {
+      callOrder.push('setThought');
+    });
+    const thinkingBlocksRef = { current: ['existing'] };
+
+    await prepareTurnForQuery(
+      false,
+      config,
+      startNewPrompt,
+      setThought,
+      thinkingBlocksRef,
+    );
+
+    expect(callOrder).toEqual([
+      'startNewPrompt',
+      'setThought',
+      'reset',
+      'invalidate:runtime-1739',
+      'ensure',
+    ]);
+    expect(thinkingBlocksRef.current).toEqual([]);
+    expect(handler.resetSession).not.toHaveBeenCalled();
+  });
+
+  it('uses default runtime id and continuation path resetSession branch', async () => {
+    const callOrder: string[] = [];
+    const handler = {
+      reset: vi.fn(() => {
+        callOrder.push('reset');
+      }),
+      invalidateAuthCache: vi.fn((runtimeId: string) => {
+        callOrder.push(`invalidate:${runtimeId}`);
+      }),
+      ensureBucketsAuthenticated: vi.fn(async () => {
+        callOrder.push('ensure');
+      }),
+      resetSession: vi.fn(() => {
+        callOrder.push('resetSession');
+      }),
+    };
+    const config = {
+      getBucketFailoverHandler: () => handler,
+    } as unknown as Config;
+    const startNewPrompt = vi.fn(() => {
+      callOrder.push('startNewPrompt');
+    });
+    const setThought = vi.fn(() => {
+      callOrder.push('setThought');
+    });
+    const thinkingBlocksRef = { current: ['existing'] };
+
+    await prepareTurnForQuery(
+      true,
+      config,
+      startNewPrompt,
+      setThought,
+      thinkingBlocksRef,
+    );
+
+    expect(callOrder).toEqual(['resetSession', 'ensure']);
+    expect(handler.reset).not.toHaveBeenCalled();
+    expect(handler.invalidateAuthCache).not.toHaveBeenCalled();
+    expect(startNewPrompt).not.toHaveBeenCalled();
+    expect(setThought).not.toHaveBeenCalled();
+    expect(thinkingBlocksRef.current).toEqual(['existing']);
+  });
+});

--- a/packages/cli/src/ui/hooks/geminiStream/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/useGeminiStream.ts
@@ -55,7 +55,7 @@ import { StreamProcessingStatus, type QueuedSubmission } from './types.js';
  * Resets or carries-over per-turn state depending on whether this is a new
  * prompt or a continuation. Also handles bucket failover reset/reauth.
  */
-async function prepareTurnForQuery(
+export async function prepareTurnForQuery(
   isContinuation: boolean,
   config: Config,
   startNewPrompt: () => void,

--- a/packages/cli/src/ui/hooks/geminiStream/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/useGeminiStream.ts
@@ -67,6 +67,14 @@ async function prepareTurnForQuery(
     setThought(null);
     thinkingBlocksRef.current = [];
     config.getBucketFailoverHandler?.()?.reset?.();
+
+    // Invalidate auth cache at turn boundaries for new turns
+    // This ensures tokens updated by other processes are picked up
+    const handler = config.getBucketFailoverHandler?.();
+    if (handler?.invalidateAuthCache) {
+      const runtimeId = config.getSessionId?.() ?? 'default';
+      handler.invalidateAuthCache(runtimeId);
+    }
   } else {
     config.getBucketFailoverHandler?.()?.resetSession?.();
   }

--- a/packages/core/src/config/configTypes.ts
+++ b/packages/core/src/config/configTypes.ts
@@ -326,6 +326,12 @@ export interface BucketFailoverHandler {
    * No-op for single-bucket profiles.
    */
   ensureBucketsAuthenticated?(): Promise<void>;
+
+  /**
+   * Invalidate the auth cache for a runtime, forcing fresh keychain reads.
+   * Called at turn boundaries and after auth errors.
+   */
+  invalidateAuthCache?(runtimeId: string): void;
 }
 
 export interface ConfigParameters {

--- a/packages/core/src/core/StreamProcessor.ts
+++ b/packages/core/src/core/StreamProcessor.ts
@@ -460,7 +460,7 @@ export class StreamProcessor {
   private async _handleBucketFailover(): Promise<boolean | null> {
     const failoverHandler =
       this.runtimeContext.providerRuntime.config?.getBucketFailoverHandler();
-    if (!failoverHandler?.isEnabled()) return null;
+    if (!failoverHandler) return null;
 
     this.logger.debug(() => 'Attempting bucket failover on persistent 429');
     const success = await failoverHandler.tryFailover();

--- a/packages/core/src/core/StreamProcessor.unbucketed-auth-failover.test.ts
+++ b/packages/core/src/core/StreamProcessor.unbucketed-auth-failover.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../auth/precedence.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../auth/precedence.js')>(
+    '../auth/precedence.js',
+  );
+  return {
+    ...actual,
+    flushRuntimeAuthScope: vi.fn(),
+  };
+});
+
+import { StreamProcessor } from './StreamProcessor.js';
+import { flushRuntimeAuthScope } from '../auth/precedence.js';
+
+describe('StreamProcessor._handleBucketFailover', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('allows single-bucket handlers to run tryFailover and flush auth scope', async () => {
+    const tryFailover = vi.fn().mockResolvedValue(true);
+
+    const processor = Object.create(StreamProcessor.prototype) as StreamProcessor;
+    Object.assign(processor, {
+      runtimeContext: {
+        state: {
+          runtimeId: 'state-runtime-1739',
+        },
+        providerRuntime: {
+          runtimeId: 'provider-runtime-1739',
+          config: {
+            getBucketFailoverHandler: () => ({
+              tryFailover,
+              getCurrentBucket: () => 'default',
+              isEnabled: () => false,
+            }),
+          },
+        },
+      },
+      logger: {
+        debug: vi.fn(),
+      },
+    });
+
+    const result = await (
+      processor as unknown as {
+        _handleBucketFailover: () => Promise<boolean | null>;
+      }
+    )._handleBucketFailover();
+
+    expect(result).toBe(true);
+    expect(tryFailover).toHaveBeenCalledTimes(1);
+    expect(flushRuntimeAuthScope).toHaveBeenCalledWith(
+      'provider-runtime-1739',
+    );
+  });
+});

--- a/packages/core/src/core/StreamProcessor.unbucketed-auth-failover.test.ts
+++ b/packages/core/src/core/StreamProcessor.unbucketed-auth-failover.test.ts
@@ -27,7 +27,9 @@ describe('StreamProcessor._handleBucketFailover', () => {
   it('allows single-bucket handlers to run tryFailover and flush auth scope', async () => {
     const tryFailover = vi.fn().mockResolvedValue(true);
 
-    const processor = Object.create(StreamProcessor.prototype) as StreamProcessor;
+    const processor = Object.create(
+      StreamProcessor.prototype,
+    ) as StreamProcessor;
     Object.assign(processor, {
       runtimeContext: {
         state: {
@@ -57,8 +59,6 @@ describe('StreamProcessor._handleBucketFailover', () => {
 
     expect(result).toBe(true);
     expect(tryFailover).toHaveBeenCalledTimes(1);
-    expect(flushRuntimeAuthScope).toHaveBeenCalledWith(
-      'provider-runtime-1739',
-    );
+    expect(flushRuntimeAuthScope).toHaveBeenCalledWith('provider-runtime-1739');
   });
 });


### PR DESCRIPTION
## Summary

Fixes #1739 - unbucketed profiles should check keychain on 401/etc or new turn

## Problem

Unbucketed profiles (single-bucket OAuth profiles) do not properly handle auth token refresh when they encounter 401/403 errors. When a key expires and the user re-authenticates, other agents can continue using cached invalid credentials instead of picking up the new token from the keychain.

## Root Cause

1. StreamProcessor._handleBucketFailover() gated tryFailover() behind failoverHandler.isEnabled(), which returns false for single-bucket profiles. That blocked single-bucket profiles from reaching Pass 3 foreground re-auth.
2. There was no turn-boundary auth cache invalidation path for single-bucket profiles, so agents could keep using stale cached credentials instead of re-reading from the keychain.

## Solution

1. Remove the isEnabled() gate so any configured failover handler can reach tryFailover().
2. Add invalidateAuthCache() to the BucketFailoverHandler interface.
3. Implement invalidateAuthCache() in BucketFailoverHandlerImpl using flushRuntimeAuthScope().
4. Call invalidateAuthCache() at new-turn boundaries in useGeminiStream before ensureBucketsAuthenticated().

## Changes

- packages/core/src/core/StreamProcessor.ts
  - Changed the failover guard from checking isEnabled() to checking handler existence only.
- packages/core/src/config/configTypes.ts
  - Added optional invalidateAuthCache(runtimeId: string): void to BucketFailoverHandler.
- packages/cli/src/auth/BucketFailoverHandlerImpl.ts
  - Implemented invalidateAuthCache() by calling flushRuntimeAuthScope(runtimeId).
- packages/cli/src/ui/hooks/geminiStream/useGeminiStream.ts
  - Invalidate auth cache at new-turn boundaries so updated tokens written by other processes are picked up.

## Verification

- cd packages/core && npm run test
- cd packages/core && npm run typecheck
- cd packages/cli && npm run typecheck
- cd packages/cli && npm run lint
- npm run build
- node scripts/start.js --profile-load synthetic "write me a haiku and nothing else"

## Notes

This keeps multi-bucket behavior intact while allowing single-bucket profiles to use the existing Pass 3 foreground re-auth path and refresh keychain state on new turns.

Fixes #1739
