### PR TITLE
fix(stream): disable idle timeout watchdog by default (Fixes #1905)

### DIFF
--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -15,7 +15,6 @@ import {
   ServerGeminiStreamEvent,
   StreamIdleTimeoutError,
   DebugLogger,
-  DEFAULT_STREAM_IDLE_TIMEOUT_MS,
 } from '@vybestack/llxprt-code-core';
 import { Part } from '@google/genai';
 import { runNonInteractive } from './nonInteractiveCli.js';
@@ -36,7 +35,6 @@ vi.mock('@vybestack/llxprt-code-core', async (importOriginal) => {
     delay: original.delay,
     nextStreamEventWithIdleTimeout: original.nextStreamEventWithIdleTimeout,
     StreamIdleTimeoutError: original.StreamIdleTimeoutError,
-    DEFAULT_STREAM_IDLE_TIMEOUT_MS: original.DEFAULT_STREAM_IDLE_TIMEOUT_MS,
   };
 });
 
@@ -184,9 +182,18 @@ describe('runNonInteractive', () => {
     }
   }
 
-  it('should cancel the turn when the stream goes idle after partial output', async () => {
+  it('should cancel the turn when the stream goes idle after partial output with explicit timeout', async () => {
     vi.useFakeTimers();
+    const testTimeoutMs = 30_000; // 30 second timeout for this test
     try {
+      // Configure mock to return explicit timeout
+      const mockGetEphemeralSetting = vi.fn((key: string) => {
+        if (key === 'stream-idle-timeout-ms') {
+          return testTimeoutMs;
+        }
+        return undefined;
+      });
+
       let capturedSignal: AbortSignal | undefined;
       mockGeminiClient.sendMessageStream.mockImplementation(
         (_messages: Part[], signal: AbortSignal) => {
@@ -199,7 +206,10 @@ describe('runNonInteractive', () => {
       );
 
       const runPromise = runNonInteractive({
-        config: mockConfig,
+        config: {
+          ...mockConfig,
+          getEphemeralSetting: mockGetEphemeralSetting,
+        } as unknown as Config,
         settings: mockSettings,
         input: 'Test input',
         prompt_id: 'prompt-id-idle',
@@ -214,7 +224,7 @@ describe('runNonInteractive', () => {
         caughtError = err;
       });
 
-      await vi.advanceTimersByTimeAsync(DEFAULT_STREAM_IDLE_TIMEOUT_MS + 1);
+      await vi.advanceTimersByTimeAsync(testTimeoutMs + 1);
       await runPromise.catch(() => {});
 
       expect(caughtError).toBeInstanceOf(StreamIdleTimeoutError);

--- a/packages/cli/src/ui/hooks/geminiStream/__tests__/useStreamEventHandlers.watchdog.test.ts
+++ b/packages/cli/src/ui/hooks/geminiStream/__tests__/useStreamEventHandlers.watchdog.test.ts
@@ -23,9 +23,17 @@ import { MessageType, type HistoryItemWithoutId } from '../../../types.js';
 import type { QueuedSubmission } from '../types.js';
 
 describe('useStreamEventHandlers stalled-stream watchdog', () => {
+  const testTimeoutMs = 30_000; // 30 second timeout for watchdog tests
+
   const mockConfig = {
     getModel: vi.fn(() => 'gemini-2.5-pro'),
     getMaxSessionTurns: vi.fn(() => 42),
+    getEphemeralSetting: vi.fn((key: string) => {
+      if (key === 'stream-idle-timeout-ms') {
+        return testTimeoutMs;
+      }
+      return undefined;
+    }),
   } as unknown as Config;
 
   const mockSettings = {
@@ -129,9 +137,7 @@ describe('useStreamEventHandlers stalled-stream watchdog', () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    await vi.advanceTimersByTimeAsync(
-      __testing.DEFAULT_STREAM_IDLE_TIMEOUT_MS + 1,
-    );
+    await vi.advanceTimersByTimeAsync(testTimeoutMs + 1);
 
     await runPromiseExpectation;
     expect(abortActiveStream).toHaveBeenCalledWith(expect.any(Error));

--- a/packages/core/src/agents/executor.test.ts
+++ b/packages/core/src/agents/executor.test.ts
@@ -38,7 +38,6 @@ import { z } from 'zod';
 import type { ToolErrorType } from '../index.js';
 import { debugLogger } from '../utils/debugLogger.js';
 import { createAbortError } from '../utils/delay.js';
-import { DEFAULT_STREAM_IDLE_TIMEOUT_MS } from '../utils/streamIdleTimeout.js';
 
 const { mockSendMessageStream, mockExecuteToolCall } = vi.hoisted(() => ({
   mockSendMessageStream: vi.fn(),
@@ -825,6 +824,9 @@ describe('AgentExecutor', () => {
     });
 
     it('should actively abort a stalled response stream before the overall timeout expires', async () => {
+      const testTimeoutMs = 30_000; // 30 second timeout for this test
+      mockConfig.setEphemeralSetting('stream-idle-timeout-ms', testTimeoutMs);
+
       const definition = createTestDefinition([LSTool.Name], {
         max_time_minutes: 5,
       });
@@ -877,7 +879,7 @@ describe('AgentExecutor', () => {
         },
       );
 
-      await vi.advanceTimersByTimeAsync(DEFAULT_STREAM_IDLE_TIMEOUT_MS + 1_000);
+      await vi.advanceTimersByTimeAsync(testTimeoutMs + 1_000);
 
       await runRejection;
       expect(capturedSignal?.aborted).toBe(true);

--- a/packages/core/src/core/geminiChat.runtime.test.ts
+++ b/packages/core/src/core/geminiChat.runtime.test.ts
@@ -26,7 +26,6 @@ import {
   createTelemetryAdapterFromConfig,
   createToolRegistryViewFromRegistry,
 } from '../runtime/runtimeAdapters.js';
-import { DEFAULT_STREAM_IDLE_TIMEOUT_MS } from '../utils/streamIdleTimeout.js';
 
 vi.mock('../utils/retry.js', () => ({
   retryWithBackoff: vi.fn((fn: () => unknown) => fn()),
@@ -173,8 +172,12 @@ describe('GeminiChat runtime context', () => {
   });
   it('aborts a stalled non-stream sendMessage response after partial provider output instead of hanging forever', async () => {
     vi.useFakeTimers();
+    const testTimeoutMs = 30_000; // 30 second timeout for this test
 
     try {
+      // Set explicit timeout via ephemeral setting
+      config.setEphemeralSetting('stream-idle-timeout-ms', testTimeoutMs);
+
       let capturedSignal: AbortSignal | undefined;
       const generateChatCompletionMock = vi.fn(async function* (
         options: GenerateChatOptions,
@@ -256,7 +259,7 @@ describe('GeminiChat runtime context', () => {
 
       await Promise.resolve();
       await Promise.resolve();
-      await vi.advanceTimersByTimeAsync(DEFAULT_STREAM_IDLE_TIMEOUT_MS + 1);
+      await vi.advanceTimersByTimeAsync(testTimeoutMs + 1);
 
       await rejection;
       expect(capturedSignal?.aborted).toBe(true);
@@ -268,8 +271,12 @@ describe('GeminiChat runtime context', () => {
 
   it('aborts a stalled direct-message response after partial provider output instead of hanging forever', async () => {
     vi.useFakeTimers();
+    const testTimeoutMs = 30_000; // 30 second timeout for this test
 
     try {
+      // Set explicit timeout via ephemeral setting
+      config.setEphemeralSetting('stream-idle-timeout-ms', testTimeoutMs);
+
       let capturedSignal: AbortSignal | undefined;
       const generateChatCompletionMock = vi.fn(async function* (
         options: GenerateChatOptions,
@@ -351,7 +358,7 @@ describe('GeminiChat runtime context', () => {
 
       await Promise.resolve();
       await Promise.resolve();
-      await vi.advanceTimersByTimeAsync(DEFAULT_STREAM_IDLE_TIMEOUT_MS + 1);
+      await vi.advanceTimersByTimeAsync(testTimeoutMs + 1);
 
       await rejection;
       expect(capturedSignal?.aborted).toBe(true);

--- a/packages/core/src/core/subagent.test.ts
+++ b/packages/core/src/core/subagent.test.ts
@@ -6,7 +6,6 @@
 
 import { vi, describe, it, expect, beforeEach, Mock, afterEach } from 'vitest';
 import { createAbortError } from '../utils/delay.js';
-import { DEFAULT_STREAM_IDLE_TIMEOUT_MS } from '../utils/streamIdleTimeout.js';
 import { SubAgentScope } from './subagent.js';
 import {
   ContextState,
@@ -1811,6 +1810,9 @@ describe('subagent.ts', () => {
         vi.useFakeTimers();
 
         const { config } = await createMockConfig();
+        const testTimeoutMs = 30_000; // 30 second timeout for this test
+        config.setEphemeralSetting('stream-idle-timeout-ms', testTimeoutMs);
+
         const runConfig: RunConfig = { max_time_minutes: 5, max_turns: 100 };
         let capturedSignal: AbortSignal | undefined;
 
@@ -1873,9 +1875,7 @@ describe('subagent.ts', () => {
           },
         );
 
-        await vi.advanceTimersByTimeAsync(
-          DEFAULT_STREAM_IDLE_TIMEOUT_MS + 1_000,
-        );
+        await vi.advanceTimersByTimeAsync(testTimeoutMs + 1_000);
 
         await runRejection;
 

--- a/packages/core/src/core/turn.test.ts
+++ b/packages/core/src/core/turn.test.ts
@@ -13,7 +13,6 @@ import {
   ServerGeminiStreamEvent,
   DEFAULT_AGENT_ID,
 } from './turn.js';
-import { DEFAULT_STREAM_IDLE_TIMEOUT_MS } from '../utils/streamIdleTimeout.js';
 import {
   GenerateContentResponse,
   Part,
@@ -237,76 +236,109 @@ describe('Turn', () => {
       expect(turn.getDebugResponses().length).toBe(1);
     });
     it('should call return() on stream iterator when aborted', async () => {
-      const abortController = new AbortController();
-      const returnSpy = vi.fn().mockResolvedValue(undefined);
+      vi.useFakeTimers();
+      try {
+        const abortController = new AbortController();
+        const returnSpy = vi.fn().mockResolvedValue(undefined);
 
-      // Create a mock async generator with a spyable return method
-      async function* mockGenerator() {
-        try {
-          yield {
-            type: StreamEventType.CHUNK,
-            value: {
-              candidates: [{ content: { parts: [{ text: 'First part' }] } }],
-            } as GenerateContentResponse,
-          };
-          // This will wait until aborted
-          await new Promise<void>((resolve) => {
-            abortController.signal.addEventListener('abort', () => resolve(), {
-              once: true,
-            });
-          });
-          yield {
-            type: StreamEventType.CHUNK,
-            value: {
-              candidates: [
+        // Set explicit timeout for this test
+        mockChatInstance = {
+          sendMessageStream: mockSendMessageStream,
+          getHistory: mockGetHistory,
+          getConfig: () => ({
+            getEphemeralSetting: (key: string) => {
+              if (key === 'stream-idle-timeout-ms') {
+                return 30_000; // 30 second timeout
+              }
+              return undefined;
+            },
+          }),
+        };
+        turn = new Turn(
+          mockChatInstance as unknown as GeminiChat,
+          'prompt-id-1',
+          DEFAULT_AGENT_ID,
+          'test',
+        );
+
+        // Create a mock async generator with a spyable return method
+        async function* mockGenerator() {
+          try {
+            yield {
+              type: StreamEventType.CHUNK,
+              value: {
+                candidates: [{ content: { parts: [{ text: 'First part' }] } }],
+              } as GenerateContentResponse,
+            };
+            // This will wait until aborted
+            await new Promise<void>((resolve) => {
+              abortController.signal.addEventListener(
+                'abort',
+                () => resolve(),
                 {
-                  content: {
-                    parts: [{ text: 'Second part - should not be processed' }],
-                  },
+                  once: true,
                 },
-              ],
-            } as GenerateContentResponse,
-          };
-        } finally {
-          // This ensures return() is called when iterator is closed
-        }
-      }
-
-      const generator = mockGenerator();
-      // Wrap the generator to spy on return()
-      const mockResponseStream = {
-        [Symbol.asyncIterator]: () => ({
-          next: () => generator.next(),
-          return: returnSpy,
-          throw: (e: unknown) => {
-            if (generator.throw) return generator.throw(e);
-            throw e;
-          },
-        }),
-      };
-
-      mockSendMessageStream.mockResolvedValue(mockResponseStream);
-
-      // Start consuming and abort after first chunk
-      const events: ServerGeminiStreamEvent[] = [];
-      const runPromise = (async () => {
-        for await (const event of turn.run(
-          [{ text: 'Test iterator cleanup' }],
-          abortController.signal,
-        )) {
-          events.push(event);
-          if (event.type === GeminiEventType.Content) {
-            // Abort after first content event
-            abortController.abort();
+              );
+            });
+            yield {
+              type: StreamEventType.CHUNK,
+              value: {
+                candidates: [
+                  {
+                    content: {
+                      parts: [
+                        { text: 'Second part - should not be processed' },
+                      ],
+                    },
+                  },
+                ],
+              } as GenerateContentResponse,
+            };
+          } finally {
+            // This ensures return() is called when iterator is closed
           }
         }
-      })();
 
-      await runPromise;
+        const generator = mockGenerator();
+        // Wrap the generator to spy on return()
+        const mockResponseStream = {
+          [Symbol.asyncIterator]: () => ({
+            next: () => generator.next(),
+            return: returnSpy,
+            throw: (e: unknown) => {
+              if (generator.throw) return generator.throw(e);
+              throw e;
+            },
+          }),
+        };
 
-      // Verify that return() was called on the iterator
-      expect(returnSpy).toHaveBeenCalled();
-      expect(events).toContainEqual({ type: GeminiEventType.UserCancelled });
+        mockSendMessageStream.mockResolvedValue(mockResponseStream);
+
+        // Start consuming and abort after first chunk
+        const events: ServerGeminiStreamEvent[] = [];
+        const runPromise = (async () => {
+          for await (const event of turn.run(
+            [{ text: 'Test iterator cleanup' }],
+            abortController.signal,
+          )) {
+            events.push(event);
+            if (event.type === GeminiEventType.Content) {
+              // Abort after first content event
+              abortController.abort();
+            }
+          }
+        })();
+
+        // Advance timers to let the abort propagate
+        await vi.advanceTimersByTimeAsync(100);
+        await runPromise;
+
+        // Verify that return() was called on the iterator
+        expect(returnSpy).toHaveBeenCalled();
+        expect(events).toContainEqual({ type: GeminiEventType.UserCancelled });
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('should allow subsequent calls after abort (sendPromise resolved)', async () => {
@@ -752,10 +784,31 @@ describe('Turn', () => {
       ]);
     });
 
-    it('should yield StreamIdleTimeout when the stream goes idle after partial output', async () => {
+    it('should yield StreamIdleTimeout when the stream goes idle after partial output with explicit timeout config', async () => {
       vi.useFakeTimers();
       try {
+        const testTimeoutMs = 30_000; // 30 second timeout for this test
         const abortSignals: AbortSignal[] = [];
+
+        // Create mock config that returns explicit timeout
+        mockChatInstance = {
+          sendMessageStream: mockSendMessageStream,
+          getHistory: mockGetHistory,
+          getConfig: () => ({
+            getEphemeralSetting: (key: string) => {
+              if (key === 'stream-idle-timeout-ms') {
+                return testTimeoutMs;
+              }
+              return undefined;
+            },
+          }),
+        };
+        turn = new Turn(
+          mockChatInstance as unknown as GeminiChat,
+          'prompt-id-1',
+          DEFAULT_AGENT_ID,
+          'test',
+        );
 
         const mockResponseStream = (async function* () {
           yield {
@@ -788,7 +841,7 @@ describe('Turn', () => {
           return events;
         })();
 
-        await vi.advanceTimersByTimeAsync(DEFAULT_STREAM_IDLE_TIMEOUT_MS + 1);
+        await vi.advanceTimersByTimeAsync(testTimeoutMs + 1);
         const events = await eventsPromise;
 
         expect(events).toEqual([
@@ -814,8 +867,29 @@ describe('Turn', () => {
     it('should allow subsequent calls after idle timeout (sendPromise deadlock prevention)', async () => {
       vi.useFakeTimers();
       try {
+        const testTimeoutMs = 30_000; // 30 second timeout for this test
         let callCount = 0;
         const abortSignals: AbortSignal[] = [];
+
+        // Create mock config that returns explicit timeout
+        mockChatInstance = {
+          sendMessageStream: mockSendMessageStream,
+          getHistory: mockGetHistory,
+          getConfig: () => ({
+            getEphemeralSetting: (key: string) => {
+              if (key === 'stream-idle-timeout-ms') {
+                return testTimeoutMs;
+              }
+              return undefined;
+            },
+          }),
+        };
+        turn = new Turn(
+          mockChatInstance as unknown as GeminiChat,
+          'prompt-id-1',
+          DEFAULT_AGENT_ID,
+          'test',
+        );
 
         const createMockStream = (shouldHang: boolean) =>
           (async function* () {
@@ -860,7 +934,7 @@ describe('Turn', () => {
           return events;
         })();
 
-        await vi.advanceTimersByTimeAsync(DEFAULT_STREAM_IDLE_TIMEOUT_MS + 1);
+        await vi.advanceTimersByTimeAsync(testTimeoutMs + 1);
         const events1 = await events1Promise;
 
         expect(events1).toContainEqual(
@@ -1436,6 +1510,84 @@ describe('Turn', () => {
         (e) => e.type === GeminiEventType.StreamIdleTimeout,
       );
       expect(timeoutEvent).toBeDefined();
+    });
+
+    it('default-off: no watchdog timer when no env var and no ephemeral setting', async () => {
+      // Ensure no env var is set
+      delete process.env.LLXPRT_STREAM_IDLE_TIMEOUT_MS;
+
+      // Config returns undefined for the setting (default-off)
+      const mockGetConfig = vi.fn().mockReturnValue({
+        getEphemeralSetting: (key: string) => {
+          if (key === 'stream-idle-timeout-ms') {
+            return undefined; // Not set — default-off
+          }
+          return undefined;
+        },
+      });
+
+      mockChatInstance = {
+        sendMessageStream: mockSendMessageStream,
+        getHistory: mockGetHistory,
+        getConfig: mockGetConfig,
+      } as unknown as MockedChatInstance;
+
+      turn = new Turn(
+        mockChatInstance as unknown as GeminiChat,
+        'prompt-id-1',
+        DEFAULT_AGENT_ID,
+        'test',
+      );
+      mockGetHistory.mockReturnValue([]);
+
+      // Iterator that never yields naturally (simulates a slow-thinking model)
+      let resolveIterator: () => void;
+      const iteratorPromise = new Promise<void>((resolve) => {
+        resolveIterator = resolve;
+      });
+
+      const mockResponseStream = (async function* () {
+        await iteratorPromise;
+        yield {
+          type: StreamEventType.CHUNK,
+          value: {
+            candidates: [{ content: { parts: [{ text: 'Finally' }] } }],
+          } as GenerateContentResponse,
+        };
+      })();
+      mockSendMessageStream.mockResolvedValue(mockResponseStream);
+
+      const events: ServerGeminiStreamEvent[] = [];
+      const reqParts: Part[] = [{ text: 'Hi' }];
+      const abortController = new AbortController();
+
+      const runPromise = (async () => {
+        for await (const event of turn.run(reqParts, abortController.signal)) {
+          events.push(event);
+        }
+      })();
+
+      // Advance well past the old 10-minute default (600_000ms)
+      // No timers should be scheduled because watchdog is disabled by default
+      await vi.advanceTimersByTimeAsync(700_000);
+      await Promise.resolve();
+
+      // No timeout event should have been emitted
+      expect(
+        events.find((e) => e.type === GeminiEventType.StreamIdleTimeout),
+      ).toBeUndefined();
+
+      // Timer count should be 0 (no watchdog scheduled)
+      expect(vi.getTimerCount()).toBe(0);
+
+      // Resolve the iterator to let the test complete
+      resolveIterator!();
+      await vi.runAllTimersAsync();
+      await runPromise;
+
+      // Should have the content event, no timeout
+      expect(events).toHaveLength(1);
+      expect(events[0].type).toBe(GeminiEventType.Content);
     });
   });
 });

--- a/packages/core/src/settings/settingsRegistry.ts
+++ b/packages/core/src/settings/settingsRegistry.ts
@@ -1183,7 +1183,7 @@ export const SETTINGS_REGISTRY: readonly SettingSpec[] = [
     key: 'stream-idle-timeout-ms',
     category: 'cli-behavior',
     description:
-      'Stream idle timeout in milliseconds. Set to 0 or negative to disable. Default: 600000 (10 minutes).',
+      'Stream idle timeout in milliseconds. Disabled by default (0). Set to a positive number of milliseconds to enable the watchdog.',
     type: 'number',
     persistToProfile: true,
     validate: (value: unknown): ValidationResult => {

--- a/packages/core/src/utils/streamIdleTimeout.test.ts
+++ b/packages/core/src/utils/streamIdleTimeout.test.ts
@@ -176,10 +176,10 @@ describe('resolveStreamIdleTimeoutMs', () => {
     process.env = originalEnv;
   });
 
-  it('returns DEFAULT_STREAM_IDLE_TIMEOUT_MS (600000) when no env var or config', () => {
+  it('returns DEFAULT_STREAM_IDLE_TIMEOUT_MS (0) when no env var or config — watchdog disabled by default', () => {
     const result = resolveStreamIdleTimeoutMs();
     expect(result).toBe(DEFAULT_STREAM_IDLE_TIMEOUT_MS);
-    expect(result).toBe(600_000);
+    expect(result).toBe(0);
   });
 
   it('env var LLXPRT_STREAM_IDLE_TIMEOUT_MS overrides default', () => {
@@ -337,6 +337,44 @@ describe('resolveStreamIdleTimeoutMs', () => {
       };
       const result = resolveStreamIdleTimeoutMs(mockConfig);
       expect(result).toBe(0);
+    });
+  });
+
+  describe('default-off behavior', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      process.env = { ...originalEnv };
+      delete process.env[LLXPRT_STREAM_IDLE_TIMEOUT_MS_ENV];
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it('default is 0 (watchdog disabled) when no env var or config is set', () => {
+      expect(DEFAULT_STREAM_IDLE_TIMEOUT_MS).toBe(0);
+      const result = resolveStreamIdleTimeoutMs();
+      expect(result).toBe(0);
+    });
+
+    it('env var LLXPRT_STREAM_IDLE_TIMEOUT_MS re-enables the watchdog with a positive value', () => {
+      process.env[LLXPRT_STREAM_IDLE_TIMEOUT_MS_ENV] = '120000';
+      const result = resolveStreamIdleTimeoutMs();
+      expect(result).toBe(120_000);
+    });
+
+    it('ephemeral setting stream-idle-timeout-ms re-enables the watchdog with a positive value', () => {
+      const mockConfig = {
+        getEphemeralSetting: (key: string) => {
+          if (key === STREAM_IDLE_TIMEOUT_SETTING_KEY) {
+            return 90_000;
+          }
+          return undefined;
+        },
+      };
+      const result = resolveStreamIdleTimeoutMs(mockConfig);
+      expect(result).toBe(90_000);
     });
   });
 });

--- a/packages/core/src/utils/streamIdleTimeout.ts
+++ b/packages/core/src/utils/streamIdleTimeout.ts
@@ -14,10 +14,12 @@ export class StreamIdleTimeoutError extends Error {
 }
 
 /**
- * Default stream idle timeout in milliseconds (10 minutes).
- * Used as fallback when no config or env var is set.
+ * Default stream idle timeout in milliseconds.
+ * Disabled by default (0). Set to a positive number via
+ * LLXPRT_STREAM_IDLE_TIMEOUT_MS env var or 'stream-idle-timeout-ms'
+ * ephemeral setting to enable the watchdog.
  */
-export const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 600_000;
+export const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 0;
 
 /**
  * Environment variable name for stream idle timeout override.
@@ -37,7 +39,7 @@ export const STREAM_IDLE_TIMEOUT_SETTING_KEY = 'stream-idle-timeout-ms';
  * Priority order:
  * 1. Environment variable LLXPRT_STREAM_IDLE_TIMEOUT_MS (if set and valid)
  * 2. Config ephemeral setting 'stream-idle-timeout-ms' (if config provided and valid)
- * 3. DEFAULT_STREAM_IDLE_TIMEOUT_MS (600_000)
+ * 3. DEFAULT_STREAM_IDLE_TIMEOUT_MS (0 — disabled)
  *
  * Values <= 0 disable the watchdog (return 0).
  * Invalid string values (including empty/whitespace) fall back to the next priority level.


### PR DESCRIPTION
## Summary

Disables the stream idle-timeout watchdog by default. Users who want the previous 10-minute watchdog can still opt in via environment variable or ephemeral setting.

Fixes #1905.

## Background

#1899 made the stream idle timeout configurable and raised the default to 10 minutes. This reduced, but did not eliminate, the false-positive "Stream idle timeout" errors reported against reasoning-capable models (Anthropic Claude, Kimi-K2, GPT-5-family, etc.).

Root cause: when a reasoning model finishes a tool call, it often spends a long time thinking before emitting the next token. The token-level idle watchdog interprets that silence as a dead stream and aborts the turn, losing work the user already paid for.

Per the issue reporter's mandate ("either remove the stream timeout or make it much much larger"), the lowest-risk, most user-respecting option is: **do not run the watchdog by default**. Provider-level socket timeouts, per-tool execution timeouts, retry/backoff logic, and user cancel signals already cover every case where the watchdog would provide real value.

## What changed

- packages/core/src/utils/streamIdleTimeout.ts: DEFAULT_STREAM_IDLE_TIMEOUT_MS is now 0. All call sites already treat a non-positive resolved timeout as "disable watchdog, call iterator.next() directly", so no logic changes were required.
- packages/core/src/settings/settingsRegistry.ts: updated help text to say "Disabled by default (0)".
- Tests across core, cli, and a2a-server adjusted to explicitly enable the watchdog (via the stream-idle-timeout-ms ephemeral setting or LLXPRT_STREAM_IDLE_TIMEOUT_MS env var) in every scenario that asserts on watchdog behaviour. New negative-path tests verify that no timer is armed when the setting is unset.

## How to re-enable

If your workflow needs the aggressive idle detection, set either:

- env var: LLXPRT_STREAM_IDLE_TIMEOUT_MS=600000
- ephemeral setting: stream-idle-timeout-ms (accepts number or string)

Both paths retain their prior precedence (env > ephemeral setting > default).

## Risk

Disabling the watchdog means a network stall in the middle of an SSE stream will not be detected at the token level. Mitigations that were already in place and remain:

- HTTP socket / TLS read timeouts in the provider clients
- Per-tool execution timeouts with abort signals
- Provider retry/backoff on transient stream errors
- User-driven cancel via AbortSignal

## Verification

- npm run test (core, cli, a2a-server) - all green
- npm run typecheck - green
- npm run lint - 0 errors
- npm run format - applied
- npm run build - green
- Smoke: node scripts/start.js --profile-load ollamakimi "write me a haiku and nothing else" - returned a haiku

## Rollout

Zero-config for existing users: behaviour changes from "watchdog at 10 minutes" to "no watchdog". No profile or settings migrations needed.
