### PR TITLE
Fix #1808: Document actual default scope behavior for /skills enable and disable

### DIFF
--- a/docs/cli/skills.md
+++ b/docs/cli/skills.md
@@ -60,8 +60,9 @@ Use the `/skills` slash command to view and manage available expertise:
 - `/skills enable <name>`: Re-enables a disabled skill.
 - `/skills reload`: Refreshes the list of discovered skills from all tiers.
 
-_Note: `/skills disable` and `/skills enable` default to the `user` scope. Use
-`--scope workspace` to manage workspace-specific settings._
+_Note: `/skills disable` uses the `workspace` scope when workspace settings are
+available; otherwise, it falls back to `user`. `/skills enable` removes the
+skill from both workspace and user disabled lists._
 
 ### From the Terminal
 
@@ -86,11 +87,15 @@ llxprt skills install /path/to/skill --scope workspace
 # Uninstall a skill by name
 llxprt skills uninstall my-expertise --scope workspace
 
-# Enable a skill (globally)
+# Enable a skill (removes disabled entries from both workspace and user scopes)
 llxprt skills enable my-expertise
 
-# Disable a skill. Can use --scope to specify workspace or user (defaults to workspace)
+# Disable a skill (defaults to workspace scope)
+llxprt skills disable my-expertise
+
+# Disable a skill in a specific scope
 llxprt skills disable my-expertise --scope workspace
+llxprt skills disable my-expertise --scope user
 ```
 
 ## Creating a Skill


### PR DESCRIPTION
Summary
Fixes #1808

This PR updates the skills documentation to match actual runtime default-scope behavior in both interactive and terminal command flows.

Changes
- Updated the interactive /skills note in docs/cli/skills.md:
  - /skills disable is documented as defaulting to workspace when workspace settings are available, otherwise user.
  - /skills enable is documented as removing disabled entries from both workspace and user disabled lists.
- Updated terminal examples to align with CLI behavior:
  - Clarified that llxprt skills enable removes disabled entries from both scopes.
  - Added a default disable example (llxprt skills disable my-expertise) showing workspace-default behavior.
  - Added explicit scoped disable examples for both --scope workspace and --scope user.

Why
The issue reported a mismatch between docs and runtime behavior. This change makes docs and examples consistent with the current command behavior.

Validation
- Reviewed changes with git diff origin/main.
- Confirmed this is a docs-only change to docs/cli/skills.md.
